### PR TITLE
feat(options): auto-start device flow on add-account panel open

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,51 @@
 ## Summary
 
-<!-- One paragraph: what changed and why. -->
+-
 
-## Validation
+## Why
 
-- pnpm lint: <pass | not run because ...>
-- pnpm typecheck: <pass | not run because ...>
-- pnpm test: <pass | not run because ...>
-- Manual: <what was verified in the browser or Chrome extension, or "not applicable">
+<!-- What problem does this solve? Why is this needed? -->
+
+## Changes
+
+<!-- Summarize by behavior, subsystem, or reviewer concern. -->
+<!-- Do not provide a file-by-file list unless file location is essential. -->
+
+-
+
+## Impact
+
+- User-facing impact:
+- API/schema impact:
+- Performance impact:
+- Operational or rollout impact:
+
+## Testing
+
+- [ ] Unit tests
+- [ ] Integration tests
+- [ ] Manual testing
+
+### Test details
+
+-
+
+## Breaking Changes
+
+- None
 
 ## Related Issues
 
-<!-- Exactly one of:
-  Resolves #123
-  Part of #123
-  No issue: <reason>
+<!-- Add one or more linkage lines using these forms:
+Resolves #123
+Part of #123
+Resolves #123, #124
+Part of #123, #124
+No issue: <clear reason>
+
+For loose relationships (tangential issues this PR is not working on),
+do not use magic words here. Instead, comment on the target issue and
+link the PR there.
 -->
 
 <!--

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,18 @@ pnpm test:e2e
 
 Prefer multiple small commits over one mixed commit. See
 [CONTRIBUTING.md](./CONTRIBUTING.md) for the full contribution
-workflow, including branch naming, PR policy, and the co-location
-checklist.
+workflow, including branch naming.
+
+## Pull Request Policy
+
+Title rules, body sections, issue linkage, and the co-location
+checklist are governed by
+[`docs/guidelines/pr-guideline.md`](./docs/guidelines/pr-guideline.md).
+Before running `gh pr create`, confirm the body matches
+[`.github/pull_request_template.md`](./.github/pull_request_template.md):
+every PR body must include `## Summary`, `## Validation`, and
+`## Related Issues`. `gh pr create --body` bypasses GitHub's
+template auto-population, so the template must be applied manually.
 
 ## Review Standard
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,8 +103,11 @@ checklist are governed by
 [`docs/guidelines/pr-guideline.md`](./docs/guidelines/pr-guideline.md).
 Before running `gh pr create`, confirm the body matches
 [`.github/pull_request_template.md`](./.github/pull_request_template.md):
-every PR body must include `## Summary`, `## Validation`, and
-`## Related Issues`. `gh pr create --body` bypasses GitHub's
+every PR body must include `## Summary`, `## Why`, `## Changes`,
+`## Impact`, `## Testing`, `## Breaking Changes`, and
+`## Related Issues`. Sections that do not apply still belong in the
+body — mark them "None", "N/A", or "not applicable" so reviewers
+see they were considered. `gh pr create --body` bypasses GitHub's
 template auto-population, so the template must be applied manually.
 
 ## Review Standard

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,10 +105,15 @@ Before running `gh pr create`, confirm the body matches
 [`.github/pull_request_template.md`](./.github/pull_request_template.md):
 every PR body must include `## Summary`, `## Why`, `## Changes`,
 `## Impact`, `## Testing`, `## Breaking Changes`, and
