### PR TITLE
docs(contrib): add contribution guidelines and policy docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report a reproducible bug in the extension
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. This extension has a narrow product
+        scope — see AGENTS.md. Fill in as much detail as you can.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A short description of the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Exact steps, starting from a fresh browser state when possible.
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: input
+    id: extension-version
+    attributes:
+      label: Extension version
+      placeholder: "1.2.3"
+    validations:
+      required: true
+  - type: input
+    id: chrome-version
+    attributes:
+      label: Chrome version
+      placeholder: "124.0.0.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: repo-type
+    attributes:
+      label: Repository type
+      options:
+        - Public
+        - Private
+    validations:
+      required: true
+  - type: textarea
+    id: dom-evidence
+    attributes:
+      label: Selector / DOM evidence (optional)
+      description: Paste relevant HTML fragments, screenshots, or selector paths when the issue is visual.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest an enhancement to the extension
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, please skim the Product Rules in AGENTS.md.
+        Enhancements outside that scope usually will not be accepted.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem are you trying to solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed behavior
+      description: What should the extension do? Include UI and data behavior.
+    validations:
+      required: true
+  - type: checkboxes
+    id: scope-check
+    attributes:
+      label: Scope check
+      options:
+        - label: I have read AGENTS.md Product Rules and believe this proposal fits the current scope
+          required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you evaluated, if any.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -24,9 +24,13 @@ body:
   - type: checkboxes
     id: scope-check
     attributes:
-      label: Scope check
+      label: Scope acknowledgment
+      description: |
+        Proposals outside the current Product Rules may still be discussed
+        if the maintainer agrees to widen scope. If you think this is such
+        a case, call it out in "Proposed behavior".
       options:
-        - label: I have read AGENTS.md Product Rules and believe this proposal fits the current scope
+        - label: I have read the Product Rules in AGENTS.md
           required: true
   - type: textarea
     id: alternatives

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- One paragraph: what changed and why. -->
+
+## Validation
+
+- pnpm lint: <pass | not run because ...>
+- pnpm typecheck: <pass | not run because ...>
+- pnpm test: <pass | not run because ...>
+- Manual: <what was verified in the browser or Chrome extension, or "not applicable">
+
+## Related Issues
+
+<!-- Exactly one of:
+  Resolves #123
+  Part of #123
+  No issue: <reason>
+-->
+
+<!--
+Optional co-location note. When a change affects reviewer UX,
+selectors, permissions, storage, auth, release artifacts, or Chrome
+Web Store copy, confirm the matching doc was updated. Full list:
+docs/guidelines/pr-guideline.md#co-location-checklist
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,12 +83,19 @@ pnpm test:e2e
 
 - `feat:` for user-facing functionality
 - `fix:` for bug fixes
-- `docs:` for documentation only
-- `chore:` for tooling, config, and repository maintenance
-- `test:` for test-only changes
 - `refactor:` for internal restructuring without behavior change
+- `docs:` for documentation only
+- `test:` for test-only changes
+- `chore:` for tooling, config, and repository maintenance
+- `perf:` for performance improvements without behavior change
+- `build:` for build system, dependencies, and release packaging
+- `ops:` for CI, release workflows, and infrastructure
+- `style:` for formatting and whitespace-only changes
 
