### PR TITLE
feat(reviewers): merge sections into avatar chips with display toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This extension brings that information into the list itself with lightweight inl
 
 ## What The Extension Shows
 
-| Requested reviewers and teams | Mixed completed review states |
+| Merged `Reviewers` section with state badges | Name-pill layout (optional) |
 | --- | --- |
 | ![Requested reviewers and teams](./docs/chrome-web-store-assets/01-pr-list-requested-and-reviewed.png) | ![Mixed review states](./docs/chrome-web-store-assets/02-pr-list-mixed-review-states.png) |
 
@@ -44,7 +44,8 @@ Review states currently surfaced in the UI:
 This repository intentionally stays narrow.
 
 - Reviewer visibility first
-- Requested reviewers, requested teams, and completed review state are in scope
+- Requested reviewers, requested teams, and completed review state are in scope, surfaced as a single `Reviewers:` section with avatar + state-badge chips.
+- Display preferences let you hide the state badge or expand each user into an `@login` pill.
 - Checks, mergeability, assignees, labels, and dashboard-style expansion are out of scope unless explicitly approved
 
 ## Authentication Model

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -20,7 +20,7 @@
 4. Resolve the covering account for `owner/repo` via `resolveAccountForRepo`.
 5. Fetch reviewer data from GitHub only when the cache is cold. Use the
    matched account's token, or no token if none matches.
-6. Render `Requested` and `Reviewed` sections inline in the PR row metadata area.
+6. Render a single `Reviewers` section inline in the PR row metadata area. Each reviewer is an avatar chip (border = attention signal, badge = latest review state); requested teams keep the text chip shape.
 7. On API errors, emit a signal to the banner aggregator; do not render
    row-level error text.
 8. Re-run row processing when GitHub mutates the page or performs SPA navigation.
@@ -31,6 +31,13 @@
 - API requests are still one pull request plus one reviews request per uncached row.
 - Public-repository no-token access still depends on GitHub's unauthenticated REST availability and rate limits.
 - Legacy single-token settings are not migrated and must be re-added as scoped entries.
+
+## Display preferences
+
+- Stored under a separate `preferences` key in `browser.storage.local` (schema `version: 1`).
+- `showStateBadge` (default `true`) toggles the SVG state badge on each avatar.
+- `showReviewerName` (default `false`) switches each user chip between avatar-only and a rounded pill containing the avatar and `@login` text.
+- Preference changes rerender without invalidating the per-row reviewer cache — no extra GitHub requests are triggered.
 
 ## Request volume decision
 

--- a/entrypoints/options/components/DisplaySettingsPanel.tsx
+++ b/entrypoints/options/components/DisplaySettingsPanel.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState, type CSSProperties } from "react";
+
+import {
+  DEFAULT_PREFERENCES,
+  getPreferences,
+  updatePreferences,
+  type Preferences,
+} from "../../../src/storage/preferences";
+
+export function DisplaySettingsPanel() {
+  const [preferences, setPreferences] = useState<Preferences>(DEFAULT_PREFERENCES);
+
+  useEffect(() => {
+    void (async () => {
+      setPreferences(await getPreferences());
+    })();
+  }, []);
+
+  async function handleChange(patch: Partial<Omit<Preferences, "version">>) {
+    const next = await updatePreferences(patch);
+    setPreferences(next);
+  }
+
+  return (
+    <section style={styles.section}>
+      <h2 style={styles.sectionTitle}>Display</h2>
+      <p style={styles.hint}>
+        Control how reviewer chips look on GitHub pull request lists.
+      </p>
+      <label style={styles.row}>
+        <input
+          data-testid="prefs-show-state-badge"
+          type="checkbox"
+          checked={preferences.showStateBadge}
+          onChange={(event) =>
+            handleChange({ showStateBadge: event.target.checked })
+          }
+        />
+        <span>Show review state badge on avatars</span>
+      </label>
+      <label style={styles.row}>
+        <input
+          data-testid="prefs-show-reviewer-name"
+          type="checkbox"
+          checked={preferences.showReviewerName}
+          onChange={(event) =>
+            handleChange({ showReviewerName: event.target.checked })
+          }
+        />
+        <span>Show reviewer names</span>
+      </label>
+    </section>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  section: {
+    marginTop: 32,
+    paddingTop: 24,
+    borderTop: "1px solid rgba(34, 29, 24, 0.08)",
+  },
+  sectionTitle: { margin: 0, fontSize: 20 },
+  hint: { color: "#6e5f52", fontSize: 13, lineHeight: 1.6, margin: "8px 0 12px" },
+  row: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    padding: "6px 0",
+    fontSize: 14,
+    color: "#221d18",
+    cursor: "pointer",
+  },
+};

--- a/entrypoints/options/options-page.tsx
+++ b/entrypoints/options/options-page.tsx
@@ -6,6 +6,7 @@ import { listAccounts, type Account } from "../../src/storage/accounts";
 import { AccountsList } from "./components/AccountsList";
 import { AddAccountPanel } from "./components/AddAccountPanel";
 import { DiagnosticsPanel } from "./components/DiagnosticsPanel";
+import { DisplaySettingsPanel } from "./components/DisplaySettingsPanel";
 import { useDeviceFlowController } from "./device-flow-controller";
 
 export function OptionsPage() {
@@ -94,6 +95,8 @@ export function OptionsPage() {
             </button>
           )}
         </section>
+
+        <DisplaySettingsPanel />
 
         <DiagnosticsPanel />
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-pulls-show-reviewers",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "description": "Chrome extension focused on showing reviewers directly in GitHub pull request lists.",

--- a/src/features/reviewers/dom.ts
+++ b/src/features/reviewers/dom.ts
@@ -1,8 +1,18 @@
-import type { ReviewerSection } from "./view-model";
+import type { ReviewState } from "../../github/api";
+import type { ReviewerEntry } from "./view-model";
+import { STATE_ICONS } from "./state-icons";
 import { githubSelectors } from "../../github/selectors";
 
 const ROOT_ATTRIBUTE = "data-ghpsr-root";
 const STYLE_ATTRIBUTE = "data-ghpsr-style";