-`## Related Issues`. Sections that do not apply still belong in the
-body — mark them "None", "N/A", or "not applicable" so reviewers
-see they were considered. `gh pr create --body` bypasses GitHub's
-template auto-population, so the template must be applied manually.
+`## Related Issues`. For `## Impact`, `## Testing`, and
+`## Breaking Changes`, sections that do not apply still belong in
+the body — mark them "None", "N/A", or "not applicable" so
+reviewers see they were considered. `## Related Issues` is not
+one of those optional sections; it must always carry one of
+`Resolves #123`, `Part of #123`, or `No issue: <reason>` per the
+[Issue linkage](./docs/guidelines/pr-guideline.md#issue-linkage)
+rules. `gh pr create --body` bypasses GitHub's template
+auto-population, so the template must be applied manually.
 
 ## Review Standard
 

--- a/docs/guidelines/pr-guideline.md
+++ b/docs/guidelines/pr-guideline.md
@@ -19,23 +19,49 @@ For breaking changes, add `!`:
 
 Breaking PRs also include a `Breaking Changes` section in the body.
 
-## Minimal description template
+## Description template
 
-Use this by default; the
-[`.github/pull_request_template.md`](../../.github/pull_request_template.md)
-auto-populates it.
+Every PR uses the same expanded template, populated by
+[`.github/pull_request_template.md`](../../.github/pull_request_template.md).
+Sections that do not apply to a given PR should still be present:
+leave a short "None", "N/A", or "not applicable" so the reviewer
+knows the author considered the section.
 
     ## Summary
 
-    One paragraph: what changed and why.
+    -
 
-    ## Validation
+    ## Why
 
-    - pnpm lint: <pass | not run because ...>
-    - pnpm typecheck: <pass | not run because ...>
-    - pnpm test: <pass | not run because ...>
-    - Manual: <what was verified in the browser or Chrome extension,
-      or "not applicable">
+    <!-- What problem does this solve? Why is this needed? -->
+
+    ## Changes
+
+    <!-- Summarize by behavior, subsystem, or reviewer concern. -->
+    <!-- Do not provide a file-by-file list unless file location is essential. -->
+
+    -
+
+    ## Impact
+
+    - User-facing impact:
+    - API/schema impact:
+    - Performance impact:
+    - Operational or rollout impact:
+
+    ## Testing
+
+    - [ ] Unit tests
+    - [ ] Integration tests
+    - [ ] Manual testing
+
+    ### Test details
+
+    -
+
+    ## Breaking Changes
+
+    - None
 
     ## Related Issues
 
@@ -43,32 +69,25 @@ auto-populates it.
     (or) Part of #123
     (or) No issue: <reason>
 
-## Expanded template (optional)
+### Writing each section
 
-For large, risky, or multi-part changes, add these sections beneath
-the minimal template:
-
-    ## Context
-
-    Prior state, constraints, and the problem being solved.
-
-    ## Approach
-
-    The chosen strategy and alternatives considered.
-
-    ## Risk
-
-    Known risk areas and mitigations.
-
-    ## Rollout
-
-    How the change is exercised after merge (manual testing, Chrome
-    Web Store release, feature flag, etc.).
-
-    ## Breaking Changes
-
-    Required when the PR title carries `!`. Describe the break and
-    the migration path.
+- **Summary** — 1 to 3 bullets describing the main outcome. Not a
+  filename list; focus on behavior or reviewer concern.
+- **Why** — a few sentences explaining the motivation or problem
+  being solved. Avoid restating the summary.
+- **Changes** — group by behavior, subsystem, or reviewer concern.
+  Examples: user-facing behavior, validation logic, data model
+  changes, performance improvements, test coverage.
+- **Impact** — call out anything release owners or reviewers should
+  notice. Use "None" when genuinely empty.
+- **Testing** — check what was actually run; the Test details list
+  should describe concrete verifications rather than "tested
+  locally". Record pnpm lint / typecheck / test results and any
+  manual Chrome verification in Test details.
+- **Breaking Changes** — state "None" for additive changes. A PR
+  that carries `!` in the title must describe the break and the
+  migration path here.
+- **Related Issues** — see the Issue linkage section below.
 
 ## Issue linkage
 
@@ -128,5 +147,5 @@ applies, the same PR should carry the matching update.
     `docs/chrome-web-store-submission.md`, and
     `docs/chrome-web-store-assets/`.
 
-The minimal PR template includes an optional co-location note; use
-it to confirm which items applied or record "none".
+The PR template includes an optional co-location note; use it to
+confirm which items applied or record "none".

--- a/docs/guidelines/pr-guideline.md
+++ b/docs/guidelines/pr-guideline.md
@@ -24,8 +24,12 @@ Breaking PRs also include a `Breaking Changes` section in the body.
 Every PR uses the same expanded template, populated by
 [`.github/pull_request_template.md`](../../.github/pull_request_template.md).
 Sections that do not apply to a given PR should still be present:
-leave a short "None", "N/A", or "not applicable" so the reviewer
-knows the author considered the section.
+for `## Impact`, `## Testing`, and `## Breaking Changes`, leave a
+short "None", "N/A", or "not applicable" so the reviewer knows the
+author considered the section. `## Summary`, `## Why`, and
+`## Changes` always carry content, and `## Related Issues` always
+carries one of the forms listed under [Issue linkage](#issue-linkage)
+— `Resolves`, `Part of`, or `No issue: <reason>` — never "None".
 
     ## Summary
 

--- a/docs/manual-chrome-testing.md
+++ b/docs/manual-chrome-testing.md
@@ -84,8 +84,10 @@ This extension is intentionally narrow. Manual verification should stay focused 
 3. If this build was intentionally packaged without the GitHub App config,
    confirm the page shows the explicit configuration warning instead of the
    sign-in controls.
-4. Otherwise, click **Add account** and complete the device flow with an account where the
-   GitHub App is installed on **All repositories**.
+4. Otherwise, click **+ Add another account**; the panel opens and
+   requests a device code automatically. Complete the device flow
+   with an account where the GitHub App is installed on
+   **All repositories**.
 5. Visit a private PR list in that account's namespace.
 6. Confirm reviewer chips render for every row without an uncovered-org banner.
 

--- a/entrypoints/options/components/AddAccountPanel.tsx
+++ b/entrypoints/options/components/AddAccountPanel.tsx
@@ -19,6 +19,7 @@ export function AddAccountPanel({ onConnected, onCancel }: Props) {
   const { state } = controller;
 
   const startedRef = useRef(false);
+  // Start the flow exactly once on mount; ref guards against re-firing because `controller` identity churns on every render.
   useEffect(() => {
     if (startedRef.current) {
       return;

--- a/entrypoints/options/components/AddAccountPanel.tsx
+++ b/entrypoints/options/components/AddAccountPanel.tsx
@@ -1,32 +1,19 @@
-import { useEffect, useRef, type CSSProperties } from "react";
+import { type CSSProperties } from "react";
 
-import { getGitHubAppConfig } from "../../../src/config/github-app";
-import type { Account } from "../../../src/storage/accounts";
-
-import { useDeviceFlowController } from "../device-flow-controller";
+import type { DeviceFlowController } from "../device-flow-controller";
 
 type Props = {
-  onConnected: (account: Account) => void;
+  controller: DeviceFlowController;
   onCancel: () => void;
 };
 
-export function AddAccountPanel({ onConnected, onCancel }: Props) {
-  const appConfig = getGitHubAppConfig();
-  const controller = useDeviceFlowController({
-    clientId: appConfig.clientId,
-    onConnected,
-  });
+export function AddAccountPanel({ controller, onCancel }: Props) {
   const { state } = controller;
 
-  const startedRef = useRef(false);
-  // Start the flow exactly once on mount; ref guards against re-firing because `controller` identity churns on every render.
-  useEffect(() => {
-    if (startedRef.current) {
-      return;
-    }
-    startedRef.current = true;
-    controller.start();
-  }, [controller]);
+  const handleCancel = () => {
+    controller.cancel();
+    onCancel();
+  };
 
   if (state.phase === "idle" || state.phase === "initiating") {
     return <div style={styles.panel}>Requesting device code...</div>;
@@ -62,14 +49,7 @@ export function AddAccountPanel({ onConnected, onCancel }: Props) {
         <p style={styles.hint}>
           Code expires at {new Date(state.expiresAt).toLocaleTimeString()}.
         </p>
-        <button
-          type="button"
-          onClick={() => {
-            controller.cancel();
-            onCancel();
-          }}
-          style={styles.secondaryButton}
-        >
+        <button type="button" onClick={handleCancel} style={styles.secondaryButton}>
           Cancel
         </button>
       </div>
@@ -115,14 +95,7 @@ export function AddAccountPanel({ onConnected, onCancel }: Props) {
       <p>
         Could not complete sign-in: {state.message} ({state.code}).
       </p>
-      <button
-        type="button"
-        onClick={() => {
-          controller.cancel();
-          onCancel();
-        }}
-        style={styles.secondaryButton}
-      >
+      <button type="button" onClick={handleCancel} style={styles.secondaryButton}>
         Close
       </button>
     </div>

--- a/entrypoints/options/components/AddAccountPanel.tsx
+++ b/entrypoints/options/components/AddAccountPanel.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties } from "react";
+import { useEffect, useRef, type CSSProperties } from "react";
 
 import { getGitHubAppConfig } from "../../../src/config/github-app";
 import type { Account } from "../../../src/storage/accounts";
@@ -7,9 +7,10 @@ import { useDeviceFlowController } from "../device-flow-controller";
 
 type Props = {
   onConnected: (account: Account) => void;
+  onCancel: () => void;
 };
 
-export function AddAccountPanel({ onConnected }: Props) {
+export function AddAccountPanel({ onConnected, onCancel }: Props) {
   const appConfig = getGitHubAppConfig();
   const controller = useDeviceFlowController({
     clientId: appConfig.clientId,
@@ -17,22 +18,16 @@ export function AddAccountPanel({ onConnected }: Props) {
   });
   const { state } = controller;
 
-  if (state.phase === "idle") {
-    return (
-      <div style={styles.panel}>
-        <button
-          type="button"
-          data-testid="add-account-start"
-          onClick={controller.start}
-          style={styles.primaryButton}
-        >
-          Add account
-        </button>
-      </div>
-    );
-  }
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (startedRef.current) {
+      return;
+    }
+    startedRef.current = true;
+    controller.start();
+  }, [controller]);
 
-  if (state.phase === "initiating") {
+  if (state.phase === "idle" || state.phase === "initiating") {
     return <div style={styles.panel}>Requesting device code...</div>;
   }
 
@@ -66,7 +61,14 @@ export function AddAccountPanel({ onConnected }: Props) {
         <p style={styles.hint}>
           Code expires at {new Date(state.expiresAt).toLocaleTimeString()}.
         </p>
-        <button type="button" onClick={controller.cancel} style={styles.secondaryButton}>
+        <button
+          type="button"
+          onClick={() => {
+            controller.cancel();
+            onCancel();
+          }}
+          style={styles.secondaryButton}
+        >
           Cancel
         </button>
       </div>
@@ -112,7 +114,14 @@ export function AddAccountPanel({ onConnected }: Props) {
       <p>
         Could not complete sign-in: {state.message} ({state.code}).
       </p>
-      <button type="button" onClick={controller.cancel} style={styles.secondaryButton}>
+      <button
+        type="button"
+        onClick={() => {
+          controller.cancel();
+          onCancel();
+        }}
+        style={styles.secondaryButton}
+      >
         Close
       </button>
     </div>

--- a/entrypoints/options/options-page.tsx
+++ b/entrypoints/options/options-page.tsx
@@ -39,7 +39,11 @@ export function OptionsPage() {
 
   const openAddPanel = () => {
     setShowAddPanel(true);
-    if (controller.state.phase === "idle") {
+    const inFlight =
+      controller.state.phase === "initiating" ||
+      controller.state.phase === "waiting" ||
+      controller.state.phase === "fetching_installations";
+    if (!inFlight) {
       controller.start();
     }
   };

--- a/entrypoints/options/options-page.tsx
+++ b/entrypoints/options/options-page.tsx
@@ -58,6 +58,7 @@ export function OptionsPage() {
                 setShowAddPanel(false);
                 await reload();
               }}
+              onCancel={() => setShowAddPanel(false)}
             />
           ) : (
             <button

--- a/entrypoints/options/options-page.tsx
+++ b/entrypoints/options/options-page.tsx
@@ -6,6 +6,7 @@ import { listAccounts, type Account } from "../../src/storage/accounts";
 import { AccountsList } from "./components/AccountsList";
 import { AddAccountPanel } from "./components/AddAccountPanel";
 import { DiagnosticsPanel } from "./components/DiagnosticsPanel";
+import { useDeviceFlowController } from "./device-flow-controller";
 
 export function OptionsPage() {
   const [accounts, setAccounts] = useState<Account[]>([]);
@@ -21,6 +22,27 @@ export function OptionsPage() {
   useEffect(() => {
     void reload();
   }, [reload]);
+
+  const handleConnected = useCallback(async () => {
+    setShowAddPanel(false);
+    await reload();
+  }, [reload]);
+
+  // Controller is owned by the parent so it survives AddAccountPanel's
+  // simulated remount under StrictMode and so start() is only ever called
+  // from a user-driven click handler, never from a useEffect that
+  // StrictMode double-invokes.
+  const controller = useDeviceFlowController({
+    clientId: appConfig?.clientId ?? "",
+    onConnected: handleConnected,
+  });
+
+  const openAddPanel = () => {
+    setShowAddPanel(true);
+    if (controller.state.phase === "idle") {
+      controller.start();
+    }
+  };
 
   return (
     <main style={styles.page}>
@@ -40,7 +62,7 @@ export function OptionsPage() {
             onChange={reload}
             onReauthenticate={() => {
               if (appConfig) {
-                setShowAddPanel(true);
+                openAddPanel();
               }
             }}
           />
@@ -54,17 +76,14 @@ export function OptionsPage() {
             </div>
           ) : showAddPanel ? (
             <AddAccountPanel
-              onConnected={async () => {
-                setShowAddPanel(false);
-                await reload();
-              }}
+              controller={controller}
               onCancel={() => setShowAddPanel(false)}
             />
           ) : (
             <button
               type="button"
               style={styles.primaryButton}
-              onClick={() => setShowAddPanel(true)}
+              onClick={openAddPanel}
               data-testid="accounts-add"
             >
               + Add another account

--- a/tests/options-page.test.ts
+++ b/tests/options-page.test.ts
@@ -117,4 +117,36 @@ describe("OptionsPage", () => {
       document.querySelector('[data-testid="options-config-warning"]'),
     ).not.toBeNull();
   });
+
+  it("auto-starts the device flow when the add-account panel opens", async () => {
+    await renderOptionsPage();
+
+    const auth = await import("../src/github/auth");
+    const initiateDeviceFlow =
+      auth.initiateDeviceFlow as unknown as ReturnType<typeof vi.fn>;
+    initiateDeviceFlow.mockResolvedValue({
+      deviceCode: "dc",
+      userCode: "ABCD-EFGH",
+      verificationUri: "https://github.com/login/device",
+      verificationUriComplete:
+        "https://github.com/login/device?user_code=ABCD-EFGH",
+      expiresIn: 900,
+      interval: 5,
+    });
+
+    const addButton = document.querySelector<HTMLButtonElement>(
+      '[data-testid="accounts-add"]',
+    );
+    expect(addButton).not.toBeNull();
+
+    await act(async () => {
+      addButton!.click();
+      await Promise.resolve();
+    });
+
+    expect(initiateDeviceFlow).toHaveBeenCalledTimes(1);
+    expect(
+      document.querySelector('[data-testid="add-account-start"]'),
+    ).toBeNull();
+  });
 });

--- a/tests/options-page.test.ts
+++ b/tests/options-page.test.ts
@@ -48,7 +48,28 @@ async function renderOptionsPage() {
   });
 }
 
+async function renderOptionsPageInStrictMode() {
+  vi.resetModules();
+  document.body.innerHTML = '<div id="root"></div>';
+  const [{ createRoot }, { StrictMode }, { OptionsPage }] = await Promise.all([
+    import("react-dom/client"),
+    import("react"),
+    import("../entrypoints/options/options-page"),
+  ]);
+  await act(async () => {
+    createRoot(document.getElementById("root")!).render(
+      createElement(StrictMode, null, createElement(OptionsPage)),
+    );
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
 beforeEach(() => {
+  // `vi.mock` factory results are cached across `vi.resetModules()` in
+  // this file (module cache is reset but factory outputs are reused), so
+  // auth mock call history leaks between tests unless cleared here.
+  vi.clearAllMocks();
   listAccountsMock.mockReset();
   listAccountsMock.mockResolvedValue([]);
 });
@@ -195,5 +216,35 @@ describe("OptionsPage", () => {
     expect(
       document.querySelector('[data-testid="accounts-add"]'),
     ).not.toBeNull();
+  });
+
+  it("does not start the device flow twice under React StrictMode", async () => {
+    await renderOptionsPageInStrictMode();
+
+    const auth = await import("../src/github/auth");
+    const initiateDeviceFlow =
+      auth.initiateDeviceFlow as unknown as ReturnType<typeof vi.fn>;
+    initiateDeviceFlow.mockResolvedValue({
+      deviceCode: "dc",
+      userCode: "ABCD-EFGH",
+      verificationUri: "https://github.com/login/device",
+      verificationUriComplete:
+        "https://github.com/login/device?user_code=ABCD-EFGH",
+      expiresIn: 900,
+      interval: 5,
+    });
+
+    const addButton = document.querySelector<HTMLButtonElement>(
+      '[data-testid="accounts-add"]',
+    );
+    expect(addButton).not.toBeNull();
+
+    await act(async () => {
+      addButton!.click();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(initiateDeviceFlow).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/options-page.test.ts
+++ b/tests/options-page.test.ts
@@ -149,4 +149,51 @@ describe("OptionsPage", () => {
       document.querySelector('[data-testid="add-account-start"]'),
     ).toBeNull();
   });
+
+  it("closes the add-account panel when the user clicks Cancel during waiting", async () => {
+    await renderOptionsPage();
+
+    const auth = await import("../src/github/auth");
+    (auth.initiateDeviceFlow as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      deviceCode: "dc",
+      userCode: "ABCD-EFGH",
+      verificationUri: "https://github.com/login/device",
+      verificationUriComplete:
+        "https://github.com/login/device?user_code=ABCD-EFGH",
+      expiresIn: 900,
+      interval: 5,
+    });
+    (auth.pollForAccessToken as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "pending",
+    });
+
+    await act(async () => {
+      document
+        .querySelector<HTMLButtonElement>('[data-testid="accounts-add"]')!
+        .click();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const userCode = document.querySelector('[data-testid="device-user-code"]');
+    expect(userCode).not.toBeNull();
+    expect(userCode!.textContent).toBe("ABCD-EFGH");
+
+    const cancelButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((b) => b.textContent?.trim() === "Cancel");
+    expect(cancelButton).toBeDefined();
+
+    await act(async () => {
+      cancelButton!.click();
+      await Promise.resolve();
+    });
+
+    expect(
+      document.querySelector('[data-testid="device-user-code"]'),
+    ).toBeNull();
+    expect(
+      document.querySelector('[data-testid="accounts-add"]'),
+    ).not.toBeNull();
+  });
 });

--- a/tests/options-page.test.ts
+++ b/tests/options-page.test.ts
@@ -218,6 +218,63 @@ describe("OptionsPage", () => {
     ).not.toBeNull();
   });
 
+  it("restarts the device flow when reopening the add-account panel after a successful connection", async () => {
+    await renderOptionsPage();
+
+    const auth = await import("../src/github/auth");
+    const initiateDeviceFlow =
+      auth.initiateDeviceFlow as unknown as ReturnType<typeof vi.fn>;
+    const pollForAccessToken =
+      auth.pollForAccessToken as unknown as ReturnType<typeof vi.fn>;
+    const fetchAuthenticatedUser =
+      auth.fetchAuthenticatedUser as unknown as ReturnType<typeof vi.fn>;
+    const fetchUserInstallations =
+      auth.fetchUserInstallations as unknown as ReturnType<typeof vi.fn>;
+
+    initiateDeviceFlow.mockResolvedValue({
+      deviceCode: "dc",
+      userCode: "ABCD-EFGH",
+      verificationUri: "https://github.com/login/device",
+      verificationUriComplete:
+        "https://github.com/login/device?user_code=ABCD-EFGH",
+      expiresIn: 900,
+      interval: 0,
+    });
+    pollForAccessToken.mockResolvedValue({
+      status: "success",
+      accessToken: "ghu_abc",
+    });
+    fetchAuthenticatedUser.mockResolvedValue({
+      login: "hon454",
+      avatarUrl: null,
+    });
+    fetchUserInstallations.mockResolvedValue([]);
+
+    await act(async () => {
+      document
+        .querySelector<HTMLButtonElement>('[data-testid="accounts-add"]')!
+        .click();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(initiateDeviceFlow).toHaveBeenCalledTimes(1);
+    expect(
+      document.querySelector('[data-testid="accounts-add"]'),
+    ).not.toBeNull();
+
+    await act(async () => {
+      document
+        .querySelector<HTMLButtonElement>('[data-testid="accounts-add"]')!
+        .click();
+      await Promise.resolve();
+    });
+
+    expect(initiateDeviceFlow).toHaveBeenCalledTimes(2);
+  });
+
   it("does not start the device flow twice under React StrictMode", async () => {
     await renderOptionsPageInStrictMode();
 


### PR DESCRIPTION
## Summary

- Collapse the two-click "+ Add another account" → "Add account" sequence on the options page into a single click by starting the GitHub device flow directly from the outer button handler.
- Keep the Cancel path sensible by unmounting the panel back to the entry button when the user cancels during the `waiting` phase.
- Fix the follow-up regression from the controller lift so reopening the panel after one successful connect starts a fresh device flow instead of getting stuck on the stale `connected` state.
- Surface the repository's PR workflow from AGENTS.md and adopt the expanded PR template as the default so this kind of UX gap does not slip through a future PR audit.

## Why

Two buttons captured the same user intent ("I want to add an account"), so the second click was pure friction. The re-authentication path reuses the same panel, so the same friction hit users coming back after a token invalidation. The StrictMode-safe controller lift fixed the double-start problem, but it also exposed a new multi-account regression: after one successful connect, reopening the panel reused the terminal controller state and no longer kicked off a second device flow. While auditing the resulting PR against `docs/guidelines/pr-guideline.md` we also noticed the PR guideline was effectively invisible from AGENTS.md and the repo still shipped with a minimal PR template, both of which contributed to a first-pass PR body that missed required sections.

## Changes

- Options UX: `OptionsPage` now owns the device-flow controller so it survives StrictMode remounts, and `openAddPanel()` starts the flow directly from the click/re-auth handler instead of relying on an `AddAccountPanel` mount effect. The add-account guard now blocks only while the controller is actively in flight (`initiating`, `waiting`, `fetching_installations`) so terminal phases (`connected`, `expired`, `denied`, `fatal`) can restart cleanly.
- Panel behavior: `AddAccountPanel` now renders the `idle` phase as the existing "Requesting device code..." loading view, accepts an `onCancel` prop, and returns to the outer `+ Add another account` button when the user cancels from `waiting` or closes a `fatal` state.
- Test coverage: `tests/options-page.test.ts` now covers four key paths: single-click auto-start, Cancel collapsing the panel, reopening after a successful connect triggering a second `initiateDeviceFlow` call, and React StrictMode not double-starting the device flow.
- Docs (bundled): AGENTS.md gains a dedicated `## Pull Request Policy` section listing the required PR body sections. `docs/manual-chrome-testing.md` reflects the single-click add-account flow. `.github/pull_request_template.md` is replaced with the expanded Summary/Why/Changes/Impact/Testing/Breaking Changes/Related Issues shape, and `docs/guidelines/pr-guideline.md` is updated to make the expanded template canonical with per-section writing guidance.

## Impact

- User-facing impact: one fewer click to add or re-authenticate a GitHub account, Cancel now returns the user to the entry button instead of a dead-end idle screen, and multi-account users can successfully start a second device-flow session after the first account connects.
- API/schema impact: None. `device-flow-controller.ts` keeps the same state machine and storage/API contracts.
- Performance impact: None.
- Operational or rollout impact: None for the UX change. The PR-template change affects every future PR opened through the web UI; the new template requires more sections but GitHub auto-populates them. `gh pr create --body` still bypasses the template, which the updated AGENTS.md now calls out explicitly.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint`: pass
- `pnpm typecheck`: pass
- `pnpm test`: pass (82/82)
- Manual: not yet run — pending maintainer execution via `pnpm dev` + unpacked extension: click `+ Add another account` and verify the GitHub device code appears without a second button click, click Cancel during the waiting phase and verify the panel collapses back to the `+ Add another account` button, complete one end-to-end device-flow sign-in, then reopen the panel and verify a second device-flow session starts successfully.

## Breaking Changes

- None

## Related Issues

No issue: UX polish and PR-workflow hardening caught during a maintainer-driven review session; no prior tracking ticket.