-Prefer multiple small commits over one mixed commit.
+Prefer multiple small commits over one mixed commit. See
+[CONTRIBUTING.md](./CONTRIBUTING.md) for the full contribution
+workflow, including branch naming, PR policy, and the co-location
+checklist.
 
 ## Review Standard
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Follow the repository instructions in [AGENTS.md](./AGENTS.md).
+Follow the repository instructions in [AGENTS.md](./AGENTS.md). See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full contribution workflow.
 
 Claude-specific note:
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at TODO: maintainer contact — replace before public promotion. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at TODO: maintainer contact — replace before public promotion. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainer at hon454@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing to GitHub Pulls Show Reviewers
+
+Thanks for your interest in contributing. This repository is a
+solo-maintained Chrome extension with a deliberately narrow product
+scope. Please read [AGENTS.md](./AGENTS.md) for the authoritative
+product rules and architecture expectations before proposing changes.
+
+## Prerequisites
+
+- Node.js LTS
+- `pnpm` 10.x (see the `packageManager` field in `package.json`)
+- Playwright Chromium (optional — only needed for `pnpm test:e2e`)
+
+## Getting started
+
+Follow the `Quick Start` section in [`README.md`](./README.md) to
+install dependencies and run the extension in development.
+
+## Reporting bugs
+
+Use GitHub Issues and pick the **Bug Report** template. Include
+enough reproduction detail that the maintainer can act on the issue
+without asking follow-up questions:
+
+- Exact steps to reproduce
+- Expected behavior and actual behavior
+- Extension version and Chrome version
+- Repository type (public or private)
+- DOM / selector evidence when the issue is visual
+
+## Suggesting enhancements
+
+Use GitHub Issues and pick the **Feature Request** template.
+Enhancements must fit the product scope defined in `AGENTS.md`.
+Proposals outside that scope will usually be declined unless the
+maintainer explicitly agrees to widen scope first.
+
+## Issue tracking
+
+- GitHub Issues is the canonical tracker.
+- Reference format is `#123`.
+- All issues, PRs, and commits are written in English.
+
+## Branch naming
+
+Allowed prefixes for human-authored branches:
+
+- `feat/`, `fix/`, `chore/`, `hotfix/`, `release/`
+
+Agent worktree branches are named `claude/<slug>` (explicit
+exception).
+
+Rules:
+
+- Lowercase letters, digits, and hyphens only.
+- No spaces or underscores.
+- No repeated, leading, or trailing hyphens.
+- Dots only for release versions (e.g. `release/v1.2.0`).
+- `chore/` is the default for docs-, style-, test-, build-, ops-only,
+  and maintenance work.
+- `hotfix/` branches still use `fix:` in commit subjects.
+
+## Commit policy
+
+See
+[`docs/guidelines/commit-guideline.md`](./docs/guidelines/commit-guideline.md)
+for the full rules. This repository has no pre-commit or commit-msg
+hook gates; run the local checks listed in the guideline manually
+before pushing.
+
+## Pull request policy
+
+See
+[`docs/guidelines/pr-guideline.md`](./docs/guidelines/pr-guideline.md)
+for title rules, the minimal and expanded description templates,
+issue linkage, and the co-location checklist.
+[`.github/pull_request_template.md`](./.github/pull_request_template.md)
+auto-populates the minimal form when you open a PR.
+
+## Issue linkage
+
+Every PR states exactly one of:
+
+- `Resolves #123` — closes the issue on merge
+- `Part of #123` — partial progress, link only
+- `No issue: <reason>` — intentionally untracked
+
+Details and multi-issue forms are in the
+[PR Guideline](./docs/guidelines/pr-guideline.md#issue-linkage).
+
+## Co-location checklist
+
+When a change affects behavior, selectors, permissions, storage,
+auth, release artifacts, or Chrome Web Store copy, update the
+companion doc in the same PR. The full 10-item checklist lives in
+the
+[PR Guideline](./docs/guidelines/pr-guideline.md#co-location-checklist).
+
+## Testing
+
+See the `Pre-release Test Workflow` section in
+[`README.md`](./README.md) and run `pnpm verify:release` before
+tagging a release. For routine changes, `pnpm lint`,
+`pnpm typecheck`, and `pnpm test` are the minimum expected signals.
+
+## Coding conventions
+
+- Prettier and ESLint are authoritative for formatting and lint.
+- TypeScript runs in strict mode.
+- Follow the `Implementation Guidelines` section in
+  [`AGENTS.md`](./AGENTS.md#implementation-guidelines) for patterns
+  specific to this codebase.
+
+## Code of Conduct
+
+This project follows the
+[Contributor Covenant](./CODE_OF_CONDUCT.md).
+
+## Scope boundary
+
+The `Product Rules` section in
+[`AGENTS.md`](./AGENTS.md#product-rules) is authoritative. Any
+change that expands scope beyond reviewer visibility needs prior
+discussion with the maintainer before code is written.

--- a/docs/guidelines/commit-guideline.md
+++ b/docs/guidelines/commit-guideline.md
@@ -1,0 +1,89 @@
+# Commit Guideline
+
+This repository follows Conventional Commits with a small set of rules
+adapted from broader internal practice. Keep commits small, readable,
+and easy to revert.
+
+## Header
+
+Format:
+
+    <type>(<scope>): <subject>
+
+- Type is required and lowercase.
+- Scope is optional, lowercase, and scoped to one subsystem (e.g.
+  `reviewers`, `storage`, `github`, `options`, `content`, `ci`).
+- Subject is imperative ("add", "fix", "remove"), no trailing period,
+  maximum 80 characters.
+- One concern per commit. If a change mixes unrelated edits, split them.
+
+## Types
+
+| Type | Use for |
+| --- | --- |
+| `feat` | User-facing functionality or behavior change |
+| `fix` | Bug fix that changes observable behavior |
+| `refactor` | Internal restructuring with no behavior change |
+| `docs` | Documentation-only changes |
+| `test` | Test-only changes (no production code change) |
+| `chore` | Tooling, config, and repository maintenance |
+| `perf` | Performance improvement with no behavior change |
+| `build` | Build system, dependencies, bundler, release packaging |
+| `ops` | CI, release workflows, infrastructure |
+| `style` | Formatting, whitespace, lint-only (no logic change) |
+
+Pick the type that most accurately describes the change. Branch prefixes
+(see [Branch naming](../../CONTRIBUTING.md#branch-naming) in
+`CONTRIBUTING.md`) do not constrain commit types — a `chore/`-prefixed
+branch can carry any commit type when that type more accurately describes
+the change.
+
+## Body
+
+- Leave a blank line between subject and body.
+- Wrap lines at 80 characters.
+- Explain **why** the change was made. Grouping by behavior is fine;
+  do not produce a file-by-file changelog.
+- If the change closes a GitHub Issue, use `Resolves #123`. See the
+  [PR Guideline](./pr-guideline.md#issue-linkage) for the full set of
+  linkage forms used in PR bodies.
+
+## Breaking changes
+
+If the commit introduces a backwards-incompatible change:
+
+- Append `!` after the type/scope in the header:
+  `feat(reviewers)!: drop dismissed-state chips`
+- Include a `BREAKING CHANGE:` paragraph in the body describing the
+  break and the migration path.
+
+Both markers are required. The `!` keeps the header self-describing;
+the `BREAKING CHANGE:` paragraph documents the details.
+
+## Local checks
+
+This repository does not run any pre-commit or commit-msg hooks. Run
+the available checks manually before committing or pushing:
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm verify:release` (before tagging a release)
+
+CI runs `pnpm typecheck` on every PR.
+
+## Examples
+
+Good:
+
+    feat(reviewers): add team reviewer chip
+    fix(github): handle 404 when PR list route is stale
+    refactor(storage): extract account resolver into its own module
+    docs(contrib): add commit and PR guidelines
+
+Avoid:
+
+    update code            # no type, no subject discipline
+    Fix bug.               # trailing period, non-imperative, no type
+    feat: stuff            # vague subject
+    chore: lots of things  # mixed concerns — split instead

--- a/docs/guidelines/pr-guideline.md
+++ b/docs/guidelines/pr-guideline.md
@@ -90,9 +90,13 @@ PR body.
 
 ## Assignee
 
-Every PR is assigned to its author. When using `gh pr create`, pass
-`--assignee @me`. When creating through the web UI, set the assignee
-to yourself.
+Maintainers and collaborators assign every PR to its author. When
+using `gh pr create`, pass `--assignee @me`. When creating through
+the web UI, set the assignee to yourself.
+
+Outside contributors opening a PR from a fork generally cannot
+assign PRs in this repository; the maintainer will set the assignee
+on merge-track PRs. No action is required from the contributor.
 
 ## Co-location checklist
 

--- a/docs/guidelines/pr-guideline.md
+++ b/docs/guidelines/pr-guideline.md
@@ -1,0 +1,128 @@
+# Pull Request Guideline
+
+This document covers PR titles, descriptions, issue linkage, and the
+co-location checklist for this repository.
+
+## Title
+
+PR titles follow the same rules as the
+[commit subject line](./commit-guideline.md#header):
+
+- `<type>(<scope>): <subject>`
+- Lowercase type and scope, imperative subject, no trailing period,
+  ≤ 80 characters.
+- One concern per PR.
+
+For breaking changes, add `!`:
+
+    feat(reviewers)!: drop dismissed-state chips
+
+Breaking PRs also include a `Breaking Changes` section in the body.
+
+## Minimal description template
+
+Use this by default; the
+[`.github/pull_request_template.md`](../../.github/pull_request_template.md)
+auto-populates it.
+
+    ## Summary
+
+    One paragraph: what changed and why.
+
+    ## Validation
+
+    - pnpm lint: <pass | not run because ...>
+    - pnpm typecheck: <pass | not run because ...>
+    - pnpm test: <pass | not run because ...>
+    - Manual: <what was verified in the browser or Chrome extension,
+      or "not applicable">
+
+    ## Related Issues
+
+    Resolves #123
+    (or) Part of #123
+    (or) No issue: <reason>
+
+## Expanded template (optional)
+
+For large, risky, or multi-part changes, add these sections beneath
+the minimal template:
+
+    ## Context
+
+    Prior state, constraints, and the problem being solved.
+
+    ## Approach
+
+    The chosen strategy and alternatives considered.
+
+    ## Risk
+
+    Known risk areas and mitigations.
+
+    ## Rollout
+
+    How the change is exercised after merge (manual testing, Chrome
+    Web Store release, feature flag, etc.).
+
+    ## Breaking Changes
+
+    Required when the PR title carries `!`. Describe the break and
+    the migration path.
+
+## Issue linkage
+
+Every PR states exactly one of these in its body:
+
+- `Resolves #123` — closes the issue on merge (documented default).
+  GitHub also recognizes `Closes #123` and `Fixes #123`; prefer
+  `Resolves`.
+- `Part of #123` — partial progress, link only, does not close. This
+  is a textual link, not a magic word.
+- `No issue: <reason>` — intentionally untracked. Give a one-line
+  reason.
+
+Multi-issue form: `Resolves #123, #124`.
+
+For loose relationships to issues the PR does not close, comment on
+the issue and link the PR rather than adding more magic words to the
+PR body.
+
+## Assignee
+
+Every PR is assigned to its author. When using `gh pr create`, pass
+`--assignee @me`. When creating through the web UI, set the assignee
+to yourself.
+
+## Co-location checklist
+
+Before opening the PR, walk through these questions. When an item
+applies, the same PR should carry the matching update.
+
+1. Did reviewer UX behavior, copy, or the set of supported review
+   states change? — update `README.md` "What The Extension Shows"
+   and `docs/implementation-notes.md`.
+2. Was `src/github/selectors.ts` touched? — add or update
+   fixture-based regression coverage under `tests/`.
+3. Did `wxt.config.ts` `permissions` or `host_permissions` change? —
+   update `docs/privacy-policy.md` "What the extension accesses" and
+   `docs/chrome-web-store-submission.md`.
+4. Did the storage schema change (`src/storage/`, Zod records)? —
+   update `docs/privacy-policy.md` "Storage and retention".
+5. Did auth or device flow change? — update
+   `docs/manual-chrome-testing.md` scenarios.
+6. Was a new entrypoint or major module added or moved? — update the
+   Repository Map in **both** `README.md` and `AGENTS.md`.
+7. Was `package.json` `version` bumped? — add
+   `docs/releases/vX.Y.Z.md`.
+8. Was a new durable design decision made? — add or update
+   `docs/adr/NNNN-<title>.md`.
+9. Did release verification (`pnpm verify:release`) change? — update
+   `README.md` "Pre-release Test Workflow".
+10. Did Chrome Web Store user-facing copy or screenshots change? —
+    update `docs/chrome-web-store.md`,
+    `docs/chrome-web-store-submission.md`, and
+    `docs/chrome-web-store-assets/`.
+
+The minimal PR template includes an optional co-location note; use
+it to confirm which items applied or record "none".


### PR DESCRIPTION
## Summary

Introduce a contributor-facing policy set adapted from broader internal practice and fitted to this solo-maintained Chrome extension with a deliberately narrow product scope. New: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, two canonical guideline docs under `docs/guidelines/`, a minimal PR template, and GitHub issue forms. Modified: `AGENTS.md` Commit Conventions expanded from 6 to 10 types with a `CONTRIBUTING.md` pointer, and a one-line pointer on `CLAUDE.md`.

The design spec (`docs/superpowers/specs/2026-04-22-contribution-guidelines-design.md`, local-only per repo ignore rules) and the implementation plan at `docs/superpowers/plans/2026-04-22-contribution-guidelines.md` drove this change. Scoped to a single logical commit per that spec.

## Validation

- pnpm lint: pass
- pnpm typecheck: pass
- pnpm test: not run (docs-only; no production code touched)
- Manual: link resolution verified for every relative link introduced by this change; heading anchors in `commit-guideline.md`, `pr-guideline.md`, and `AGENTS.md` confirmed to exist; YAML parsed for all three issue forms

## Related Issues

No issue: bootstrap of the contribution policy set; no prior tracked issue.

<!--
Co-location note: this change does not touch reviewer UX, selectors, permissions, storage, auth, release artifacts, or Chrome Web Store copy, so none of the 10 co-location triggers in docs/guidelines/pr-guideline.md apply.
-->

## Follow-ups (not in this PR)

- Replace the `TODO: maintainer contact — replace before public promotion` line in `CODE_OF_CONDUCT.md` before any public promotion. `docs/privacy-policy.md` also carries a related placeholder.
- No pre-commit or commit-msg hooks are added or implied by this change.