+
+type BorderTone = "requested" | "approved" | "changes-requested";
+type BadgeTone = "approved" | "changes-requested" | "commented" | "dismissed";
+
+type RenderReviewersOptions = {
+  showStateBadge: boolean;
+  showReviewerName: boolean;
+};
 
 export function ensureReviewerStyles(): void {
   if (document.head.querySelector(`[${STYLE_ATTRIBUTE}]`)) {
@@ -16,21 +26,100 @@ export function ensureReviewerStyles(): void {
       display: inline-flex;
       flex-wrap: wrap;
       align-items: center;
-      gap: 6px 8px;
+      gap: 4px 6px;
       margin-left: 8px;
       vertical-align: middle;
-    }
-    .ghpsr-section {
-      display: inline-flex;
-      align-items: center;
-      flex-wrap: wrap;
-      gap: 6px;
     }
     .ghpsr-section-label {
       color: var(--fgColor-muted, #656d76);
       font-size: 12px;
       font-weight: 600;
+      margin-right: 2px;
     }
+    .ghpsr-status {
+      color: var(--fgColor-muted, #656d76);
+      font-size: 12px;
+    }
+
+    .ghpsr-avatar {
+      position: relative;
+      display: inline-block;
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      box-shadow: 0 0 0 2px var(--ghpsr-border-color, transparent);
+      margin-right: 2px;
+    }
+    .ghpsr-avatar-img,
+    .ghpsr-initials {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      display: block;
+    }
+    .ghpsr-initials {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      font-size: 11px;
+      font-weight: 600;
+    }
+
+    .ghpsr-avatar--border-requested         { --ghpsr-border-color: #0969da; }
+    .ghpsr-avatar--border-approved          { --ghpsr-border-color: #2ea043; }
+    .ghpsr-avatar--border-changes-requested { --ghpsr-border-color: #cf222e; }
+
+    .ghpsr-badge {
+      position: absolute;
+      bottom: -3px;
+      right: -5px;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      border: 2px solid var(--bgColor-default, #fff);
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+      background: var(--ghpsr-badge-color, #6e7781);
+    }
+    .ghpsr-badge svg { width: 10px; height: 10px; fill: currentColor; }
+    .ghpsr-badge--approved          { --ghpsr-badge-color: #2ea043; }
+    .ghpsr-badge--changes-requested { --ghpsr-badge-color: #cf222e; }
+    .ghpsr-badge--commented         { --ghpsr-badge-color: #6e7781; }
+    .ghpsr-badge--dismissed         { --ghpsr-badge-color: #8250df; }
+
+    .ghpsr-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 2px 8px 2px 3px;
+      border-radius: 12px;
+      font-size: 12px;
+      line-height: 20px;
+      text-decoration: none;
+      background: var(--ghpsr-pill-bg);
+      color: var(--ghpsr-pill-fg);
+    }
+    .ghpsr-pill:hover { filter: brightness(0.98); }
+    .ghpsr-pill-name { font-weight: 500; }
+    .ghpsr-avatar--small { width: 18px; height: 18px; }
+    .ghpsr-avatar--small .ghpsr-avatar-img,
+    .ghpsr-avatar--small .ghpsr-initials { width: 18px; height: 18px; }
+    .ghpsr-badge--small {
+      width: 12px;
+      height: 12px;
+      bottom: -2px;
+      right: -3px;
+    }
+    .ghpsr-badge--small svg { width: 8px; height: 8px; }
+
+    .ghpsr-pill--requested         { --ghpsr-pill-bg: var(--bgColor-accent-muted,  #ddf4ff); --ghpsr-pill-fg: var(--fgColor-accent,  #0969da); }
+    .ghpsr-pill--approved          { --ghpsr-pill-bg: var(--bgColor-success-muted, #dafbe1); --ghpsr-pill-fg: var(--fgColor-success, #1a7f37); }
+    .ghpsr-pill--changes-requested { --ghpsr-pill-bg: var(--bgColor-danger-muted,  #ffebe9); --ghpsr-pill-fg: var(--fgColor-danger,  #cf222e); }
+
     .ghpsr-chip {
       display: inline-flex;
       align-items: center;
@@ -42,48 +131,11 @@ export function ensureReviewerStyles(): void {
       text-decoration: none;
       border: 1px solid transparent;
     }
-    .ghpsr-chip:hover {
-      text-decoration: none;
-      filter: brightness(0.98);
-    }
-    .ghpsr-chip--requested {
-      color: var(--fgColor-accent, #0969da);
-      background: color-mix(in srgb, var(--bgColor-accent-muted, #ddf4ff) 80%, white);
-      border-color: color-mix(in srgb, var(--borderColor-accent-muted, #54aeff) 55%, white);
-    }
+    .ghpsr-chip:hover { text-decoration: none; filter: brightness(0.98); }
     .ghpsr-chip--team {
       color: var(--fgColor-attention, #9a6700);
       background: color-mix(in srgb, var(--bgColor-attention-muted, #fff8c5) 80%, white);
       border-color: color-mix(in srgb, var(--borderColor-attention-muted, #d4a72c) 55%, white);
-    }
-    .ghpsr-chip--reviewed {
-      color: var(--fgColor-success, #1a7f37);
-      background: color-mix(in srgb, var(--bgColor-success-muted, #dafbe1) 80%, white);
-      border-color: color-mix(in srgb, var(--borderColor-success-muted, #4ac26b) 55%, white);
-    }
-    .ghpsr-chip--approved {
-      color: var(--fgColor-success, #1a7f37);
-      background: color-mix(in srgb, var(--bgColor-success-muted, #dafbe1) 80%, white);
-      border-color: color-mix(in srgb, var(--borderColor-success-muted, #4ac26b) 55%, white);
-    }
-    .ghpsr-chip--changes-requested {
-      color: var(--fgColor-danger, #cf222e);
-      background: color-mix(in srgb, var(--bgColor-danger-muted, #ffebe9) 82%, white);
-      border-color: color-mix(in srgb, var(--borderColor-danger-muted, #ff818266) 55%, white);
-    }
-    .ghpsr-chip--commented {
-      color: var(--fgColor-muted, #57606a);
-      background: color-mix(in srgb, var(--bgColor-muted, #f6f8fa) 88%, white);
-      border-color: color-mix(in srgb, var(--borderColor-muted, #d0d7de) 80%, white);
-    }
-    .ghpsr-chip--dismissed {
-      color: var(--fgColor-done, #8250df);
-      background: color-mix(in srgb, var(--bgColor-done-muted, #fbefff) 82%, white);
-      border-color: color-mix(in srgb, var(--borderColor-done-muted, #c297ff) 55%, white);
-    }
-    .ghpsr-status {
-      color: var(--fgColor-muted, #656d76);
-      font-size: 12px;
     }
   `;
 
@@ -112,7 +164,10 @@ export function ensureReviewerMount(row: Element): HTMLElement | null {
     return null;
   }
 
-  let inlineMetaRow = findFirst<HTMLElement>(metaContainer, githubSelectors.inlineMetaRowSelectors);
+  let inlineMetaRow = findFirst<HTMLElement>(
+    metaContainer,
+    githubSelectors.inlineMetaRowSelectors,
+  );
   if (inlineMetaRow == null) {
     inlineMetaRow = document.createElement("span");
     inlineMetaRow.className = "d-none d-md-inline-flex";
@@ -138,49 +193,163 @@ export function renderLoading(mount: HTMLElement): void {
   mount.removeAttribute("title");
 }
 
-export function renderReviewerSections(
+export function renderReviewers(
   mount: HTMLElement,
-  sections: ReviewerSection[],
+  entries: ReviewerEntry[],
+  options: RenderReviewersOptions,
 ): void {
-  if (sections.length === 0) {
+  if (entries.length === 0) {
     mount.replaceChildren();
     mount.removeAttribute("title");
     return;
   }
 
-  mount.replaceChildren(...sections.map(createSectionNode));
+  const label = document.createElement("span");
+  label.className = "ghpsr-section-label";
+  label.textContent = "Reviewers:";
+
+  const nodes: Node[] = [label];
+  for (const entry of entries) {
+    if (entry.kind === "team") {
+      nodes.push(createTeamNode(entry));
+    } else {
+      nodes.push(createUserNode(entry, options));
+    }
+  }
+  mount.replaceChildren(...nodes);
   mount.removeAttribute("title");
 }
 
-function createSectionNode(section: ReviewerSection): HTMLElement {
-  const sectionNode = document.createElement("span");
-  sectionNode.className = "ghpsr-section";
+function createTeamNode(entry: Extract<ReviewerEntry, { kind: "team" }>): HTMLElement {
+  const link = document.createElement("a");
+  link.className = "ghpsr-chip ghpsr-chip--team";
+  link.href = entry.href;
+  link.textContent = `Team: ${entry.slug}`;
+  return link;
+}
 
-  const labelNode = document.createElement("span");
-  labelNode.className = "ghpsr-section-label";
-  labelNode.textContent = `${section.label}:`;
-  sectionNode.append(labelNode);
+function createUserNode(
+  entry: Extract<ReviewerEntry, { kind: "user" }>,
+  options: RenderReviewersOptions,
+): HTMLElement {
+  const borderTone = resolveBorderTone(entry);
+  const badgeTone = entry.state ? resolveBadgeTone(entry.state) : null;
+  const stateLabel = resolveStateLabel(entry);
+  const titleText = `@${entry.login} · ${stateLabel}`;
+  const ariaText = `@${entry.login}, ${stateLabel}`;
 
-  if (section.chips.length === 0) {
-    const emptyNode = document.createElement("span");
-    emptyNode.className = "ghpsr-status";
-    emptyNode.textContent = section.emptyLabel;
-    sectionNode.append(emptyNode);
-    return sectionNode;
+  if (options.showReviewerName) {
+    const pill = document.createElement("a");
+    pill.className = `ghpsr-pill ghpsr-pill--${borderTone}`;
+    pill.href = entry.href;
+    pill.title = titleText;
+    pill.setAttribute("aria-label", ariaText);
+
+    const avatarWrap = document.createElement("span");
+    avatarWrap.className = `ghpsr-avatar ghpsr-avatar--small ghpsr-avatar--border-${borderTone}`;
+    attachAvatarImage(avatarWrap, entry, 18);
+    if (options.showStateBadge && badgeTone) {
+      avatarWrap.append(createBadgeNode(badgeTone, true));
+    }
+
+    const name = document.createElement("span");
+    name.className = "ghpsr-pill-name";
+    name.textContent = `@${entry.login}`;
+
+    pill.append(avatarWrap, name);
+    return pill;
   }
 
-  section.chips.forEach((chip) => {
-    const link = document.createElement("a");
-    link.className = `ghpsr-chip ghpsr-chip--${chip.tone}`;
-    link.href = chip.href;
-    link.textContent = chip.label;
-    if (chip.title) {
-      link.title = chip.title;
-    }
-    sectionNode.append(link);
-  });
+  const link = document.createElement("a");
+  link.className = `ghpsr-avatar ghpsr-avatar--border-${borderTone}`;
+  link.href = entry.href;
+  link.title = titleText;
+  link.setAttribute("aria-label", ariaText);
+  attachAvatarImage(link, entry, 24);
+  if (options.showStateBadge && badgeTone) {
+    link.append(createBadgeNode(badgeTone, false));
+  }
+  return link;
+}
 
-  return sectionNode;
+function attachAvatarImage(
+  container: HTMLElement,
+  entry: Extract<ReviewerEntry, { kind: "user" }>,
+  size: 18 | 24,
+): void {
+  const img = document.createElement("img");
+  img.className = "ghpsr-avatar-img";
+  img.alt = "";
+  img.setAttribute("loading", "lazy");
+  img.setAttribute("width", String(size));
+  img.setAttribute("height", String(size));
+  img.src = entry.avatarUrl ?? `https://github.com/${entry.login}.png?size=48`;
+  img.addEventListener("error", () => {
+    const initials = document.createElement("span");
+    initials.className = "ghpsr-initials";
+    initials.textContent = (entry.login[0] ?? "?").toUpperCase();
+    initials.style.background = initialsBackground(entry.login);
+    img.replaceWith(initials);
+  });
+  container.append(img);
+}
+
+function createBadgeNode(tone: BadgeTone, small: boolean): HTMLElement {
+  const badge = document.createElement("span");
+  badge.className = small
+    ? `ghpsr-badge ghpsr-badge--small ghpsr-badge--${tone}`
+    : `ghpsr-badge ghpsr-badge--${tone}`;
+  badge.setAttribute("aria-hidden", "true");
+  badge.innerHTML = selectIconMarkup(tone);
+  return badge;
+}
+
+function selectIconMarkup(tone: BadgeTone): string {
+  if (tone === "approved") return STATE_ICONS.approved;
+  if (tone === "changes-requested") return STATE_ICONS.changesRequested;
+  if (tone === "commented") return STATE_ICONS.commented;
+  return STATE_ICONS.dismissed;
+}
+
+function resolveBorderTone(
+  entry: Extract<ReviewerEntry, { kind: "user" }>,
+): BorderTone {
+  if (entry.isRequested) return "requested";
+  if (entry.state === "CHANGES_REQUESTED") return "changes-requested";
+  return "approved";
+}
+
+function resolveBadgeTone(state: ReviewState): BadgeTone {
+  if (state === "APPROVED") return "approved";
+  if (state === "CHANGES_REQUESTED") return "changes-requested";
+  if (state === "COMMENTED") return "commented";
+  return "dismissed";
+}
+
+function resolveStateLabel(
+  entry: Extract<ReviewerEntry, { kind: "user" }>,
+): string {
+  const base = stateLabelBase(entry.state);
+  if (entry.state != null && entry.isRequested) {
+    return `${base} (still requested)`;
+  }
+  return base;
+}
+
+function stateLabelBase(state: ReviewState | null): string {
+  if (state === "APPROVED") return "approved";
+  if (state === "CHANGES_REQUESTED") return "changes requested";
+  if (state === "COMMENTED") return "commented";
+  if (state === "DISMISSED") return "dismissed";
+  return "requested";
+}
+
+function initialsBackground(login: string): string {
+  let hash = 0;
+  for (let index = 0; index < login.length; index += 1) {
+    hash = (hash * 31 + login.charCodeAt(index)) >>> 0;
+  }
+  return `hsl(${hash % 360}, 40%, 55%)`;
 }
 
 function findFirst<T extends Element>(root: ParentNode, selectors: readonly string[]): T | null {

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -9,17 +9,23 @@ import {
 import { fetchPullReviewerSummary } from "../../github/api";
 import { parsePullListRoute } from "../../github/routes";
 import { githubSelectors } from "../../github/selectors";
-import { resolveAccountForRepo, type Account } from "../../storage/accounts";
+import { markAccountInvalidated, resolveAccountForRepo, type Account } from "../../storage/accounts";
+import {
+  DEFAULT_PREFERENCES,
+  getPreferences,
+  isAccountsChange,
+  isPreferencesChange,
+  type Preferences,
+} from "../../storage/preferences";
 
 import {
   ensureReviewerMount,
   ensureReviewerStyles,
   extractPullNumber,
   renderLoading,
-  renderReviewerSections,
+  renderReviewers,
 } from "./dom";
-import { buildReviewerSections } from "./view-model";
-import { markAccountInvalidated } from "../../storage/accounts";
+import { buildReviewers } from "./view-model";
 
 export type ReviewerBootOptions = {
   onRowFailure?: (signal: {
@@ -39,26 +45,45 @@ export function bootReviewerListPage(
   let currentRoute = parsePullListRoute(window.location.pathname);
   let currentHref = window.location.href;
   const inflightRequests = new Map<string, Promise<void>>();
+  let cachedPreferences: Preferences | null = null;
+
+  async function readPreferences(): Promise<Preferences> {
+    if (cachedPreferences != null) return cachedPreferences;
+    try {
+      cachedPreferences = await getPreferences();
+    } catch {
+      cachedPreferences = DEFAULT_PREFERENCES;
+    }
+    return cachedPreferences;
+  }
+
+  async function renderSummaryForMount(
+    mount: HTMLElement,
+    route: NonNullable<typeof currentRoute>,
+    summary: ReturnType<typeof getCachedReviewerSummary>,
+  ): Promise<void> {
+    if (!summary) return;
+    const preferences = await readPreferences();
+    renderReviewers(mount, buildReviewers(route, summary), {
+      showStateBadge: preferences.showStateBadge,
+      showReviewerName: preferences.showReviewerName,
+    });
+  }
 
   async function processRow(row: Element): Promise<void> {
-    if (currentRoute == null) {
-      return;
-    }
+    if (currentRoute == null) return;
 
     const pullNumber = extractPullNumber(row);
-    if (pullNumber == null) {
-      return;
-    }
+    if (pullNumber == null) return;
 
     const mount = ensureReviewerMount(row);
-    if (mount == null) {
-      return;
-    }
+    if (mount == null) return;
 
-    const cacheKey = buildReviewerCacheKey(currentRoute.owner, currentRoute.repo, pullNumber);
+    const route = currentRoute;
+    const cacheKey = buildReviewerCacheKey(route.owner, route.repo, pullNumber);
     const cachedSummary = getCachedReviewerSummary(cacheKey);
     if (cachedSummary) {
-      renderReviewerSections(mount, buildReviewerSections(currentRoute, cachedSummary));
+      await renderSummaryForMount(mount, route, cachedSummary);
       return;
     }
 
@@ -66,26 +91,20 @@ export function bootReviewerListPage(
     if (existingRequest) {
       renderLoading(mount);
       await existingRequest;
-      const summary = getCachedReviewerSummary(cacheKey);
-      if (summary && currentRoute) {
-        renderReviewerSections(mount, buildReviewerSections(currentRoute, summary));
-      }
+      await renderSummaryForMount(mount, route, getCachedReviewerSummary(cacheKey));
       return;
     }
 
     renderLoading(mount);
 
     const request = (async () => {
-      const account = await resolveAccountForRepo(
-        currentRoute!.owner,
-        currentRoute!.repo,
-      );
+      const account = await resolveAccountForRepo(route.owner, route.repo);
       const githubToken = account?.token ?? null;
 
       try {
         const summary = await fetchPullReviewerSummary({
-          owner: currentRoute!.owner,
-          repo: currentRoute!.repo,
+          owner: route.owner,
+          repo: route.repo,
           pullNumber,
           githubToken,
         });
@@ -99,8 +118,8 @@ export function bootReviewerListPage(
         mount.replaceChildren();
         mount.removeAttribute("title");
         options?.onRowFailure?.({
-          owner: currentRoute!.owner,
-          repo: currentRoute!.repo,
+          owner: route.owner,
+          repo: route.repo,
           account,
           error,
         });
@@ -112,17 +131,11 @@ export function bootReviewerListPage(
     inflightRequests.set(cacheKey, request);
     await request;
 
-    const summary = getCachedReviewerSummary(cacheKey);
-    if (summary && currentRoute) {
-      renderReviewerSections(mount, buildReviewerSections(currentRoute, summary));
-    }
+    await renderSummaryForMount(mount, route, getCachedReviewerSummary(cacheKey));
   }
 
   function processRows(root: ParentNode = document): void {
-    if (currentRoute == null) {
-      return;
-    }
-
+    if (currentRoute == null) return;
     root.querySelectorAll(githubSelectors.row).forEach((row) => {
       void processRow(row);
     });
@@ -130,9 +143,7 @@ export function bootReviewerListPage(
 
   function refreshRoute(force = false): void {
     const nextHref = window.location.href;
-    if (!force && nextHref === currentHref) {
-      return;
-    }
+    if (!force && nextHref === currentHref) return;
 
     currentHref = nextHref;
     const previousRoute = currentRoute;
@@ -153,15 +164,11 @@ export function bootReviewerListPage(
   const observer = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
       mutation.addedNodes.forEach((node) => {
-        if (!(node instanceof Element)) {
-          return;
-        }
-
+        if (!(node instanceof Element)) return;
         if (node.matches(githubSelectors.row)) {
           void processRow(node);
           return;
         }
-
         processRows(node);
       });
     }
@@ -176,10 +183,18 @@ export function bootReviewerListPage(
   ctx.addEventListener(document, "pjax:end", () => refreshRoute(true));
 
   const storageListener: Parameters<typeof browser.storage.onChanged.addListener>[0] = (
-    _changes,
+    changes,
     areaName,
   ) => {
-    if (areaName === "local") {
+    if (areaName !== "local") return;
+
+    if (isPreferencesChange(changes)) {
+      cachedPreferences = null;
+      processRows();
+      return;
+    }
+
+    if (isAccountsChange(changes)) {
       clearReviewerCache();
       inflightRequests.clear();
       processRows();

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -45,14 +45,11 @@ export function bootReviewerListPage(
   let currentRoute = parsePullListRoute(window.location.pathname);
   let currentHref = window.location.href;
   const inflightRequests = new Map<string, Promise<void>>();
-  let cachedPreferences: Preferences | null = null;
+  let cachedPreferences: Promise<Preferences> | null = null;
 
-  async function readPreferences(): Promise<Preferences> {
-    if (cachedPreferences != null) return cachedPreferences;
-    try {
-      cachedPreferences = await getPreferences();
-    } catch {
-      cachedPreferences = DEFAULT_PREFERENCES;
+  function readPreferences(): Promise<Preferences> {
+    if (cachedPreferences == null) {
+      cachedPreferences = getPreferences().catch(() => DEFAULT_PREFERENCES);
     }
     return cachedPreferences;
   }

--- a/src/features/reviewers/state-icons.ts
+++ b/src/features/reviewers/state-icons.ts
@@ -1,0 +1,9 @@
+// SVG icons adapted from GitHub Octicons (MIT License).
+// https://github.com/primer/octicons
+
+export const STATE_ICONS = {
+  approved: `<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/></svg>`,
+  changesRequested: `<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/></svg>`,
+  commented: `<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0113.25 12H9.06l-2.573 2.573A1.458 1.458 0 014 13.543V12H2.75A1.75 1.75 0 011 10.25v-7.5z"/></svg>`,
+  dismissed: `<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm3.56-3.44a.75.75 0 000 1.06l6.82 6.82a.75.75 0 101.06-1.06L4.62 4.56a.75.75 0 00-1.06 0z"/></svg>`,
+} as const;

--- a/src/features/reviewers/view-model.ts
+++ b/src/features/reviewers/view-model.ts
@@ -1,148 +1,104 @@
-import type { CompletedReview, PullReviewerSummary, ReviewState } from "../../github/api";
+import type {
+  CompletedReview,
+  PullReviewerSummary,
+  ReviewState,
+  ReviewerUser,
+} from "../../github/api";
 import type { PullListRoute } from "../../github/routes";
 
-export type ReviewerChipTone =
-  | "requested"
-  | "team"
-  | "approved"
-  | "changes-requested"
-  | "commented"
-  | "dismissed";
+export type ReviewerEntry =
+  | {
+      kind: "user";
+      login: string;
+      avatarUrl: string | null;
+      state: ReviewState | null;
+      isRequested: boolean;
+      href: string;
+    }
+  | {
+      kind: "team";
+      slug: string;
+      href: string;
+    };
 
-export type ReviewerChip = {
-  label: string;
-  href: string;
-  tone: ReviewerChipTone;
-  title?: string;
-};
-
-export type ReviewerSection = {
-  label: string;
-  emptyLabel: string;
-  chips: ReviewerChip[];
-};
-
-export function buildReviewerSections(
+export function buildReviewers(
   route: PullListRoute,
   summary: PullReviewerSummary,
-): ReviewerSection[] {
-  const requestedUserChips = summary.requestedUsers.map((reviewer) =>
-    buildChip(route, reviewer, "requested"),
-  );
-  const requestedTeamChips = summary.requestedTeams.map((team) =>
-    buildChip(route, `@${team}`, "team"),
-  );
-  const reviewedChips = [...summary.completedReviews]
-    .sort((left, right) => compareReviewState(left, right))
-    .map((review) => buildReviewedChip(route, review));
+): ReviewerEntry[] {
+  const reviewedByLogin = new Map<string, CompletedReview>();
+  for (const review of summary.completedReviews) {
+    reviewedByLogin.set(review.login, review);
+  }
 
-  const sections: ReviewerSection[] = [];
+  const requestedByLogin = new Map<string, ReviewerUser>();
+  for (const user of summary.requestedUsers) {
+    requestedByLogin.set(user.login, user);
+  }
 
-  if (requestedUserChips.length > 0 || requestedTeamChips.length > 0) {
-    sections.push({
-      label: "Requested",
-      emptyLabel: "No requested reviewers",
-      chips: [...requestedUserChips, ...requestedTeamChips],
+  const allLogins = new Set<string>([
+    ...reviewedByLogin.keys(),
+    ...requestedByLogin.keys(),
+  ]);
+
+  const userEntries: Extract<ReviewerEntry, { kind: "user" }>[] = [];
+  for (const login of allLogins) {
+    const reviewed = reviewedByLogin.get(login);
+    const requested = requestedByLogin.get(login);
+    const isRequested = requested != null;
+    const state = reviewed?.state ?? null;
+    const avatarUrl = reviewed?.avatarUrl ?? requested?.avatarUrl ?? null;
+    userEntries.push({
+      kind: "user",
+      login,
+      avatarUrl,
+      state,
+      isRequested,
+      href: buildUserHref(route, login, isRequested),
     });
   }
 
-  if (reviewedChips.length > 0) {
-    sections.push({
-      label: "Reviewed",
-      emptyLabel: "No completed reviews",
-      chips: reviewedChips,
-    });
+  userEntries.sort((left, right) => {
+    const rankDelta = rankUser(left) - rankUser(right);
+    if (rankDelta !== 0) return rankDelta;
+    return left.login.localeCompare(right.login);
+  });
+
+  const teamEntries: Extract<ReviewerEntry, { kind: "team" }>[] = [
+    ...summary.requestedTeams,
+  ]
+    .sort((left, right) => left.localeCompare(right))
+    .map((slug) => ({
+      kind: "team" as const,
+      slug,
+      href: buildTeamHref(route, slug),
+    }));
+
+  return [...userEntries, ...teamEntries];
+}
+
+function rankUser(entry: Extract<ReviewerEntry, { kind: "user" }>): number {
+  if (!entry.isRequested) {
+    return entry.state === "CHANGES_REQUESTED" ? 0 : 1;
   }
-
-  return sections;
+  if (entry.state === "COMMENTED") return 2;
+  if (entry.state === "DISMISSED") return 3;
+  if (entry.state != null) return 3.5;
+  return 4;
 }
 
-function buildChip(
+function buildUserHref(
   route: PullListRoute,
-  rawReviewer: string,
-  tone: ReviewerChipTone,
-): ReviewerChip {
-  const isTeam = rawReviewer.startsWith("@");
-  const label = rawReviewer;
-
-  return {
-    label,
-    tone,
-    href: buildPullSearchUrl(route, rawReviewer, tone, isTeam),
-  };
-}
-
-function buildReviewedChip(route: PullListRoute, review: CompletedReview): ReviewerChip {
-  const tone = mapReviewStateToTone(review.state);
-  const suffix = formatReviewState(review.state);
-
-  return {
-    label: `${review.login} · ${suffix}`,
-    title: `${review.login}: ${suffix}`,
-    tone,
-    href: buildPullSearchUrl(route, review.login, tone, false),
-  };
-}
-
-function buildPullSearchUrl(
-  route: PullListRoute,
-  reviewer: string,
-  tone: ReviewerChipTone,
-  isTeam: boolean,
+  login: string,
+  isRequested: boolean,
 ): string {
-  const normalizedReviewer = isTeam ? reviewer.slice(1) : reviewer;
-  let query = "is:pr";
-
-  if (
-    tone === "approved" ||
-    tone === "changes-requested" ||
-    tone === "commented" ||
-    tone === "dismissed"
-  ) {
-    query += ` reviewed-by:${normalizedReviewer}`;
-  } else if (isTeam) {
-    query += ` team-review-requested:${route.owner}/${normalizedReviewer}`;
-  } else {
-    query += ` review-requested:${normalizedReviewer}`;
-  }
-
+  const qualifier = isRequested
+    ? `review-requested:${login}`
+    : `reviewed-by:${login}`;
+  const query = `is:pr ${qualifier}`;
   return `https://github.com/${route.owner}/${route.repo}/pulls?q=${encodeURIComponent(query)}`;
 }
 
-function mapReviewStateToTone(state: ReviewState): ReviewerChipTone {
-  if (state === "APPROVED") {
-    return "approved";
-  }
-
-  if (state === "CHANGES_REQUESTED") {
-    return "changes-requested";
-  }
-
-  if (state === "DISMISSED") {
-    return "dismissed";
-  }
-
-  return "commented";
-}
-
-function formatReviewState(state: ReviewState): string {
-  if (state === "CHANGES_REQUESTED") {
-    return "changes requested";
-  }
-
-  return state.toLowerCase();
-}
-
-function compareReviewState(left: CompletedReview, right: CompletedReview): number {
-  const priority = {
-    CHANGES_REQUESTED: 0,
-    APPROVED: 1,
-    COMMENTED: 2,
-    DISMISSED: 3,
-  } as const;
-
-  return (
-    priority[left.state] - priority[right.state] ||
-    left.login.localeCompare(right.login)
-  );
+function buildTeamHref(route: PullListRoute, slug: string): string {
+  const query = `is:pr team-review-requested:${route.owner}/${slug}`;
+  return `https://github.com/${route.owner}/${route.repo}/pulls?q=${encodeURIComponent(query)}`;
 }

--- a/src/features/reviewers/view-model.ts
+++ b/src/features/reviewers/view-model.ts
@@ -53,7 +53,7 @@ export function buildReviewers(
       avatarUrl,
       state,
       isRequested,
-      href: buildUserHref(route, login, isRequested),
+      href: buildUserHref(route, login, state),
     });
   }
 
@@ -89,11 +89,11 @@ function rankUser(entry: Extract<ReviewerEntry, { kind: "user" }>): number {
 function buildUserHref(
   route: PullListRoute,
   login: string,
-  isRequested: boolean,
+  state: ReviewState | null,
 ): string {
-  const qualifier = isRequested
-    ? `review-requested:${login}`
-    : `reviewed-by:${login}`;
+  const qualifier = state != null
+    ? `reviewed-by:${login}`
+    : `review-requested:${login}`;
   const query = `is:pr ${qualifier}`;
   return `https://github.com/${route.owner}/${route.repo}/pulls?q=${encodeURIComponent(query)}`;
 }

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -7,6 +7,7 @@ type GitHubAuthContext = {
 const avatarUrlField = z
   .string()
   .url()
+  .refine((value) => /^https?:\/\//i.test(value), "Avatar URL must be http(s)")
   .nullable()
   .optional()
   .catch(null);

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -4,17 +4,23 @@ type GitHubAuthContext = {
   githubToken: string | null;
 };
 
+const avatarUrlField = z
+  .string()
+  .url()
+  .nullable()
+  .optional()
+  .catch(null);
+
+const userLiteSchema = z.object({
+  login: z.string(),
+  avatar_url: avatarUrlField,
+});
+
 const pullSchema = z.object({
   user: z.object({
     login: z.string(),
   }),
-  requested_reviewers: z
-    .array(
-      z.object({
-        login: z.string(),
-      }),
-    )
-    .default([]),
+  requested_reviewers: z.array(userLiteSchema).default([]),
   requested_teams: z
     .array(
       z.object({
@@ -34,11 +40,7 @@ const reviewsSchema = z.array(
   z.object({
     state: z.string(),
     submitted_at: z.string().nullable().optional(),
-    user: z
-      .object({
-        login: z.string(),
-      })
-      .nullable(),
+    user: userLiteSchema.nullable(),
   }),
 );
 
@@ -61,14 +63,13 @@ export type ReviewState =
   | "COMMENTED"
   | "DISMISSED";
 
-export type CompletedReview = {
-  login: string;
-  state: ReviewState;
-};
+export type ReviewerUser = { login: string; avatarUrl: string | null };
+
+export type CompletedReview = ReviewerUser & { state: ReviewState };
 
 export type PullReviewerSummary = {
   status: PullReviewerSummaryStatus;
-  requestedUsers: string[];
+  requestedUsers: ReviewerUser[];
   requestedTeams: string[];
   completedReviews: CompletedReview[];
 };
@@ -176,6 +177,10 @@ export function describeGitHubApiError(
   return "Unknown GitHub API error.";
 }
 
+function normalizeAvatarUrl(raw: string | null | undefined): string | null {
+  return raw ?? null;
+}
+
 export async function fetchPullReviewerSummary(input: {
   owner: string;
   repo: string;
@@ -217,7 +222,12 @@ export async function fetchPullReviewerSummary(input: {
   const reviews = reviewsSchema.parse(await reviewsResponse.json());
   const latestReviewByUser = new Map<
     string,
-    { state: ReviewState; submittedAt: string | null; index: number }
+    {
+      state: ReviewState;
+      avatarUrl: string | null;
+      submittedAt: string | null;
+      index: number;
+    }
   >();
 
   reviews.forEach((review, index) => {
@@ -239,22 +249,29 @@ export async function fetchPullReviewerSummary(input: {
     ) {
       latestReviewByUser.set(reviewer, {
         state: normalizedState,
+        avatarUrl: normalizeAvatarUrl(review.user?.avatar_url),
         submittedAt: review.submitted_at ?? null,
         index,
       });
     }
   });
 
-  const completedReviews = Array.from(latestReviewByUser.entries())
+  const completedReviews: CompletedReview[] = Array.from(
+    latestReviewByUser.entries(),
+  )
     .map(([login, review]) => ({
       login,
+      avatarUrl: review.avatarUrl,
       state: review.state,
     }))
     .sort((left, right) => left.login.localeCompare(right.login));
 
   return {
     status: "ok" as const,
-    requestedUsers: pull.requested_reviewers.map((reviewer) => reviewer.login),
+    requestedUsers: pull.requested_reviewers.map((reviewer) => ({
+      login: reviewer.login,
+      avatarUrl: normalizeAvatarUrl(reviewer.avatar_url),
+    })),
     requestedTeams: pull.requested_teams.map((team) => team.slug),
     completedReviews,
   };

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+const PREFERENCES_KEY = "preferences";
+const SETTINGS_KEY = "settings";
+
+const preferencesSchema = z.object({
+  version: z.literal(1),
+  showStateBadge: z.boolean(),
+  showReviewerName: z.boolean(),
+});
+
+export type Preferences = z.infer<typeof preferencesSchema>;
+
+export const DEFAULT_PREFERENCES: Preferences = {
+  version: 1,
+  showStateBadge: true,
+  showReviewerName: false,
+};
+
+export async function getPreferences(): Promise<Preferences> {
+  const result = await browser.storage.local.get(PREFERENCES_KEY);
+  const parsed = preferencesSchema.safeParse(result[PREFERENCES_KEY]);
+  return parsed.success ? parsed.data : DEFAULT_PREFERENCES;
+}
+
+export async function updatePreferences(
+  patch: Partial<Omit<Preferences, "version">>,
+): Promise<Preferences> {
+  const current = await getPreferences();
+  const next: Preferences = { ...current, ...patch, version: 1 };
+  await browser.storage.local.set({ [PREFERENCES_KEY]: next });
+  return next;
+}
+
+type StorageChange = { oldValue?: unknown; newValue?: unknown };
+
+export function isPreferencesChange(
+  changes: Record<string, StorageChange>,
+): boolean {
+  return PREFERENCES_KEY in changes;
+}
+
+export function isAccountsChange(
+  changes: Record<string, StorageChange>,
+): boolean {
+  return SETTINGS_KEY in changes;
+}

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -315,6 +315,51 @@ describe("fetchPullReviewerSummary", () => {
       expect(message).not.toContain("SSO");
     }
   });
+
+  it("rejects non-http(s) avatar_url schemes (javascript:, data:, file:) as null", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            user: { login: "hon454" },
+            requested_reviewers: [
+              { login: "alice", avatar_url: "javascript:alert(1)" },
+              { login: "bella", avatar_url: "data:text/html,<script>alert(1)</script>" },
+              { login: "carol", avatar_url: "file:///etc/passwd" },
+              {
+                login: "dora",
+                avatar_url: "https://avatars.githubusercontent.com/u/1?v=4",
+              },
+            ],
+            requested_teams: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+    });
+
+    expect(summary.requestedUsers).toEqual([
+      { login: "alice", avatarUrl: null },
+      { login: "bella", avatarUrl: null },
+      { login: "carol", avatarUrl: null },
+      {
+        login: "dora",
+        avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+      },
+    ]);
+  });
 });
 
 describe("validateGitHubRepositoryAccess", () => {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -134,9 +134,9 @@ describe("fetchPullReviewerSummary", () => {
 
     expect(summary).toEqual({
       status: "ok",
-      requestedUsers: ["alice"],
+      requestedUsers: [{ login: "alice", avatarUrl: null }],
       requestedTeams: ["platform"],
-      completedReviews: [{ login: "bob", state: "APPROVED" }],
+      completedReviews: [{ login: "bob", avatarUrl: null, state: "APPROVED" }],
     });
 
     const firstHeaders = fetchMock.mock.calls[0]?.[1]?.headers;
@@ -171,6 +171,102 @@ describe("fetchPullReviewerSummary", () => {
     });
 
     expect(summary.status).toBe("ok");
+  });
+
+  it("returns avatarUrl for requested reviewers and completed reviews", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            user: { login: "hon454" },
+            requested_reviewers: [
+              { login: "alice", avatar_url: "https://avatars.githubusercontent.com/u/1?v=4" },
+            ],
+            requested_teams: [{ slug: "platform" }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "APPROVED",
+              submitted_at: "2026-04-20T12:00:00Z",
+              user: {
+                login: "bob",
+                avatar_url: "https://avatars.githubusercontent.com/u/2?v=4",
+              },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+    });
+
+    expect(summary.requestedUsers).toEqual([
+      { login: "alice", avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4" },
+    ]);
+    expect(summary.completedReviews).toEqual([
+      {
+        login: "bob",
+        avatarUrl: "https://avatars.githubusercontent.com/u/2?v=4",
+        state: "APPROVED",
+      },
+    ]);
+  });
+
+  it("coerces missing, null, empty, and invalid avatar_url values to null without failing the payload", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            user: { login: "hon454" },
+            requested_reviewers: [
+              { login: "alice" }, // missing
+              { login: "bella", avatar_url: null },
+              { login: "carol", avatar_url: "" },
+              { login: "dora", avatar_url: "garbage" },
+              {
+                login: "eve",
+                avatar_url: "https://avatars.githubusercontent.com/u/9?v=4",
+              },
+            ],
+            requested_teams: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+    });
+
+    expect(summary.requestedUsers).toEqual([
+      { login: "alice", avatarUrl: null },
+      { login: "bella", avatarUrl: null },
+      { login: "carol", avatarUrl: null },
+      { login: "dora", avatarUrl: null },
+      {
+        login: "eve",
+        avatarUrl: "https://avatars.githubusercontent.com/u/9?v=4",
+      },
+    ]);
   });
 
   it("reports the exact reviews endpoint when review history access is denied", async () => {

--- a/tests/e2e/capture-cws-assets.spec.ts
+++ b/tests/e2e/capture-cws-assets.spec.ts
@@ -32,7 +32,8 @@ test("capture Chrome Web Store assets", async () => {
           user: { login: "bob" },
         },
       ],
-      expectedTexts: ["alice", "@platform", "bob"],
+      expectedLogins: ["alice", "bob"],
+      expectedTeamText: "Team: platform",
     });
 
     await capturePullListScreenshot(context, {
@@ -51,7 +52,8 @@ test("capture Chrome Web Store assets", async () => {
           user: { login: "kian" },
         },
       ],
-      expectedTexts: ["jules", "@security", "kian"],
+      expectedLogins: ["jules", "kian"],
+      expectedTeamText: "Team: security",
     });
 
     await captureOptionsScreenshot(context, extensionId);
@@ -92,7 +94,8 @@ async function capturePullListScreenshot(
     pullNumber: string;
     summary: object;
     reviews: object[];
-    expectedTexts: string[];
+    expectedLogins: string[];
+    expectedTeamText: string;
   },
 ): Promise<void> {
   const fixturePath = path.join(projectRoot, "tests/fixtures", scene.fixture);
@@ -132,10 +135,10 @@ async function capturePullListScreenshot(
   await page.goto("https://github.com/hon454/github-pulls-show-reviewers/pulls");
 
   const root = page.locator(".ghpsr-root");
-  await expect(root).toContainText("Requested:");
-  await expect(root).toContainText("Reviewed:");
-  for (const text of scene.expectedTexts) {
-    await expect(root).toContainText(text);
+  await expect(root).toContainText("Reviewers:");
+  await expect(root).toContainText(scene.expectedTeamText);
+  for (const login of scene.expectedLogins) {
+    await expect(root.locator(`a.ghpsr-avatar[title*="@${login}"]`)).toHaveCount(1);
   }
 
   await page.addStyleTag({

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -62,11 +62,12 @@ for (const fixtureCase of renderCases) {
       await page.goto("https://github.com/hon454/github-pulls-show-reviewers/pulls");
 
       const root = page.locator(".ghpsr-root");
-      await expect(root).toContainText("Requested:");
-      await expect(root).toContainText("alice");
-      await expect(root).toContainText("@platform");
-      await expect(root).toContainText("Reviewed:");
-      await expect(root).toContainText("bob · approved");
+      await expect(root).toContainText("Reviewers:");
+      await expect(root).toContainText("Team: platform");
+      await expect(root.locator('a.ghpsr-avatar[title*="@alice"]')).toHaveCount(1);
+      await expect(
+        root.locator('a.ghpsr-avatar[title*="@bob"][title*="approved"]'),
+      ).toHaveCount(1);
     });
   });
 }
@@ -120,7 +121,7 @@ test("clears the reviewer slot silently when review history is denied", async ()
     const page = await context.newPage();
     await page.goto("https://github.com/hon454/github-pulls-show-reviewers/pulls");
 
-    // Row-level error rendering is removed in v1.2.0; failures silently clear the reviewer slot.
+    // Row-level error rendering is removed; failures silently clear the reviewer slot.
     await expect(page.locator(".ghpsr-status--error")).toHaveCount(0);
     // The root mount is either absent or empty after a fetch failure.
     const root = page.locator(".ghpsr-root");

--- a/tests/options-page.test.ts
+++ b/tests/options-page.test.ts
@@ -11,6 +11,18 @@ type AccountsModuleType = typeof AccountsModule;
 
 const listAccountsMock = vi.fn<() => Promise<Account[]>>(async () => []);
 
+const getPreferencesMock = vi.fn(async () => ({
+  version: 1 as const,
+  showStateBadge: true,
+  showReviewerName: false,
+}));
+const updatePreferencesMock = vi.fn(async (patch: Record<string, unknown>) => ({
+  version: 1 as const,
+  showStateBadge: true,
+  showReviewerName: false,
+  ...patch,
+}));
+
 vi.mock("../src/storage/accounts", async (importActual) => {
   const actual = await importActual<AccountsModuleType>();
   return {
@@ -22,6 +34,18 @@ vi.mock("../src/storage/accounts", async (importActual) => {
     resolveAccountForRepo: vi.fn(async () => null),
   };
 });
+
+vi.mock("../src/storage/preferences", () => ({
+  getPreferences: getPreferencesMock,
+  updatePreferences: updatePreferencesMock,
+  DEFAULT_PREFERENCES: {
+    version: 1,
+    showStateBadge: true,
+    showReviewerName: false,
+  },
+  isPreferencesChange: () => false,
+  isAccountsChange: () => false,
+}));
 
 vi.mock("../src/github/auth", () => ({
   initiateDeviceFlow: vi.fn(),
@@ -72,6 +96,13 @@ beforeEach(() => {
   vi.clearAllMocks();
   listAccountsMock.mockReset();
   listAccountsMock.mockResolvedValue([]);
+  getPreferencesMock.mockClear();
+  updatePreferencesMock.mockClear();
+  getPreferencesMock.mockResolvedValue({
+    version: 1,
+    showStateBadge: true,
+    showReviewerName: false,
+  });
 });
 
 afterEach(() => {
@@ -303,5 +334,44 @@ describe("OptionsPage", () => {
     });
 
     expect(initiateDeviceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the display settings panel with both checkboxes", async () => {
+    await renderOptionsPage();
+    expect(
+      document.querySelector('[data-testid="prefs-show-state-badge"]'),
+    ).not.toBeNull();
+    expect(
+      document.querySelector('[data-testid="prefs-show-reviewer-name"]'),
+    ).not.toBeNull();
+  });
+
+  it("reflects stored preferences in checkbox state on mount", async () => {
+    getPreferencesMock.mockResolvedValueOnce({
+      version: 1,
+      showStateBadge: false,
+      showReviewerName: true,
+    });
+    await renderOptionsPage();
+    const badgeCheckbox = document.querySelector<HTMLInputElement>(
+      '[data-testid="prefs-show-state-badge"]',
+    )!;
+    const nameCheckbox = document.querySelector<HTMLInputElement>(
+      '[data-testid="prefs-show-reviewer-name"]',
+    )!;
+    expect(badgeCheckbox.checked).toBe(false);
+    expect(nameCheckbox.checked).toBe(true);
+  });
+
+  it("calls updatePreferences when a checkbox is toggled", async () => {
+    await renderOptionsPage();
+    const badgeCheckbox = document.querySelector<HTMLInputElement>(
+      '[data-testid="prefs-show-state-badge"]',
+    )!;
+    await act(async () => {
+      badgeCheckbox.click();
+      await Promise.resolve();
+    });
+    expect(updatePreferencesMock).toHaveBeenCalledWith({ showStateBadge: false });
   });
 });

--- a/tests/preferences.test.ts
+++ b/tests/preferences.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type StorageShape = Record<string, unknown>;
+
+function createBrowserMock() {
+  let storage: StorageShape = {};
+  const get = vi.fn(async (key?: string | string[] | Record<string, unknown>) => {
+    if (typeof key === "string") {
+      return key in storage ? { [key]: storage[key] } : {};
+    }
+    return { ...storage };
+  });
+  const set = vi.fn(async (items: StorageShape) => {
+    storage = { ...storage, ...items };
+  });
+  return {
+    browser: { storage: { local: { get, set } } },
+    reset() {
+      storage = {};
+      get.mockClear();
+      set.mockClear();
+    },
+  };
+}
+
+let browserMock: ReturnType<typeof createBrowserMock>;
+
+beforeEach(() => {
+  browserMock = createBrowserMock();
+  vi.stubGlobal("browser", browserMock.browser);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("preferences storage", () => {
+  it("returns defaults when nothing is persisted", async () => {
+    const { getPreferences } = await import("../src/storage/preferences");
+    await expect(getPreferences()).resolves.toEqual({
+      version: 1,
+      showStateBadge: true,
+      showReviewerName: false,
+    });
+  });
+
+  it("returns defaults when persisted payload fails schema", async () => {
+    browserMock.browser.storage.local.get.mockResolvedValueOnce({
+      preferences: { showStateBadge: "yes" },
+    });
+    const { getPreferences } = await import("../src/storage/preferences");
+    await expect(getPreferences()).resolves.toEqual({
+      version: 1,
+      showStateBadge: true,
+      showReviewerName: false,
+    });
+  });
+
+  it("updatePreferences merges partial patches and preserves version", async () => {
+    const { updatePreferences, getPreferences } = await import(
+      "../src/storage/preferences"
+    );
+    const next = await updatePreferences({ showStateBadge: false });
+    expect(next).toEqual({
+      version: 1,
+      showStateBadge: false,
+      showReviewerName: false,
+    });
+    await expect(getPreferences()).resolves.toEqual(next);
+  });
+
+  it("updatePreferences preserves unrelated fields when toggling one", async () => {
+    const { updatePreferences } = await import("../src/storage/preferences");
+    await updatePreferences({ showStateBadge: false });
+    const afterNameToggle = await updatePreferences({ showReviewerName: true });
+    expect(afterNameToggle).toEqual({
+      version: 1,
+      showStateBadge: false,
+      showReviewerName: true,
+    });
+  });
+});
+
+describe("storage change classification", () => {
+  it("isPreferencesChange returns true when the preferences key is in the change map", async () => {
+    const { isPreferencesChange, isAccountsChange } = await import(
+      "../src/storage/preferences"
+    );
+    expect(
+      isPreferencesChange({
+        preferences: { oldValue: undefined, newValue: { version: 1 } },
+      }),
+    ).toBe(true);
+    expect(isPreferencesChange({ settings: { oldValue: undefined, newValue: {} } })).toBe(
+      false,
+    );
+    expect(isAccountsChange({ settings: { oldValue: undefined, newValue: {} } })).toBe(
+      true,
+    );
+    expect(isAccountsChange({ preferences: { oldValue: undefined, newValue: {} } })).toBe(
+      false,
+    );
+  });
+});

--- a/tests/reviewer-dom.test.ts
+++ b/tests/reviewer-dom.test.ts
@@ -9,96 +9,251 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   ensureReviewerMount,
   extractPullNumber,
-  renderReviewerSections,
+  renderReviewers,
 } from "../src/features/reviewers/dom";
-import { buildReviewerSections } from "../src/features/reviewers/view-model";
+import { buildReviewers } from "../src/features/reviewers/view-model";
 
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const fixturesDir = path.join(currentDir, "fixtures");
 
 async function loadFixture(name: string): Promise<void> {
-  document.body.innerHTML = await readFile(path.join(fixturesDir, name), "utf8");
+  document.body.innerHTML = await readFile(
+    path.join(fixturesDir, name),
+    "utf8",
+  );
 }
 
-describe("reviewer dom rendering", () => {
-  beforeEach(() => {
-    document.body.innerHTML = `
-      <div class="js-issue-row" id="issue_42">
-        <div class="d-flex mt-1 text-small color-fg-muted">
-          <span class="d-none d-md-inline-flex">
-            <span class="issue-meta-section ml-2">Existing metadata</span>
-          </span>
-        </div>
+beforeEach(() => {
+  document.body.innerHTML = `
+    <div class="js-issue-row" id="issue_42">
+      <div class="d-flex mt-1 text-small color-fg-muted">
+        <span class="d-none d-md-inline-flex">
+          <span class="issue-meta-section ml-2">Existing metadata</span>
+        </span>
       </div>
-    `;
+    </div>
+  `;
+});
+
+describe("renderReviewers", () => {
+  const route = { owner: "hon454", repo: "github-pulls-show-reviewers" };
+
+  function mount(): HTMLElement {
+    const row = document.querySelector(".js-issue-row")!;
+    return ensureReviewerMount(row)!;
+  }
+
+  it("renders a single 'Reviewers:' label followed by entries", () => {
+    const entries = buildReviewers(route, {
+      status: "ok",
+      requestedUsers: [{ login: "alice", avatarUrl: null }],
+      requestedTeams: ["platform"],
+      completedReviews: [
+        { login: "bob", avatarUrl: null, state: "APPROVED" },
+      ],
+    });
+
+    renderReviewers(mount(), entries, {
+      showStateBadge: true,
+      showReviewerName: false,
+    });
+
+    const labels = document.querySelectorAll(".ghpsr-section-label");
+    expect(labels).toHaveLength(1);
+    expect(labels[0].textContent).toBe("Reviewers:");
   });
 
-  it("renders requested and reviewed chips into the metadata row", () => {
-    const row = document.querySelector(".js-issue-row");
-    expect(row).not.toBeNull();
+  it("renders the avatar-only shape when showReviewerName is false", () => {
+    const entries = buildReviewers(route, {
+      status: "ok",
+      requestedUsers: [{ login: "alice", avatarUrl: "https://example/a.png" }],
+      requestedTeams: [],
+      completedReviews: [],
+    });
 
-    const mount = ensureReviewerMount(row!);
-    expect(mount).not.toBeNull();
+    renderReviewers(mount(), entries, {
+      showStateBadge: true,
+      showReviewerName: false,
+    });
 
-    const sections = buildReviewerSections(
-      { owner: "hon454", repo: "github-pulls-show-reviewers" },
-      {
-        status: "ok",
-        requestedUsers: ["alice"],
-        requestedTeams: ["platform"],
-        completedReviews: [{ login: "bob", state: "APPROVED" }],
-      },
+    const avatar = document.querySelector<HTMLAnchorElement>("a.ghpsr-avatar");
+    expect(avatar).not.toBeNull();
+    expect(avatar?.classList.contains("ghpsr-avatar--border-requested")).toBe(
+      true,
     );
-
-    renderReviewerSections(mount!, sections);
-
-    expect(mount?.textContent).toContain("Requested:");
-    expect(mount?.textContent).toContain("alice");
-    expect(mount?.textContent).toContain("@platform");
-    expect(mount?.textContent).toContain("bob");
-    expect(mount?.textContent).toContain("approved");
+    expect(avatar?.querySelector("img.ghpsr-avatar-img")?.getAttribute("src")).toBe(
+      "https://example/a.png",
+    );
+    expect(avatar?.querySelector("img.ghpsr-avatar-img")?.getAttribute("loading")).toBe(
+      "lazy",
+    );
+    expect(avatar?.querySelector("img.ghpsr-avatar-img")?.getAttribute("width")).toBe(
+      "24",
+    );
+    expect(document.querySelector(".ghpsr-pill")).toBeNull();
   });
 
-  it("clears the inline reviewer mount when there are no sections to render", () => {
-    const row = document.querySelector(".js-issue-row");
-    expect(row).not.toBeNull();
+  it("renders the pill shape with @login text when showReviewerName is true", () => {
+    const entries = buildReviewers(route, {
+      status: "ok",
+      requestedUsers: [{ login: "alice", avatarUrl: "https://example/a.png" }],
+      requestedTeams: [],
+      completedReviews: [],
+    });
 
-    const mount = ensureReviewerMount(row!);
-    expect(mount).not.toBeNull();
+    renderReviewers(mount(), entries, {
+      showStateBadge: true,
+      showReviewerName: true,
+    });
 
-    renderReviewerSections(mount!, []);
+    const pill = document.querySelector<HTMLAnchorElement>("a.ghpsr-pill");
+    expect(pill).not.toBeNull();
+    expect(pill?.classList.contains("ghpsr-pill--requested")).toBe(true);
+    expect(pill?.querySelector(".ghpsr-pill-name")?.textContent).toBe("@alice");
+  });
 
-    expect(mount?.textContent).toBe("");
-    expect(mount?.childElementCount).toBe(0);
+  it("omits the badge when showStateBadge is false even if state is set", () => {
+    const entries = buildReviewers(route, {
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: [],
+      completedReviews: [
+        { login: "bob", avatarUrl: null, state: "APPROVED" },
+      ],
+    });
+
+    renderReviewers(mount(), entries, {
+      showStateBadge: false,
+      showReviewerName: false,
+    });
+
+    expect(document.querySelector(".ghpsr-badge")).toBeNull();
+  });
+
+  it("omits the badge when state is null even if showStateBadge is true", () => {
+    const entries = buildReviewers(route, {
+      status: "ok",
+      requestedUsers: [{ login: "alice", avatarUrl: null }],
+      requestedTeams: [],
+      completedReviews: [],
+    });
+
+    renderReviewers(mount(), entries, {
+      showStateBadge: true,
+      showReviewerName: false,
+    });
+
+    expect(document.querySelector(".ghpsr-badge")).toBeNull();
+  });
+
+  it("renders state-specific badge classes when enabled and state is non-null", () => {
+    const entries = buildReviewers(route, {
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: [],
+      completedReviews: [
+        { login: "bob", avatarUrl: null, state: "CHANGES_REQUESTED" },
+      ],
+    });
+
+    renderReviewers(mount(), entries, {
+      showStateBadge: true,
+      showReviewerName: false,
+    });
+
+    expect(
+      document.querySelector(".ghpsr-badge--changes-requested"),
+    ).not.toBeNull();
+  });
+
+  it("appends '(still requested)' to the title when the reviewer is still in requested_reviewers", () => {
+    const entries = buildReviewers(route, {
+      status: "ok",
+      requestedUsers: [{ login: "alice", avatarUrl: null }],
+      requestedTeams: [],
+      completedReviews: [
+        { login: "alice", avatarUrl: null, state: "COMMENTED" },
+      ],
+    });
+
+    renderReviewers(mount(), entries, {
+      showStateBadge: true,
+      showReviewerName: false,
+    });
+
+    const avatar = document.querySelector<HTMLAnchorElement>("a.ghpsr-avatar");
+    expect(avatar?.title).toBe("@alice · commented (still requested)");
+  });
+
+  it("renders teams as the existing text chip shape", () => {
+    const entries = buildReviewers(route, {
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: ["platform"],
+      completedReviews: [],
+    });
+
+    renderReviewers(mount(), entries, {
+      showStateBadge: true,
+      showReviewerName: false,
+    });
+
+    const chip = document.querySelector<HTMLAnchorElement>(
+      ".ghpsr-chip.ghpsr-chip--team",
+    );
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toBe("Team: platform");
+  });
+
+  it("swaps the img for an initials span when the avatar image fails to load", () => {
+    const entries = buildReviewers(route, {
+      status: "ok",
+      requestedUsers: [{ login: "alice", avatarUrl: null }],
+      requestedTeams: [],
+      completedReviews: [],
+    });
+
+    renderReviewers(mount(), entries, {
+      showStateBadge: true,
+      showReviewerName: false,
+    });
+
+    const img = document.querySelector<HTMLImageElement>(".ghpsr-avatar-img")!;
+    img.dispatchEvent(new Event("error"));
+
+    expect(document.querySelector(".ghpsr-avatar-img")).toBeNull();
+    const initials = document.querySelector(".ghpsr-initials")!;
+    expect(initials.textContent).toBe("A");
+  });
+
+  it("clears the mount when entries is empty", () => {
+    renderReviewers(mount(), [], {
+      showStateBadge: true,
+      showReviewerName: false,
+    });
+
+    const mountEl = document.querySelector('[data-ghpsr-root="true"]')!;
+    expect(mountEl.textContent).toBe("");
+    expect(mountEl.childElementCount).toBe(0);
   });
 
   it("extracts the pull number from the primary link when the row id is missing", async () => {
     await loadFixture("github-pulls-link-only.html");
-
     const row = document.querySelector(".js-issue-row");
-    expect(row).not.toBeNull();
     expect(extractPullNumber(row!)).toBe("77");
   });
 
   it("finds CSS-module metadata rows by stable class prefix", async () => {
     await loadFixture("github-pulls-list-item-metadata.html");
-
     const row = document.querySelector(".js-issue-row");
-    expect(row).not.toBeNull();
-
-    const mount = ensureReviewerMount(row!);
-    expect(mount).not.toBeNull();
-    expect(row?.querySelector('[data-ghpsr-root="true"]')).toBe(mount);
+    const mountNode = ensureReviewerMount(row!);
+    expect(mountNode).not.toBeNull();
   });
 
   it("creates an inline metadata row when GitHub omits the desktop wrapper span", async () => {
     await loadFixture("github-pulls-missing-inline-meta.html");
-
     const row = document.querySelector(".js-issue-row");
-    expect(row).not.toBeNull();
-
-    const mount = ensureReviewerMount(row!);
-    expect(mount).not.toBeNull();
+    expect(ensureReviewerMount(row!)).not.toBeNull();
     expect(row?.querySelector(".d-none.d-md-inline-flex")).not.toBeNull();
   });
 });

--- a/tests/reviewer-view-model.test.ts
+++ b/tests/reviewer-view-model.test.ts
@@ -1,50 +1,211 @@
 import { describe, expect, it } from "vitest";
 
-import { buildReviewerSections } from "../src/features/reviewers/view-model";
+import { buildReviewers } from "../src/features/reviewers/view-model";
+import type { PullReviewerSummary } from "../src/github/api";
 
-describe("buildReviewerSections", () => {
-  const route = {
-    owner: "hon454",
-    repo: "github-pulls-show-reviewers",
+const route = { owner: "hon454", repo: "github-pulls-show-reviewers" };
+
+function summary(partial: Partial<PullReviewerSummary>): PullReviewerSummary {
+  return {
+    status: "ok",
+    requestedUsers: [],
+    requestedTeams: [],
+    completedReviews: [],
+    ...partial,
   };
+}
 
-  it("builds requested and reviewed sections with repo-scoped links", () => {
-    const sections = buildReviewerSections(route, {
-      status: "ok",
-      requestedUsers: ["alice"],
-      requestedTeams: ["platform"],
-      completedReviews: [{ login: "bob", state: "APPROVED" }],
-    });
+describe("buildReviewers", () => {
+  it("returns an empty list when there are no reviewers or teams", () => {
+    expect(buildReviewers(route, summary({}))).toEqual([]);
+  });
 
-    expect(sections[0]?.chips.map((chip) => chip.label)).toEqual(["alice", "@platform"]);
-    expect(sections[0]?.chips[0]?.href).toContain("review-requested%3Aalice");
-    expect(sections[0]?.chips[1]?.href).toContain(
-      "team-review-requested%3Ahon454%2Fplatform",
+  it("emits a single entry per login with state and isRequested combined", () => {
+    const entries = buildReviewers(
+      route,
+      summary({
+        requestedUsers: [
+          { login: "alice", avatarUrl: null },
+          { login: "bob", avatarUrl: null },
+        ],
+        completedReviews: [
+          { login: "bob", avatarUrl: "https://example/b.png", state: "COMMENTED" },
+        ],
+      }),
     );
-    expect(sections[1]?.chips[0]?.label).toContain("approved");
-    expect(sections[1]?.chips[0]?.href).toContain("reviewed-by%3Abob");
+
+    const logins = entries
+      .filter((entry) => entry.kind === "user")
+      .map((entry) => (entry.kind === "user" ? entry.login : ""));
+    expect(logins).toEqual(["bob", "alice"]);
+
+    const bob = entries.find(
+      (entry) => entry.kind === "user" && entry.login === "bob",
+    );
+    expect(bob).toMatchObject({
+      kind: "user",
+      login: "bob",
+      state: "COMMENTED",
+      isRequested: true,
+      avatarUrl: "https://example/b.png",
+    });
   });
 
-  it("omits both sections when no requested reviewers or completed reviews exist", () => {
-    const sections = buildReviewerSections(route, {
-      status: "ok",
-      requestedUsers: [],
-      requestedTeams: [],
-      completedReviews: [],
-    });
+  it("dedups DISMISSED reviewer who is still in requested_reviewers", () => {
+    const entries = buildReviewers(
+      route,
+      summary({
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        completedReviews: [
+          { login: "alice", avatarUrl: null, state: "DISMISSED" },
+        ],
+      }),
+    );
 
-    expect(sections).toEqual([]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "user",
+      state: "DISMISSED",
+      isRequested: true,
+    });
   });
 
-  it("renders only the reviewed section when there are no requested reviewers", () => {
-    const sections = buildReviewerSections(route, {
-      status: "ok",
-      requestedUsers: [],
-      requestedTeams: [],
-      completedReviews: [{ login: "bob", state: "APPROVED" }],
-    });
+  it("marks APPROVED reviewers as isRequested: false when GitHub removed them", () => {
+    const entries = buildReviewers(
+      route,
+      summary({
+        requestedUsers: [],
+        completedReviews: [{ login: "alice", avatarUrl: null, state: "APPROVED" }],
+      }),
+    );
 
-    expect(sections.map((section) => section.label)).toEqual(["Reviewed"]);
-    expect(sections[0]?.chips[0]?.label).toContain("bob");
+    expect(entries[0]).toMatchObject({
+      kind: "user",
+      state: "APPROVED",
+      isRequested: false,
+    });
+  });
+
+  it("handles the approved-and-still-requested race (isRequested wins for border, state kept)", () => {
+    const entries = buildReviewers(
+      route,
+      summary({
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        completedReviews: [{ login: "alice", avatarUrl: null, state: "APPROVED" }],
+      }),
+    );
+    expect(entries[0]).toMatchObject({
+      kind: "user",
+      state: "APPROVED",
+      isRequested: true,
+    });
+  });
+
+  it("sorts users across all four buckets with alphabetical tiebreak", () => {
+    const entries = buildReviewers(
+      route,
+      summary({
+        requestedUsers: [
+          { login: "zed", avatarUrl: null },
+          { login: "eve", avatarUrl: null },
+          { login: "cal", avatarUrl: null },
+          { login: "mia", avatarUrl: null },
+        ],
+        completedReviews: [
+          { login: "zed", avatarUrl: null, state: "COMMENTED" },
+          { login: "mia", avatarUrl: null, state: "DISMISSED" },
+          { login: "ben", avatarUrl: null, state: "APPROVED" },
+          { login: "amy", avatarUrl: null, state: "CHANGES_REQUESTED" },
+        ],
+      }),
+    );
+
+    expect(
+      entries
+        .filter((entry) => entry.kind === "user")
+        .map((entry) => (entry.kind === "user" ? entry.login : "")),
+    ).toEqual([
+      "amy", // resolved CHANGES_REQUESTED
+      "ben", // resolved APPROVED
+      "zed", // pending + COMMENTED
+      "mia", // pending + DISMISSED
+      "cal", // pending, no activity (alphabetical before eve)
+      "eve",
+    ]);
+  });
+
+  it("places teams after all user entries", () => {
+    const entries = buildReviewers(
+      route,
+      summary({
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: ["platform", "design"],
+      }),
+    );
+
+    expect(entries.map((entry) => entry.kind)).toEqual(["user", "team", "team"]);
+    expect(
+      entries
+        .filter((entry) => entry.kind === "team")
+        .map((entry) => (entry.kind === "team" ? entry.slug : "")),
+    ).toEqual(["design", "platform"]);
+  });
+
+  it("builds review-requested URLs when isRequested is true", () => {
+    const entries = buildReviewers(
+      route,
+      summary({
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+      }),
+    );
+    const user = entries[0];
+    expect(user.kind).toBe("user");
+    if (user.kind !== "user") return;
+    expect(user.href).toContain("review-requested%3Aalice");
+  });
+
+  it("builds reviewed-by URLs when isRequested is false", () => {
+    const entries = buildReviewers(
+      route,
+      summary({
+        completedReviews: [{ login: "bob", avatarUrl: null, state: "APPROVED" }],
+      }),
+    );
+    const user = entries[0];
+    expect(user.kind).toBe("user");
+    if (user.kind !== "user") return;
+    expect(user.href).toContain("reviewed-by%3Abob");
+  });
+
+  it("builds team-review-requested URLs scoped to the route owner", () => {
+    const entries = buildReviewers(
+      route,
+      summary({ requestedTeams: ["platform"] }),
+    );
+    const team = entries[0];
+    expect(team.kind).toBe("team");
+    if (team.kind !== "team") return;
+    expect(team.href).toContain("team-review-requested%3Ahon454%2Fplatform");
+  });
+
+  it("prefers the avatarUrl from the latest review when a login appears in both sources", () => {
+    const entries = buildReviewers(
+      route,
+      summary({
+        requestedUsers: [
+          { login: "alice", avatarUrl: "https://old.example/a.png" },
+        ],
+        completedReviews: [
+          {
+            login: "alice",
+            avatarUrl: "https://new.example/a.png",
+            state: "COMMENTED",
+          },
+        ],
+      }),
+    );
+    const user = entries[0];
+    if (user.kind !== "user") throw new Error("expected user entry");
+    expect(user.avatarUrl).toBe("https://new.example/a.png");
   });
 });

--- a/tests/reviewer-view-model.test.ts
+++ b/tests/reviewer-view-model.test.ts
@@ -177,6 +177,24 @@ describe("buildReviewers", () => {
     expect(user.href).toContain("reviewed-by%3Abob");
   });
 
+  it("builds reviewed-by URLs when a reviewer has a state even if also re-requested", () => {
+    const entries = buildReviewers(
+      route,
+      summary({
+        requestedUsers: [{ login: "carol", avatarUrl: null }],
+        completedReviews: [
+          { login: "carol", avatarUrl: null, state: "COMMENTED" },
+        ],
+      }),
+    );
+    const user = entries[0];
+    expect(user.kind).toBe("user");
+    if (user.kind !== "user") return;
+    expect(user.isRequested).toBe(true);
+    expect(user.state).toBe("COMMENTED");
+    expect(user.href).toContain("reviewed-by%3Acarol");
+  });
+
   it("builds team-review-requested URLs scoped to the route owner", () => {
     const entries = buildReviewers(
       route,

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PullReviewerSummary } from "../src/github/api";
+import type * as PreferencesModule from "../src/storage/preferences";
 
 const fetchPullReviewerSummaryMock = vi.fn();
 const resolveAccountForRepoMock = vi.fn();
@@ -18,7 +19,7 @@ vi.mock("../src/storage/accounts", () => ({
 }));
 
 vi.mock("../src/storage/preferences", async () => {
-  const actual = await vi.importActual<typeof import("../src/storage/preferences")>(
+  const actual = await vi.importActual<typeof PreferencesModule>(
     "../src/storage/preferences",
   );
   return {

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { PullReviewerSummary } from "../src/github/api";
+
 const fetchPullReviewerSummaryMock = vi.fn();
 const resolveAccountForRepoMock = vi.fn();
 const markAccountInvalidatedMock = vi.fn();
+const getPreferencesMock = vi.fn();
 
 vi.mock("../src/github/api", () => ({
   fetchPullReviewerSummary: fetchPullReviewerSummaryMock,
@@ -14,8 +17,37 @@ vi.mock("../src/storage/accounts", () => ({
   markAccountInvalidated: markAccountInvalidatedMock,
 }));
 
+vi.mock("../src/storage/preferences", async () => {
+  const actual = await vi.importActual<typeof import("../src/storage/preferences")>(
+    "../src/storage/preferences",
+  );
+  return {
+    ...actual,
+    getPreferences: getPreferencesMock,
+  };
+});
+
 function flushMicrotasks() {
   return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+type StorageChange = { oldValue?: unknown; newValue?: unknown };
+type StorageListener = (
+  changes: Record<string, StorageChange>,
+  areaName: string,
+) => void;
+
+let capturedStorageListener: StorageListener | null = null;
+let pendingTeardowns: Array<() => void>;
+
+function makeCtx() {
+  const teardowns: Array<() => void> = [];
+  pendingTeardowns.push(() => teardowns.forEach((fn) => fn()));
+  return {
+    addEventListener: vi.fn(),
+    setInterval: vi.fn(),
+    onInvalidated: vi.fn((fn: () => void) => teardowns.push(fn)),
+  } as never;
 }
 
 beforeEach(() => {
@@ -23,11 +55,21 @@ beforeEach(() => {
   fetchPullReviewerSummaryMock.mockReset();
   resolveAccountForRepoMock.mockReset();
   markAccountInvalidatedMock.mockReset();
+  getPreferencesMock.mockReset();
+  getPreferencesMock.mockResolvedValue({
+    version: 1,
+    showStateBadge: true,
+    showReviewerName: false,
+  });
+  capturedStorageListener = null;
+  pendingTeardowns = [];
 
   vi.stubGlobal("browser", {
     storage: {
       onChanged: {
-        addListener: vi.fn(),
+        addListener: vi.fn((listener: StorageListener) => {
+          capturedStorageListener = listener;
+        }),
         removeListener: vi.fn(),
       },
     },
@@ -40,14 +82,12 @@ beforeEach(() => {
       <div class="d-flex mt-1 text-small color-fg-muted"></div>
     </div>
   `;
-  window.history.replaceState(
-    {},
-    "",
-    "/cinev/shotloom/pulls",
-  );
+  window.history.replaceState({}, "", "/cinev/shotloom/pulls");
 });
 
 afterEach(() => {
+  pendingTeardowns.forEach((fn) => fn());
+  pendingTeardowns = [];
   vi.unstubAllGlobals();
 });
 
@@ -61,15 +101,85 @@ describe("bootReviewerListPage", () => {
     fetchPullReviewerSummaryMock.mockRejectedValue({ status: 401 });
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
-    bootReviewerListPage({
-      addEventListener: vi.fn(),
-      setInterval: vi.fn(),
-      onInvalidated: vi.fn(),
-    } as never);
+    bootReviewerListPage(makeCtx());
 
     await flushMicrotasks();
     await flushMicrotasks();
 
     expect(markAccountInvalidatedMock).toHaveBeenCalledWith("acc-1", "revoked");
+  });
+
+  it("rerenders on preferences change without refetching reviewer data", async () => {
+    resolveAccountForRepoMock.mockResolvedValue(null);
+    const summary: PullReviewerSummary = {
+      status: "ok",
+      requestedUsers: [{ login: "alice", avatarUrl: null }],
+      requestedTeams: [],
+      completedReviews: [],
+    };
+    fetchPullReviewerSummaryMock.mockResolvedValue(summary);
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(1);
+    expect(document.querySelector("a.ghpsr-pill")).toBeNull();
+    expect(document.querySelector("a.ghpsr-avatar")).not.toBeNull();
+
+    getPreferencesMock.mockResolvedValueOnce({
+      version: 1,
+      showStateBadge: true,
+      showReviewerName: true,
+    });
+    capturedStorageListener!(
+      {
+        preferences: {
+          oldValue: { version: 1, showStateBadge: true, showReviewerName: false },
+          newValue: { version: 1, showStateBadge: true, showReviewerName: true },
+        },
+      },
+      "local",
+    );
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(1);
+    expect(document.querySelector("a.ghpsr-pill")).not.toBeNull();
+  });
+
+  it("clears the reviewer cache on settings (accounts) change", async () => {
+    resolveAccountForRepoMock.mockResolvedValue(null);
+    const summary: PullReviewerSummary = {
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: [],
+      completedReviews: [],
+    };
+    fetchPullReviewerSummaryMock.mockResolvedValue(summary);
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(1);
+
+    capturedStorageListener!(
+      {
+        settings: {
+          oldValue: { version: 2, accounts: [] },
+          newValue: { version: 2, accounts: [] },
+        },
+      },
+      "local",
+    );
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/state-icons.test.ts
+++ b/tests/state-icons.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { STATE_ICONS } from "../src/features/reviewers/state-icons";
+
+describe("STATE_ICONS", () => {
+  it("provides four well-formed SVG strings", () => {
+    for (const key of ["approved", "changesRequested", "commented", "dismissed"] as const) {
+      const svg = STATE_ICONS[key];
+      expect(typeof svg).toBe("string");
+      expect(svg).toMatch(/^<svg[\s>]/);
+      expect(svg).toContain("</svg>");
+      expect(svg).toContain('viewBox="0 0 16 16"');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Merge the `Requested` and `Reviewed` metadata rows into a single `Reviewers:` section with 24px avatar chips: border tone encodes *attention-needed* (blue when still requested, green/red when resolved), optional SVG badge encodes *latest review activity*.
- Add two user preferences on the options page — *Show review state badge on avatars* (default on) and *Show reviewer names* (default off; when on, each user becomes an `@login` pill) — persisted under a new `preferences` storage key separate from account settings.
- Harden avatar URL ingestion against non-http(s) schemes and wire a deterministic initials fallback for failed image loads (CSP-safe, no inline `onerror`).

## Why

The two-section `Requested` / `Reviewed` layout consumes horizontal real estate on GitHub pull-request lists and spells out each login as text. A more glanceable, GitHub-native presentation that mirrors the assignee avatar pattern works better there, while still preserving the "still requested" signal for reviewers who only commented or had a review dismissed. The toggle pair keeps the name-centric layout available for users who rely on text density.

## Changes

- **Data model (`src/github/api.ts`)**: extend `userLiteSchema` with an `avatar_url` field guarded by `z.string().url().refine(http(s)).catch(null)`; export `ReviewerUser`; `CompletedReview` and `PullReviewerSummary.requestedUsers` now carry `avatarUrl`.
- **View-model (`src/features/reviewers/view-model.ts`)**: replace `buildReviewerSections` with `buildReviewers` returning a flat `ReviewerEntry[]`. Each login appears exactly once (`isRequested` and latest `state` combined), teams sort last, users sort by a four-bucket rank with alphabetical tiebreak.
- **Renderer (`src/features/reviewers/dom.ts`, `state-icons.ts`)**: replace `renderReviewerSections` with `renderReviewers(mount, entries, {showStateBadge, showReviewerName})`. Avatar-only or pill layout, optional state badge, Octicon SVGs (`check` / `x` / `comment` / `circle-slash`), initials fallback via `addEventListener("error", …)`.
- **Storage (`src/storage/preferences.ts`)**: new `preferences` key with versioned Zod schema and `isPreferencesChange` / `isAccountsChange` routing helpers. `src/storage/accounts.ts` is untouched.
- **Content script (`src/features/reviewers/index.ts`)**: cache `Preferences` in closure, route `storage.onChanged` by key — `settings` still clears the reviewer cache, `preferences` only invalidates the cached prefs and re-renders without refetching.
- **Options UI (`entrypoints/options/components/DisplaySettingsPanel.tsx`, `options-page.tsx`)**: new "Display" section with two checkboxes bound via `getPreferences` / `updatePreferences`.
- **Docs (`README.md`, `docs/implementation-notes.md`)**: captions, feature bullet, and runtime-flow step describe the merged section and the display toggles. `package.json` bumped to v1.3.0.
- **E2E assertions (`tests/e2e/*`)**: updated to the new `Reviewers:` label, `Team: {slug}` chip, and avatar-by-title selectors.

## Impact

- User-facing impact: PR-list reviewer presentation changes visually. The two section labels disappear; team chip text changes from `@slug` to `Team: {slug}`. No link semantics change — user avatars still navigate to the reviewer's filtered PR list, teams still navigate to `team-review-requested:owner/slug`.
- API/schema impact: storage gains a new top-level `preferences` key (schema `version: 1`); the existing `settings` key is untouched. GitHub REST usage is unchanged — avatar URLs are already in the responses we fetch.
- Performance impact: toggling display preferences no longer invalidates the per-row reviewer cache, so preference changes rerender without additional GitHub API calls. No new network work on any path.
- Operational or rollout impact: bundled size grows by four inline Octicon SVG strings and a small CSS block; no manifest changes, no new permissions. First boot after update reads an empty `preferences` key and falls back to defaults (badge on, name off).

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint` — clean.
- `pnpm typecheck` — clean.
- `pnpm test` — 112 / 112 pass across 14 files. New suites: `tests/state-icons.test.ts`, `tests/preferences.test.ts`; rewritten: `tests/reviewer-view-model.test.ts`, `tests/reviewer-dom.test.ts`, `tests/reviewers.test.ts`, `tests/options-page.test.ts` (three new cases added alongside existing device-flow cases).
- `pnpm test:e2e` — not yet run in CI for this branch. The Playwright specs in `tests/e2e/` were updated to the new DOM (`Reviewers:`, `Team: platform`, `a.ghpsr-avatar[title*="@login"]` selectors) and should be exercised before tagging v1.3.0 via `pnpm verify:release`.
- Manual Chrome verification — not yet performed. Recommended smoke: install the unpacked build, visit a repo's pulls list, toggle both preferences on the options page, and confirm the row UI updates without a refetch (DevTools network panel should show no new `/pulls/{n}` or `/reviews` calls on toggle).

## Breaking Changes

- None. The options storage `settings` key (accounts) is unchanged. The `preferences` key is additive with a safe default. The content-script DOM contract (`.ghpsr-root` mount) is preserved for hosts that may be scraping it.

## Related Issues

No issue: greenfield UX iteration proposed directly against the current two-section layout.

<!--
Co-location checklist walk-through:
1. Reviewer UX / supported states — updated `README.md` and `docs/implementation-notes.md` ✓
2. `src/github/selectors.ts` — not touched.
3. `wxt.config.ts` permissions — not changed.
4. Storage schema — new `preferences` key. `docs/privacy-policy.md` "Storage and retention" section SHOULD be updated to list the new key; follow-up recommended before v1.3.0 tagging.
5. Auth / device flow — not changed.
6. New modules added (`src/storage/preferences.ts`, `src/features/reviewers/state-icons.ts`, `entrypoints/options/components/DisplaySettingsPanel.tsx`). `README.md` / `AGENTS.md` Repository Map sections are directory-level and still accurate; no update needed.
7. `package.json` version bumped to v1.3.0 — `docs/releases/v1.3.0.md` NOT YET ADDED; needs follow-up commit before the release is tagged.
8. No new durable design decision warranting an ADR.
9. `pnpm verify:release` unchanged.
10. Chrome Web Store copy and screenshots describe the old two-section UX; `docs/chrome-web-store*.md` and `docs/chrome-web-store-assets/` will need a refresh before v1.3.0 hits the Web Store.
-->