### PR TITLE
fix(auth): refresh GitHub App access tokens before invalidating accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,16 @@ This repository intentionally stays narrow.
 - **Multiple accounts** are supported. Add a personal account and a work
   account side-by-side; the content script resolves the right one per repo from
   each account's installations.
+- **Token expiry** is handled automatically. GitHub App user-to-server access
+  tokens expire after about 8 hours; the extension stores the refresh token at
+  sign-in and exchanges it for a new access token in the background when GitHub
+  returns 401. You stay signed in until the refresh token itself expires
+  (about 6 months) or the app is revoked.
 - **Revocation** happens on GitHub's
   [Applications page](https://github.com/settings/applications). Removing an
-  account from the options page only deletes the locally stored token.
+  account from the options page only deletes the locally stored token. If a
+  refresh attempt itself fails (`refresh_failed` on the options page), sign in
+  again to restore access.
 
 See [ADR 0003](docs/adr/0003-github-app-device-flow.md) for the rationale.
 

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -54,7 +54,10 @@
 | No signed-in account | 200 for pulls list, pull detail, and reviews | Repository works on the public no-token path                                |
 | No signed-in account | 403 with rate-limit signal                   | Unauthenticated rate limit exhausted                                        |
 | No signed-in account | 404 / 401 / private-like 403                 | Repository behaves like a private or permission-gated resource              |
-| Matched account    | 401 on `/rate_limit` or a repository endpoint | Token was revoked — sign in again from the options page                     |
+| Matched account    | 401 on a repository endpoint, refresh succeeds | Access token was expired — refreshed transparently via the background script |
+| Matched account    | 401 with no stored refresh token              | Pre-v3 account or refresh token never issued — marked `revoked`, sign in again |
+| Matched account    | 401 then refresh returns `bad_refresh_token`  | Refresh token rejected — marked `refresh_failed`, sign in again from the options page |
+| Matched account    | 401 then refresh succeeds then 401 again      | New access token rejected (app revoked or scope changed) — marked `revoked`, sign in again |
 | Matched account    | 403 / 404 without rate-limit signal           | Installation does not cover this repository — install the GitHub App on the owner |
 
 ## Next implementation targets

--- a/docs/manual-chrome-testing.md
+++ b/docs/manual-chrome-testing.md
@@ -121,6 +121,27 @@ This extension is intentionally narrow. Manual verification should stay focused 
 4. Open the options page; confirm the account card shows the invalidated
    styling and a **Sign in again** button.
 
+### Expired access token with valid refresh token
+
+1. Sign in with a private-repository account and confirm reviewer chips render.
+2. Open `chrome.storage.local` in the extension's service worker DevTools.
+3. Replace the stored `account:auth:<id>.token` value with a known-bad token
+   while keeping `refreshToken` intact.
+4. Reload the private PR list.
+5. Confirm reviewer chips still render and the extension performs exactly one
+   refresh-token exchange against `https://github.com/login/oauth/access_token`.
+6. Open the options page and click **Refresh installations**.
+7. Confirm the installation refresh also succeeds without requiring a fresh
+   sign-in.
+
+### Expired access token with invalid refresh token
+
+1. Starting from the previous scenario, also corrupt
+   `account:auth:<id>.refreshToken`.
+2. Reload the private PR list.
+3. Confirm the account is marked invalidated with
+   `invalidatedReason: "refresh_failed"` and the UI prompts for sign-in again.
+
 ### Unauthenticated rate limit
 
 1. Sign out of every account in the options page.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-Last updated: 2026-04-22
+Last updated: 2026-04-23
 
 `GitHub Pulls Show Reviewers` is a Chrome extension that shows requested reviewers, requested teams, and completed review state directly inside GitHub pull request list pages.
 
@@ -12,24 +12,26 @@ To provide its reviewer visibility feature, the extension may access:
 
 - GitHub repository and pull request context from the current page, including repository owner/name, pull request numbers, and visible metadata needed to place reviewer chips in the list UI.
 - Reviewer-related metadata returned by GitHub's REST API, including requested reviewers, requested teams, and review states.
-- User-to-server access tokens issued by GitHub after you sign in with our
-  GitHub App (requested permission: `Pull requests: Read`). Tokens are
-  long-lived and revocable from
+- User-to-server access tokens and refresh tokens issued by GitHub after you
+  sign in with our GitHub App (requested permission: `Pull requests: Read`).
+  These credentials are revocable from
   [github.com/settings/applications](https://github.com/settings/applications).
 
 ## How data is used
 
 - GitHub page context is used locally to determine which repository and pull requests are visible on the current page.
 - Reviewer metadata is requested from GitHub's API and rendered inline on the GitHub pull request list page.
-- The GitHub App token is used only to authenticate requests to GitHub for private repository access.
+- The GitHub App credentials are used only to authenticate requests to GitHub for private repository access and to refresh expired access tokens.
 
 ## Storage and retention
 
-- Connected accounts are stored locally in `browser.storage.local` under a
-  single `settings` key. Each record contains the GitHub login, avatar URL,
-  user-to-server access token, creation timestamp, a cached list of GitHub App
-  installations, and a revocation flag. Entries live there until the user
-  removes the account.
+- Connected accounts are stored locally in `browser.storage.local`. The
+  `settings` key stores the account id list, and per-account records are split
+  across `account:profile:*`, `account:auth:*`, and
+  `account:installations:*` keys. These records contain the GitHub login,
+  avatar URL, creation timestamp, user-to-server access token, refresh token,
+  token expiry timestamps, cached GitHub App installations, and invalidation
+  state. Entries live there until the user removes the account.
 - Display preferences are stored locally in `browser.storage.local` under a
   separate `preferences` key. That record currently stores whether review-state
   badges stay visible and whether reviewer names expand into text pills. The

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,15 +1,42 @@
+import { createRefreshCoordinator } from "../src/auth/refresh-coordinator";
+import { getGitHubAppConfig } from "../src/config/github-app";
+
 export default defineBackground(() => {
+  const coordinator = createRefreshCoordinator({
+    getClientId: () => getGitHubAppConfig().clientId,
+  });
+
   browser.runtime.onInstalled.addListener((details) => {
     if (details.reason === "install") {
       browser.runtime.openOptionsPage().catch((error) => {
-        console.error("[GitHub Pulls Show Reviewers] Failed to open options page.", error);
+        console.error(
+          "[GitHub Pulls Show Reviewers] Failed to open options page.",
+          error,
+        );
       });
     }
   });
 
   browser.action.onClicked.addListener(() => {
     browser.runtime.openOptionsPage().catch((error) => {
-      console.error("[GitHub Pulls Show Reviewers] Failed to open options page.", error);
+      console.error(
+        "[GitHub Pulls Show Reviewers] Failed to open options page.",
+        error,
+      );
     });
+  });
+
+  browser.runtime.onMessage.addListener((message: unknown) => {
+    if (
+      message != null &&
+      typeof message === "object" &&
+      (message as { type?: unknown }).type === "refreshAccessToken" &&
+      typeof (message as { accountId?: unknown }).accountId === "string"
+    ) {
+      return coordinator.refreshAccountToken(
+        (message as { accountId: string }).accountId,
+      );
+    }
+    return undefined;
   });
 });

--- a/entrypoints/options/components/AccountsList.tsx
+++ b/entrypoints/options/components/AccountsList.tsx
@@ -1,5 +1,6 @@
 import { type CSSProperties } from "react";
 
+import { retryWithAccountRefresh } from "../../../src/auth/account-token-refresh";
 import {
   fetchInstallationRepositories,
   fetchUserInstallations,
@@ -19,23 +20,30 @@ type Props = {
 
 export function AccountsList({ accounts, onChange, onReauthenticate }: Props) {
   async function handleRefresh(account: Account) {
-    const apiInstallations = await fetchUserInstallations({
-      token: account.token,
+    const installations = await retryWithAccountRefresh({
+      account,
+      execute: async (token) => {
+        if (token == null) {
+          throw new Error("Account token is required to refresh installations.");
+        }
+
+        const apiInstallations = await fetchUserInstallations({ token });
+        return Promise.all(
+          apiInstallations.map(async (installation): Promise<Installation> => ({
+            id: installation.id,
+            account: installation.account,
+            repositorySelection: installation.repositorySelection,
+            repoFullNames:
+              installation.repositorySelection === "selected"
+                ? await fetchInstallationRepositories({
+                    token,
+                    installationId: installation.id,
+                  })
+                : null,
+          })),
+        );
+      },
     });
-    const installations: Installation[] = await Promise.all(
-      apiInstallations.map(async (installation) => ({
-        id: installation.id,
-        account: installation.account,
-        repositorySelection: installation.repositorySelection,
-        repoFullNames:
-          installation.repositorySelection === "selected"
-            ? await fetchInstallationRepositories({
-                token: account.token,
-                installationId: installation.id,
-              })
-            : null,
-      })),
-    );
     await replaceInstallations(account.id, installations);
     await onChange();
   }

--- a/entrypoints/options/device-flow-controller.ts
+++ b/entrypoints/options/device-flow-controller.ts
@@ -105,7 +105,7 @@ export function useDeviceFlowController(input: {
             }
             setState({ phase: "fetching_installations" });
             const connected = await completeAccountConnect(
-              result.accessToken,
+              result,
               input.onConnected,
               () => cancelledRef.current,
             );
@@ -178,24 +178,29 @@ export function useDeviceFlowController(input: {
 }
 
 async function completeAccountConnect(
-  accessToken: string,
+  poll: {
+    accessToken: string;
+    refreshToken: string | null;
+    expiresAt: number | null;
+    refreshTokenExpiresAt: number | null;
+  },
   onConnected: (account: Account) => void,
   isCancelled: () => boolean,
 ): Promise<boolean> {
   if (isCancelled()) {
     return false;
   }
-  const user = await fetchAuthenticatedUser({ token: accessToken });
+  const user = await fetchAuthenticatedUser({ token: poll.accessToken });
   if (isCancelled()) {
     return false;
   }
-  const apiInstallations = await fetchUserInstallations({ token: accessToken });
+  const apiInstallations = await fetchUserInstallations({ token: poll.accessToken });
   const installations: Installation[] = await Promise.all(
     apiInstallations.map(async (installation) => {
       const repoFullNames =
         installation.repositorySelection === "selected"
           ? await fetchInstallationRepositories({
-              token: accessToken,
+              token: poll.accessToken,
               installationId: installation.id,
             })
           : null;
@@ -214,12 +219,15 @@ async function completeAccountConnect(
     id: globalThis.crypto.randomUUID(),
     login: user.login,
     avatarUrl: user.avatarUrl,
-    token: accessToken,
+    token: poll.accessToken,
     createdAt: Date.now(),
     installations,
     installationsRefreshedAt: Date.now(),
     invalidated: false,
     invalidatedReason: null,
+    refreshToken: poll.refreshToken,
+    expiresAt: poll.expiresAt,
+    refreshTokenExpiresAt: poll.refreshTokenExpiresAt,
   };
   await addAccount(account);
   if (isCancelled()) {

--- a/src/auth/account-token-refresh.ts
+++ b/src/auth/account-token-refresh.ts
@@ -1,0 +1,69 @@
+import { getAccountById, markAccountInvalidated, type Account } from "../storage/accounts";
+
+function extractStatus(error: unknown): number | null {
+  if (error && typeof error === "object" && "status" in error) {
+    const value = (error as { status: unknown }).status;
+    return typeof value === "number" ? value : null;
+  }
+
+  if (
+    error &&
+    typeof error === "object" &&
+    "failures" in error &&
+    Array.isArray((error as { failures: unknown }).failures)
+  ) {
+    const first = (error as { failures: Array<{ status?: number }> }).failures[0];
+    return typeof first?.status === "number" ? first.status : null;
+  }
+
+  if (error instanceof Error) {
+    const match = /status (\d+)/i.exec(error.message);
+    if (match) {
+      return Number(match[1]);
+    }
+  }
+
+  return null;
+}
+
+export async function retryWithAccountRefresh<T>(input: {
+  account: Account | null;
+  execute: (token: string | null) => Promise<T>;
+}): Promise<T> {
+  const { account, execute } = input;
+
+  try {
+    return await execute(account?.token ?? null);
+  } catch (error) {
+    if (extractStatus(error) !== 401 || account == null) {
+      throw error;
+    }
+
+    if (account.refreshToken == null) {
+      await markAccountInvalidated(account.id, "revoked");
+      throw error;
+    }
+
+    const outcome = (await browser.runtime.sendMessage({
+      type: "refreshAccessToken",
+      accountId: account.id,
+    })) as
+      | { ok: true; token: string }
+      | { ok: false; terminal: boolean }
+      | undefined;
+
+    if (!outcome || outcome.ok !== true) {
+      throw error;
+    }
+
+    const refreshed = await getAccountById(account.id);
+    try {
+      return await execute(refreshed?.token ?? outcome.token);
+    } catch (retryError) {
+      if (extractStatus(retryError) === 401) {
+        await markAccountInvalidated(account.id, "revoked");
+      }
+      throw retryError;
+    }
+  }
+}

--- a/src/auth/refresh-coordinator.ts
+++ b/src/auth/refresh-coordinator.ts
@@ -3,7 +3,7 @@ import {
   RefreshTokenError,
 } from "../github/auth";
 import {
-  listAccounts,
+  getAccountById,
   markAccountInvalidated,
   updateAccountTokens,
 } from "../storage/accounts";
@@ -22,8 +22,7 @@ export function createRefreshCoordinator(input: {
   const inFlight = new Map<string, Promise<RefreshOutcome>>();
 
   async function run(accountId: string): Promise<RefreshOutcome> {
-    const accounts = await listAccounts();
-    const account = accounts.find((candidate) => candidate.id === accountId);
+    const account = await getAccountById(accountId);
     if (!account || account.refreshToken == null) {
       return { ok: false, terminal: true };
     }

--- a/src/auth/refresh-coordinator.ts
+++ b/src/auth/refresh-coordinator.ts
@@ -1,0 +1,65 @@
+import {
+  refreshAccessToken,
+  RefreshTokenError,
+} from "../github/auth";
+import {
+  listAccounts,
+  markAccountInvalidated,
+  updateAccountTokens,
+} from "../storage/accounts";
+
+export type RefreshOutcome =
+  | { ok: true; token: string }
+  | { ok: false; terminal: boolean };
+
+export type RefreshCoordinator = {
+  refreshAccountToken(accountId: string): Promise<RefreshOutcome>;
+};
+
+export function createRefreshCoordinator(input: {
+  getClientId: () => string;
+}): RefreshCoordinator {
+  const inFlight = new Map<string, Promise<RefreshOutcome>>();
+
+  async function run(accountId: string): Promise<RefreshOutcome> {
+    const accounts = await listAccounts();
+    const account = accounts.find((candidate) => candidate.id === accountId);
+    if (!account || account.refreshToken == null) {
+      return { ok: false, terminal: true };
+    }
+
+    try {
+      const result = await refreshAccessToken({
+        clientId: input.getClientId(),
+        refreshToken: account.refreshToken,
+      });
+      await updateAccountTokens(accountId, {
+        token: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresAt: result.expiresAt,
+        refreshTokenExpiresAt: result.refreshTokenExpiresAt,
+      });
+      return { ok: true, token: result.accessToken };
+    } catch (error) {
+      if (error instanceof RefreshTokenError && error.kind === "terminal") {
+        await markAccountInvalidated(accountId, "refresh_failed");
+        return { ok: false, terminal: true };
+      }
+      return { ok: false, terminal: false };
+    }
+  }
+
+  return {
+    refreshAccountToken(accountId: string): Promise<RefreshOutcome> {
+      const existing = inFlight.get(accountId);
+      if (existing) {
+        return existing;
+      }
+      const promise = run(accountId).finally(() => {
+        inFlight.delete(accountId);
+      });
+      inFlight.set(accountId, promise);
+      return promise;
+    },
+  };
+}

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -96,22 +96,16 @@ export function bootReviewerListPage(
 
     const request = (async () => {
       const account = await resolveAccountForRepo(route.owner, route.repo);
-      const githubToken = account?.token ?? null;
 
       try {
-        const summary = await fetchPullReviewerSummary({
+        const summary = await fetchWithRefresh({
+          account,
           owner: route.owner,
           repo: route.repo,
           pullNumber,
-          githubToken,
         });
         setCachedReviewerSummary(cacheKey, summary);
       } catch (error) {
-        const invalidationReason =
-          account == null ? null : getAccountInvalidationReason(error);
-        if (account != null && invalidationReason != null) {
-          await markAccountInvalidated(account.id, invalidationReason);
-        }
         mount.replaceChildren();
         mount.removeAttribute("title");
         options?.onRowFailure?.({
@@ -206,10 +200,58 @@ export function bootReviewerListPage(
   });
 }
 
-function getAccountInvalidationReason(
-  error: unknown,
-): "revoked" | "expired" | "unknown" | null {
-  return extractStatus(error) === 401 ? "revoked" : null;
+async function fetchWithRefresh(args: {
+  account: Account | null;
+  owner: string;
+  repo: string;
+  pullNumber: string;
+}): Promise<Awaited<ReturnType<typeof fetchPullReviewerSummary>>> {
+  const { account, owner, repo, pullNumber } = args;
+
+  try {
+    return await fetchPullReviewerSummary({
+      owner,
+      repo,
+      pullNumber,
+      githubToken: account?.token ?? null,
+    });
+  } catch (error) {
+    if (extractStatus(error) !== 401 || account == null) {
+      throw error;
+    }
+
+    if (account.refreshToken == null) {
+      await markAccountInvalidated(account.id, "revoked");
+      throw error;
+    }
+
+    const outcome = (await browser.runtime.sendMessage({
+      type: "refreshAccessToken",
+      accountId: account.id,
+    })) as
+      | { ok: true; token: string }
+      | { ok: false; terminal: boolean }
+      | undefined;
+
+    if (!outcome || outcome.ok !== true) {
+      throw error;
+    }
+
+    const refreshed = await resolveAccountForRepo(owner, repo);
+    try {
+      return await fetchPullReviewerSummary({
+        owner,
+        repo,
+        pullNumber,
+        githubToken: refreshed?.token ?? outcome.token,
+      });
+    } catch (retryError) {
+      if (extractStatus(retryError) === 401) {
+        await markAccountInvalidated(account.id, "revoked");
+      }
+      throw retryError;
+    }
+  }
 }
 
 function extractStatus(error: unknown): number | null {

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -1,5 +1,6 @@
 import type { ContentScriptContext } from "wxt/utils/content-script-context";
 
+import { retryWithAccountRefresh } from "../../auth/account-token-refresh";
 import {
   buildReviewerCacheKey,
   clearReviewerCache,
@@ -9,7 +10,7 @@ import {
 import { fetchPullReviewerSummary } from "../../github/api";
 import { parsePullListRoute } from "../../github/routes";
 import { githubSelectors } from "../../github/selectors";
-import { markAccountInvalidated, resolveAccountForRepo, type Account } from "../../storage/accounts";
+import { resolveAccountForRepo, type Account } from "../../storage/accounts";
 import {
   DEFAULT_PREFERENCES,
   getPreferences,
@@ -208,68 +209,14 @@ async function fetchWithRefresh(args: {
 }): Promise<Awaited<ReturnType<typeof fetchPullReviewerSummary>>> {
   const { account, owner, repo, pullNumber } = args;
 
-  try {
-    return await fetchPullReviewerSummary({
+  return retryWithAccountRefresh({
+    account,
+    execute: async (token) =>
+      fetchPullReviewerSummary({
       owner,
       repo,
       pullNumber,
-      githubToken: account?.token ?? null,
-    });
-  } catch (error) {
-    if (extractStatus(error) !== 401 || account == null) {
-      throw error;
-    }
-
-    if (account.refreshToken == null) {
-      await markAccountInvalidated(account.id, "revoked");
-      throw error;
-    }
-
-    const outcome = (await browser.runtime.sendMessage({
-      type: "refreshAccessToken",
-      accountId: account.id,
-    })) as
-      | { ok: true; token: string }
-      | { ok: false; terminal: boolean }
-      | undefined;
-
-    if (!outcome || outcome.ok !== true) {
-      throw error;
-    }
-
-    const refreshed = await resolveAccountForRepo(owner, repo);
-    try {
-      return await fetchPullReviewerSummary({
-        owner,
-        repo,
-        pullNumber,
-        githubToken: refreshed?.token ?? outcome.token,
-      });
-    } catch (retryError) {
-      if (extractStatus(retryError) === 401) {
-        await markAccountInvalidated(account.id, "revoked");
-      }
-      throw retryError;
-    }
-  }
-}
-
-function extractStatus(error: unknown): number | null {
-  if (error && typeof error === "object" && "status" in error) {
-    const value = (error as { status: unknown }).status;
-    return typeof value === "number" ? value : null;
-  }
-
-  if (
-    error &&
-    typeof error === "object" &&
-    "failures" in error &&
-    Array.isArray((error as { failures: unknown }).failures)
-  ) {
-    const first = (error as { failures: Array<{ status?: number }> })
-      .failures[0];
-    return typeof first?.status === "number" ? first.status : null;
-  }
-
-  return null;
+      githubToken: token,
+    }),
+  });
 }

--- a/src/github/auth.ts
+++ b/src/github/auth.ts
@@ -82,6 +82,9 @@ const accessTokenResponseSchema = z.union([
     access_token: z.string(),
     token_type: z.string(),
     scope: z.string().optional(),
+    expires_in: z.number().optional(),
+    refresh_token: z.string().optional(),
+    refresh_token_expires_in: z.number().optional(),
   }),
   z.object({
     error: z.string(),
@@ -91,7 +94,13 @@ const accessTokenResponseSchema = z.union([
 ]);
 
 export type AccessTokenPollResult =
-  | { status: "success"; accessToken: string }
+  | {
+      status: "success";
+      accessToken: string;
+      refreshToken: string | null;
+      expiresAt: number | null;
+      refreshTokenExpiresAt: number | null;
+    }
   | { status: "pending" }
   | { status: "slow_down"; interval: number };
 
@@ -137,7 +146,20 @@ export async function pollForAccessToken(input: {
   }
 
   if ("access_token" in payload.data) {
-    return { status: "success", accessToken: payload.data.access_token };
+    const now = Date.now();
+    return {
+      status: "success",
+      accessToken: payload.data.access_token,
+      refreshToken: payload.data.refresh_token ?? null,
+      expiresAt:
+        typeof payload.data.expires_in === "number"
+          ? now + payload.data.expires_in * 1000
+          : null,
+      refreshTokenExpiresAt:
+        typeof payload.data.refresh_token_expires_in === "number"
+          ? now + payload.data.refresh_token_expires_in * 1000
+          : null,
+    };
   }
 
   if (payload.data.error === "authorization_pending") {

--- a/src/github/auth.ts
+++ b/src/github/auth.ts
@@ -186,6 +186,112 @@ export async function pollForAccessToken(input: {
   );
 }
 
+export type RefreshTokenErrorKind = "terminal" | "transient";
+
+export class RefreshTokenError extends Error {
+  constructor(
+    public readonly kind: RefreshTokenErrorKind,
+    public readonly code: string,
+    message?: string,
+  ) {
+    super(message ?? `Refresh token error: ${code}`);
+    this.name = "RefreshTokenError";
+  }
+}
+
+const TERMINAL_REFRESH_ERRORS = new Set<string>([
+  "bad_refresh_token",
+  "unauthorized_client",
+  "invalid_grant",
+  "unsupported_grant_type",
+]);
+
+export type RefreshTokenResult = {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresAt: number | null;
+  refreshTokenExpiresAt: number | null;
+};
+
+export async function refreshAccessToken(input: {
+  clientId: string;
+  refreshToken: string;
+  signal?: AbortSignal;
+}): Promise<RefreshTokenResult> {
+  let response: Response;
+  try {
+    response = await fetch("https://github.com/login/oauth/access_token", {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: input.clientId,
+        grant_type: "refresh_token",
+        refresh_token: input.refreshToken,
+      }).toString(),
+      signal: input.signal,
+    });
+  } catch (cause) {
+    throw new RefreshTokenError(
+      "transient",
+      "network_error",
+      cause instanceof Error ? cause.message : undefined,
+    );
+  }
+
+  if (!response.ok) {
+    throw new RefreshTokenError(
+      "transient",
+      "network_error",
+      `Refresh request failed with status ${response.status}.`,
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch (cause) {
+    throw new RefreshTokenError(
+      "transient",
+      "invalid_response",
+      cause instanceof Error ? cause.message : undefined,
+    );
+  }
+
+  const parsed = accessTokenResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new RefreshTokenError(
+      "transient",
+      "invalid_response",
+      "Malformed refresh-token response.",
+    );
+  }
+
+  if ("access_token" in parsed.data) {
+    const now = Date.now();
+    return {
+      accessToken: parsed.data.access_token,
+      refreshToken: parsed.data.refresh_token ?? null,
+      expiresAt:
+        typeof parsed.data.expires_in === "number"
+          ? now + parsed.data.expires_in * 1000
+          : null,
+      refreshTokenExpiresAt:
+        typeof parsed.data.refresh_token_expires_in === "number"
+          ? now + parsed.data.refresh_token_expires_in * 1000
+          : null,
+    };
+  }
+
+  const code = parsed.data.error;
+  const kind: RefreshTokenErrorKind = TERMINAL_REFRESH_ERRORS.has(code)
+    ? "terminal"
+    : "transient";
+  throw new RefreshTokenError(kind, code, parsed.data.error_description);
+}
+
 function createAuthHeaders(token: string): Headers {
   return new Headers({
     Accept: "application/vnd.github+json",

--- a/src/storage/accounts.ts
+++ b/src/storage/accounts.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
 const SETTINGS_KEY = "settings";
+const ACCOUNT_PROFILE_KEY_PREFIX = "account:profile:";
+const ACCOUNT_AUTH_KEY_PREFIX = "account:auth:";
+const ACCOUNT_INSTALLATIONS_KEY_PREFIX = "account:installations:";
 
 const installationSchema = z.object({
   id: z.number().int().positive(),
@@ -13,14 +16,15 @@ const installationSchema = z.object({
   repoFullNames: z.array(z.string()).nullable(),
 });
 
-const accountSchema = z.object({
+const accountProfileSchema = z.object({
   id: z.string(),
   login: z.string(),
   avatarUrl: z.string().url().nullable(),
-  token: z.string(),
   createdAt: z.number(),
-  installations: z.array(installationSchema),
-  installationsRefreshedAt: z.number(),
+});
+
+const accountAuthSchema = z.object({
+  token: z.string(),
   invalidated: z.boolean().default(false),
   invalidatedReason: z
     .enum(["revoked", "expired", "refresh_failed", "unknown"])
@@ -31,10 +35,21 @@ const accountSchema = z.object({
   refreshTokenExpiresAt: z.number().nullable().default(null),
 });
 
-const extensionSettingsSchemaV3 = z.object({
-  version: z.literal(3),
-  accounts: z.array(accountSchema),
+const accountInstallationsSchema = z.object({
+  installations: z.array(installationSchema),
+  installationsRefreshedAt: z.number(),
 });
+
+const accountSchema = accountProfileSchema
+  .merge(accountAuthSchema)
+  .merge(accountInstallationsSchema);
+
+const extensionSettingsSchemaV4 = z.object({
+  version: z.literal(4),
+  accountIds: z.array(z.string()),
+});
+
+const legacyAccountSchemaV3 = accountSchema;
 
 const legacyAccountSchemaV2 = z.object({
   id: z.string(),
@@ -51,6 +66,11 @@ const legacyAccountSchemaV2 = z.object({
     .default(null),
 });
 
+const extensionSettingsSchemaV3 = z.object({
+  version: z.literal(3),
+  accounts: z.array(legacyAccountSchemaV3),
+});
+
 const extensionSettingsSchemaV2 = z.object({
   version: z.literal(2),
   accounts: z.array(legacyAccountSchemaV2),
@@ -58,98 +78,235 @@ const extensionSettingsSchemaV2 = z.object({
 
 export type Installation = z.infer<typeof installationSchema>;
 export type Account = z.infer<typeof accountSchema>;
-export type ExtensionSettings = z.infer<typeof extensionSettingsSchemaV3>;
+export type ExtensionSettings = z.infer<typeof extensionSettingsSchemaV4>;
 
-const EMPTY_SETTINGS: ExtensionSettings = { version: 3, accounts: [] };
+const EMPTY_SETTINGS: ExtensionSettings = { version: 4, accountIds: [] };
 
-export async function getSettings(): Promise<ExtensionSettings> {
-  const result = await browser.storage.local.get(SETTINGS_KEY);
-  const raw = result[SETTINGS_KEY];
+function accountProfileKey(accountId: string): string {
+  return `${ACCOUNT_PROFILE_KEY_PREFIX}${accountId}`;
+}
 
-  const v3 = extensionSettingsSchemaV3.safeParse(raw);
-  if (v3.success) {
-    return v3.data;
+function accountAuthKey(accountId: string): string {
+  return `${ACCOUNT_AUTH_KEY_PREFIX}${accountId}`;
+}
+
+function accountInstallationsKey(accountId: string): string {
+  return `${ACCOUNT_INSTALLATIONS_KEY_PREFIX}${accountId}`;
+}
+
+function accountStorageKeys(accountId: string): [string, string, string] {
+  return [
+    accountProfileKey(accountId),
+    accountAuthKey(accountId),
+    accountInstallationsKey(accountId),
+  ];
+}
+
+function decomposeAccount(account: Account) {
+  return {
+    profile: {
+      id: account.id,
+      login: account.login,
+      avatarUrl: account.avatarUrl,
+      createdAt: account.createdAt,
+    },
+    auth: {
+      token: account.token,
+      invalidated: account.invalidated,
+      invalidatedReason: account.invalidatedReason,
+      refreshToken: account.refreshToken,
+      expiresAt: account.expiresAt,
+      refreshTokenExpiresAt: account.refreshTokenExpiresAt,
+    },
+    installations: {
+      installations: account.installations,
+      installationsRefreshedAt: account.installationsRefreshedAt,
+    },
+  };
+}
+
+function composeAccount(input: {
+  profile: unknown;
+  auth: unknown;
+  installations: unknown;
+}): Account | null {
+  const profile = accountProfileSchema.safeParse(input.profile);
+  const auth = accountAuthSchema.safeParse(input.auth);
+  const installations = accountInstallationsSchema.safeParse(input.installations);
+
+  if (!profile.success || !auth.success || !installations.success) {
+    return null;
   }
 
-  const v2 = extensionSettingsSchemaV2.safeParse(raw);
-  if (v2.success) {
-    const migrated: ExtensionSettings = {
-      version: 3,
-      accounts: v2.data.accounts.map((account) => ({
-        ...account,
-        refreshToken: null,
-        expiresAt: null,
-        refreshTokenExpiresAt: null,
-      })),
-    };
-    await writeSettings(migrated);
-    return migrated;
-  }
-
-  return EMPTY_SETTINGS;
+  return {
+    ...profile.data,
+    ...auth.data,
+    ...installations.data,
+  };
 }
 
 async function writeSettings(settings: ExtensionSettings): Promise<void> {
   await browser.storage.local.set({ [SETTINGS_KEY]: settings });
 }
 
+async function writeAccounts(
+  settings: ExtensionSettings,
+  accounts: Account[],
+): Promise<void> {
+  const payload: Record<string, unknown> = {
+    [SETTINGS_KEY]: settings,
+  };
+
+  for (const account of accounts) {
+    const fragments = decomposeAccount(account);
+    payload[accountProfileKey(account.id)] = fragments.profile;
+    payload[accountAuthKey(account.id)] = fragments.auth;
+    payload[accountInstallationsKey(account.id)] = fragments.installations;
+  }
+
+  await browser.storage.local.set(payload);
+}
+
+async function migrateAccounts(accounts: Account[]): Promise<ExtensionSettings> {
+  const settings: ExtensionSettings = {
+    version: 4,
+    accountIds: accounts.map((account) => account.id),
+  };
+  await writeAccounts(settings, accounts);
+  return settings;
+}
+
+async function loadAccountsByIds(accountIds: string[]): Promise<{
+  accounts: Account[];
+  validIds: string[];
+}> {
+  if (accountIds.length === 0) {
+    return { accounts: [], validIds: [] };
+  }
+
+  const result = await browser.storage.local.get(
+    accountIds.flatMap((accountId) => accountStorageKeys(accountId)),
+  );
+
+  const accounts: Account[] = [];
+  const validIds: string[] = [];
+  for (const accountId of accountIds) {
+    const account = composeAccount({
+      profile: result[accountProfileKey(accountId)],
+      auth: result[accountAuthKey(accountId)],
+      installations: result[accountInstallationsKey(accountId)],
+    });
+    if (account == null) {
+      continue;
+    }
+    accounts.push(account);
+    validIds.push(accountId);
+  }
+
+  return { accounts, validIds };
+}
+
+export async function getSettings(): Promise<ExtensionSettings> {
+  const result = await browser.storage.local.get(SETTINGS_KEY);
+  const raw = result[SETTINGS_KEY];
+
+  const v4 = extensionSettingsSchemaV4.safeParse(raw);
+  if (v4.success) {
+    return v4.data;
+  }
+
+  const v3 = extensionSettingsSchemaV3.safeParse(raw);
+  if (v3.success) {
+    return migrateAccounts(v3.data.accounts);
+  }
+
+  const v2 = extensionSettingsSchemaV2.safeParse(raw);
+  if (v2.success) {
+    return migrateAccounts(
+      v2.data.accounts.map((account) => ({
+        ...account,
+        refreshToken: null,
+        expiresAt: null,
+        refreshTokenExpiresAt: null,
+      })),
+    );
+  }
+
+  return EMPTY_SETTINGS;
+}
+
 export async function listAccounts(): Promise<Account[]> {
   const settings = await getSettings();
-  return [...settings.accounts].sort((a, b) => a.createdAt - b.createdAt);
+  const { accounts, validIds } = await loadAccountsByIds(settings.accountIds);
+  if (validIds.length !== settings.accountIds.length) {
+    await writeSettings({ version: 4, accountIds: validIds });
+  }
+  return [...accounts].sort((a, b) => a.createdAt - b.createdAt);
+}
+
+export async function getAccountById(accountId: string): Promise<Account | null> {
+  const result = await browser.storage.local.get(accountStorageKeys(accountId));
+  return composeAccount({
+    profile: result[accountProfileKey(accountId)],
+    auth: result[accountAuthKey(accountId)],
+    installations: result[accountInstallationsKey(accountId)],
+  });
 }
 
 export async function addAccount(account: Account): Promise<void> {
   const settings = await getSettings();
   const next: ExtensionSettings = {
-    version: 3,
-    accounts: [...settings.accounts, account],
+    version: 4,
+    accountIds: [...settings.accountIds.filter((id) => id !== account.id), account.id],
   };
-  await writeSettings(next);
+  await writeAccounts(next, [account]);
 }
 
 export async function removeAccount(id: string): Promise<void> {
   const settings = await getSettings();
   const next: ExtensionSettings = {
-    version: 3,
-    accounts: settings.accounts.filter((account) => account.id !== id),
+    version: 4,
+    accountIds: settings.accountIds.filter((accountId) => accountId !== id),
   };
   await writeSettings(next);
+  await browser.storage.local.remove(accountStorageKeys(id));
 }
 
 export async function replaceInstallations(
   accountId: string,
   installations: Installation[],
 ): Promise<void> {
-  const settings = await getSettings();
-  const next: ExtensionSettings = {
-    version: 3,
-    accounts: settings.accounts.map((account) =>
-      account.id === accountId
-        ? {
-            ...account,
-            installations,
-            installationsRefreshedAt: Date.now(),
-          }
-        : account,
-    ),
-  };
-  await writeSettings(next);
+  const result = await browser.storage.local.get(accountInstallationsKey(accountId));
+  const parsed = accountInstallationsSchema.safeParse(result[accountInstallationsKey(accountId)]);
+  if (!parsed.success) {
+    return;
+  }
+
+  await browser.storage.local.set({
+    [accountInstallationsKey(accountId)]: {
+      installations,
+      installationsRefreshedAt: Date.now(),
+    },
+  });
 }
 
 export async function markAccountInvalidated(
   accountId: string,
   reason: "revoked" | "expired" | "refresh_failed" | "unknown",
 ): Promise<void> {
-  const settings = await getSettings();
-  const next: ExtensionSettings = {
-    version: 3,
-    accounts: settings.accounts.map((account) =>
-      account.id === accountId
-        ? { ...account, invalidated: true, invalidatedReason: reason }
-        : account,
-    ),
-  };
-  await writeSettings(next);
+  const result = await browser.storage.local.get(accountAuthKey(accountId));
+  const parsed = accountAuthSchema.safeParse(result[accountAuthKey(accountId)]);
+  if (!parsed.success) {
+    return;
+  }
+
+  await browser.storage.local.set({
+    [accountAuthKey(accountId)]: {
+      ...parsed.data,
+      invalidated: true,
+      invalidatedReason: reason,
+    },
+  });
 }
 
 export async function updateAccountTokens(
@@ -161,22 +318,21 @@ export async function updateAccountTokens(
     refreshTokenExpiresAt: number | null;
   },
 ): Promise<void> {
-  const settings = await getSettings();
-  const next: ExtensionSettings = {
-    version: 3,
-    accounts: settings.accounts.map((account) =>
-      account.id === accountId
-        ? {
-            ...account,
-            token: tokens.token,
-            refreshToken: tokens.refreshToken,
-            expiresAt: tokens.expiresAt,
-            refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
-          }
-        : account,
-    ),
-  };
-  await writeSettings(next);
+  const result = await browser.storage.local.get(accountAuthKey(accountId));
+  const parsed = accountAuthSchema.safeParse(result[accountAuthKey(accountId)]);
+  if (!parsed.success) {
+    return;
+  }
+
+  await browser.storage.local.set({
+    [accountAuthKey(accountId)]: {
+      ...parsed.data,
+      token: tokens.token,
+      refreshToken: tokens.refreshToken,
+      expiresAt: tokens.expiresAt,
+      refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
+    },
+  });
 }
 
 export async function resolveAccountForRepo(

--- a/src/storage/accounts.ts
+++ b/src/storage/accounts.ts
@@ -23,26 +23,70 @@ const accountSchema = z.object({
   installationsRefreshedAt: z.number(),
   invalidated: z.boolean().default(false),
   invalidatedReason: z
+    .enum(["revoked", "expired", "refresh_failed", "unknown"])
+    .nullable()
+    .default(null),
+  refreshToken: z.string().nullable().default(null),
+  expiresAt: z.number().nullable().default(null),
+  refreshTokenExpiresAt: z.number().nullable().default(null),
+});
+
+const extensionSettingsSchemaV3 = z.object({
+  version: z.literal(3),
+  accounts: z.array(accountSchema),
+});
+
+const legacyAccountSchemaV2 = z.object({
+  id: z.string(),
+  login: z.string(),
+  avatarUrl: z.string().url().nullable(),
+  token: z.string(),
+  createdAt: z.number(),
+  installations: z.array(installationSchema),
+  installationsRefreshedAt: z.number(),
+  invalidated: z.boolean().default(false),
+  invalidatedReason: z
     .enum(["revoked", "expired", "unknown"])
     .nullable()
     .default(null),
 });
 
-const extensionSettingsSchema = z.object({
+const extensionSettingsSchemaV2 = z.object({
   version: z.literal(2),
-  accounts: z.array(accountSchema),
+  accounts: z.array(legacyAccountSchemaV2),
 });
 
 export type Installation = z.infer<typeof installationSchema>;
 export type Account = z.infer<typeof accountSchema>;
-export type ExtensionSettings = z.infer<typeof extensionSettingsSchema>;
+export type ExtensionSettings = z.infer<typeof extensionSettingsSchemaV3>;
 
-const EMPTY_SETTINGS: ExtensionSettings = { version: 2, accounts: [] };
+const EMPTY_SETTINGS: ExtensionSettings = { version: 3, accounts: [] };
 
 export async function getSettings(): Promise<ExtensionSettings> {
   const result = await browser.storage.local.get(SETTINGS_KEY);
-  const parsed = extensionSettingsSchema.safeParse(result[SETTINGS_KEY]);
-  return parsed.success ? parsed.data : EMPTY_SETTINGS;
+  const raw = result[SETTINGS_KEY];
+
+  const v3 = extensionSettingsSchemaV3.safeParse(raw);
+  if (v3.success) {
+    return v3.data;
+  }
+
+  const v2 = extensionSettingsSchemaV2.safeParse(raw);
+  if (v2.success) {
+    const migrated: ExtensionSettings = {
+      version: 3,
+      accounts: v2.data.accounts.map((account) => ({
+        ...account,
+        refreshToken: null,
+        expiresAt: null,
+        refreshTokenExpiresAt: null,
+      })),
+    };
+    await writeSettings(migrated);
+    return migrated;
+  }
+
+  return EMPTY_SETTINGS;
 }
 
 async function writeSettings(settings: ExtensionSettings): Promise<void> {
@@ -57,7 +101,7 @@ export async function listAccounts(): Promise<Account[]> {
 export async function addAccount(account: Account): Promise<void> {
   const settings = await getSettings();
   const next: ExtensionSettings = {
-    version: 2,
+    version: 3,
     accounts: [...settings.accounts, account],
   };
   await writeSettings(next);
@@ -66,7 +110,7 @@ export async function addAccount(account: Account): Promise<void> {
 export async function removeAccount(id: string): Promise<void> {
   const settings = await getSettings();
   const next: ExtensionSettings = {
-    version: 2,
+    version: 3,
     accounts: settings.accounts.filter((account) => account.id !== id),
   };
   await writeSettings(next);
@@ -78,7 +122,7 @@ export async function replaceInstallations(
 ): Promise<void> {
   const settings = await getSettings();
   const next: ExtensionSettings = {
-    version: 2,
+    version: 3,
     accounts: settings.accounts.map((account) =>
       account.id === accountId
         ? {
@@ -94,14 +138,41 @@ export async function replaceInstallations(
 
 export async function markAccountInvalidated(
   accountId: string,
-  reason: "revoked" | "expired" | "unknown",
+  reason: "revoked" | "expired" | "refresh_failed" | "unknown",
 ): Promise<void> {
   const settings = await getSettings();
   const next: ExtensionSettings = {
-    version: 2,
+    version: 3,
     accounts: settings.accounts.map((account) =>
       account.id === accountId
         ? { ...account, invalidated: true, invalidatedReason: reason }
+        : account,
+    ),
+  };
+  await writeSettings(next);
+}
+
+export async function updateAccountTokens(
+  accountId: string,
+  tokens: {
+    token: string;
+    refreshToken: string | null;
+    expiresAt: number | null;
+    refreshTokenExpiresAt: number | null;
+  },
+): Promise<void> {
+  const settings = await getSettings();
+  const next: ExtensionSettings = {
+    version: 3,
+    accounts: settings.accounts.map((account) =>
+      account.id === accountId
+        ? {
+            ...account,
+            token: tokens.token,
+            refreshToken: tokens.refreshToken,
+            expiresAt: tokens.expiresAt,
+            refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
+          }
         : account,
     ),
   };

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 const PREFERENCES_KEY = "preferences";
 const SETTINGS_KEY = "settings";
+const ACCOUNT_KEY_PREFIX = "account:";
 
 const preferencesSchema = z.object({
   version: z.literal(1),
@@ -43,5 +44,7 @@ export function isPreferencesChange(
 export function isAccountsChange(
   changes: Record<string, StorageChange>,
 ): boolean {
-  return SETTINGS_KEY in changes;
+  return Object.keys(changes).some(
+    (key) => key === SETTINGS_KEY || key.startsWith(ACCOUNT_KEY_PREFIX),
+  );
 }

--- a/tests/accounts.migration.test.ts
+++ b/tests/accounts.migration.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type StorageShape = Record<string, unknown>;
+
+function createBrowserMock() {
+  let storage: StorageShape = {};
+  const get = vi.fn(async (key?: string) => {
+    if (typeof key === "string") {
+      return key in storage ? { [key]: storage[key] } : {};
+    }
+    return { ...storage };
+  });
+  const set = vi.fn(async (items: StorageShape) => {
+    storage = { ...storage, ...items };
+  });
+  return {
+    browser: { storage: { local: { get, set } } },
+    snapshot: () => ({ ...storage }),
+    seed(value: unknown) {
+      storage = { settings: value };
+    },
+  };
+}
+
+let browserMock: ReturnType<typeof createBrowserMock>;
+
+beforeEach(() => {
+  vi.resetModules();
+  browserMock = createBrowserMock();
+  vi.stubGlobal("browser", browserMock.browser);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("settings migration v2 -> v3", () => {
+  it("rewrites a v2 settings shape to v3 with null token-lifetime fields", async () => {
+    browserMock.seed({
+      version: 2,
+      accounts: [
+        {
+          id: "acc-1",
+          login: "hon454",
+          avatarUrl: null,
+          token: "ghu_old",
+          createdAt: 1,
+          installations: [],
+          installationsRefreshedAt: 1,
+          invalidated: false,
+          invalidatedReason: null,
+        },
+      ],
+    });
+
+    const { getSettings } = await import("../src/storage/accounts");
+    const settings = await getSettings();
+
+    expect(settings.version).toBe(3);
+    expect(settings.accounts).toHaveLength(1);
+    expect(settings.accounts[0]).toMatchObject({
+      id: "acc-1",
+      token: "ghu_old",
+      refreshToken: null,
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
+    });
+
+    expect(browserMock.snapshot().settings).toMatchObject({ version: 3 });
+  });
+
+  it("returns an empty v3 settings shape when storage is empty", async () => {
+    const { getSettings } = await import("../src/storage/accounts");
+    await expect(getSettings()).resolves.toEqual({ version: 3, accounts: [] });
+  });
+
+  it("loads a v3 shape unchanged", async () => {
+    browserMock.seed({
+      version: 3,
+      accounts: [
+        {
+          id: "acc-1",
+          login: "hon454",
+          avatarUrl: null,
+          token: "ghu_x",
+          createdAt: 1,
+          installations: [],
+          installationsRefreshedAt: 1,
+          invalidated: false,
+          invalidatedReason: null,
+          refreshToken: "ghr_x",
+          expiresAt: 1234,
+          refreshTokenExpiresAt: 5678,
+        },
+      ],
+    });
+
+    const { getSettings } = await import("../src/storage/accounts");
+    const settings = await getSettings();
+    expect(settings.version).toBe(3);
+    expect(settings.accounts[0].refreshToken).toBe("ghr_x");
+  });
+});
+
+describe("updateAccountTokens", () => {
+  it("replaces the four token fields without touching invalidation state", async () => {
+    const { addAccount, updateAccountTokens, listAccounts } = await import(
+      "../src/storage/accounts"
+    );
+
+    await addAccount({
+      id: "acc-1",
+      login: "hon454",
+      avatarUrl: null,
+      token: "ghu_old",
+      createdAt: 1,
+      installations: [],
+      installationsRefreshedAt: 1,
+      invalidated: false,
+      invalidatedReason: null,
+      refreshToken: "ghr_old",
+      expiresAt: 100,
+      refreshTokenExpiresAt: 200,
+    });
+
+    await updateAccountTokens("acc-1", {
+      token: "ghu_new",
+      refreshToken: "ghr_new",
+      expiresAt: 999,
+      refreshTokenExpiresAt: 1999,
+    });
+
+    const [account] = await listAccounts();
+    expect(account).toMatchObject({
+      token: "ghu_new",
+      refreshToken: "ghr_new",
+      expiresAt: 999,
+      refreshTokenExpiresAt: 1999,
+      invalidated: false,
+      invalidatedReason: null,
+    });
+  });
+});

--- a/tests/accounts.migration.test.ts
+++ b/tests/accounts.migration.test.ts
@@ -4,17 +4,27 @@ type StorageShape = Record<string, unknown>;
 
 function createBrowserMock() {
   let storage: StorageShape = {};
-  const get = vi.fn(async (key?: string) => {
+  const get = vi.fn(async (key?: string | string[] | Record<string, unknown>) => {
     if (typeof key === "string") {
       return key in storage ? { [key]: storage[key] } : {};
+    }
+    if (Array.isArray(key)) {
+      return Object.fromEntries(
+        key.filter((entry) => entry in storage).map((entry) => [entry, storage[entry]]),
+      );
     }
     return { ...storage };
   });
   const set = vi.fn(async (items: StorageShape) => {
     storage = { ...storage, ...items };
   });
+  const remove = vi.fn(async (keys: string | string[]) => {
+    for (const key of Array.isArray(keys) ? keys : [keys]) {
+      delete storage[key];
+    }
+  });
   return {
-    browser: { storage: { local: { get, set } } },
+    browser: { storage: { local: { get, set, remove } } },
     snapshot: () => ({ ...storage }),
     seed(value: unknown) {
       storage = { settings: value };
@@ -34,8 +44,8 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("settings migration v2 -> v3", () => {
-  it("rewrites a v2 settings shape to v3 with null token-lifetime fields", async () => {
+describe("settings migration", () => {
+  it("rewrites a v2 settings shape to v4 with a per-account storage entry", async () => {
     browserMock.seed({
       version: 2,
       accounts: [
@@ -56,49 +66,60 @@ describe("settings migration v2 -> v3", () => {
     const { getSettings } = await import("../src/storage/accounts");
     const settings = await getSettings();
 
-    expect(settings.version).toBe(3);
-    expect(settings.accounts).toHaveLength(1);
-    expect(settings.accounts[0]).toMatchObject({
-      id: "acc-1",
-      token: "ghu_old",
-      refreshToken: null,
-      expiresAt: null,
-      refreshTokenExpiresAt: null,
+    expect(settings).toEqual({ version: 4, accountIds: ["acc-1"] });
+    expect(browserMock.snapshot()).toMatchObject({
+      settings: { version: 4, accountIds: ["acc-1"] },
+      "account:profile:acc-1": {
+        id: "acc-1",
+        login: "hon454",
+      },
+      "account:auth:acc-1": {
+        token: "ghu_old",
+        refreshToken: null,
+        expiresAt: null,
+        refreshTokenExpiresAt: null,
+      },
+      "account:installations:acc-1": {
+        installations: [],
+      },
     });
-
-    expect(browserMock.snapshot().settings).toMatchObject({ version: 3 });
   });
 
-  it("returns an empty v3 settings shape when storage is empty", async () => {
+  it("returns an empty v4 settings shape when storage is empty", async () => {
     const { getSettings } = await import("../src/storage/accounts");
-    await expect(getSettings()).resolves.toEqual({ version: 3, accounts: [] });
+    await expect(getSettings()).resolves.toEqual({ version: 4, accountIds: [] });
   });
 
-  it("loads a v3 shape unchanged", async () => {
+  it("loads a v4 shape unchanged", async () => {
     browserMock.seed({
-      version: 3,
-      accounts: [
-        {
-          id: "acc-1",
-          login: "hon454",
-          avatarUrl: null,
-          token: "ghu_x",
-          createdAt: 1,
-          installations: [],
-          installationsRefreshedAt: 1,
-          invalidated: false,
-          invalidatedReason: null,
-          refreshToken: "ghr_x",
-          expiresAt: 1234,
-          refreshTokenExpiresAt: 5678,
-        },
-      ],
+      version: 4,
+      accountIds: ["acc-1"],
+    });
+    await browserMock.browser.storage.local.set({
+      "account:profile:acc-1": {
+        id: "acc-1",
+        login: "hon454",
+        avatarUrl: null,
+        createdAt: 1,
+      },
+      "account:auth:acc-1": {
+        token: "ghu_x",
+        invalidated: false,
+        invalidatedReason: null,
+        refreshToken: "ghr_x",
+        expiresAt: 1234,
+        refreshTokenExpiresAt: 5678,
+      },
+      "account:installations:acc-1": {
+        installations: [],
+        installationsRefreshedAt: 1,
+      },
     });
 
-    const { getSettings } = await import("../src/storage/accounts");
-    const settings = await getSettings();
-    expect(settings.version).toBe(3);
-    expect(settings.accounts[0].refreshToken).toBe("ghr_x");
+    const { getSettings, listAccounts } = await import("../src/storage/accounts");
+    await expect(getSettings()).resolves.toEqual({ version: 4, accountIds: ["acc-1"] });
+    const [account] = await listAccounts();
+    expect(account.refreshToken).toBe("ghr_x");
   });
 });
 
@@ -138,6 +159,57 @@ describe("updateAccountTokens", () => {
       refreshTokenExpiresAt: 1999,
       invalidated: false,
       invalidatedReason: null,
+    });
+  });
+
+  it("updates only the targeted account key", async () => {
+    const { addAccount, updateAccountTokens } = await import("../src/storage/accounts");
+
+    await addAccount({
+      id: "acc-1",
+      login: "hon454",
+      avatarUrl: null,
+      token: "ghu_old_1",
+      createdAt: 1,
+      installations: [],
+      installationsRefreshedAt: 1,
+      invalidated: false,
+      invalidatedReason: null,
+      refreshToken: "ghr_old_1",
+      expiresAt: 100,
+      refreshTokenExpiresAt: 200,
+    });
+    await addAccount({
+      id: "acc-2",
+      login: "hon454-work",
+      avatarUrl: null,
+      token: "ghu_old_2",
+      createdAt: 2,
+      installations: [],
+      installationsRefreshedAt: 2,
+      invalidated: false,
+      invalidatedReason: null,
+      refreshToken: "ghr_old_2",
+      expiresAt: 300,
+      refreshTokenExpiresAt: 400,
+    });
+
+    await updateAccountTokens("acc-1", {
+      token: "ghu_new_1",
+      refreshToken: "ghr_new_1",
+      expiresAt: 999,
+      refreshTokenExpiresAt: 1999,
+    });
+
+    expect(browserMock.snapshot()).toMatchObject({
+      "account:auth:acc-1": {
+        token: "ghu_new_1",
+        refreshToken: "ghr_new_1",
+      },
+      "account:auth:acc-2": {
+        token: "ghu_old_2",
+        refreshToken: "ghr_old_2",
+      },
     });
   });
 });

--- a/tests/accounts.test.ts
+++ b/tests/accounts.test.ts
@@ -74,6 +74,9 @@ describe("accounts storage", () => {
       installationsRefreshedAt: 1,
       invalidated: false,
       invalidatedReason: null,
+      refreshToken: null,
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
     });
     const accounts = await listAccounts();
     expect(accounts).toHaveLength(1);
@@ -94,6 +97,9 @@ describe("accounts storage", () => {
       installationsRefreshedAt: 1,
       invalidated: false,
       invalidatedReason: null,
+      refreshToken: null,
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
     });
     await removeAccount("acc-1");
     await expect(listAccounts()).resolves.toEqual([]);
@@ -113,6 +119,9 @@ describe("accounts storage", () => {
       installationsRefreshedAt: 1,
       invalidated: false,
       invalidatedReason: null,
+      refreshToken: null,
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
     });
     await replaceInstallations("acc-1", [
       {
@@ -142,6 +151,9 @@ describe("accounts storage", () => {
       installationsRefreshedAt: 1,
       invalidated: false,
       invalidatedReason: null,
+      refreshToken: null,
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
     });
     await markAccountInvalidated("acc-1", "revoked");
     const [account] = await listAccounts();

--- a/tests/accounts.test.ts
+++ b/tests/accounts.test.ts
@@ -39,15 +39,15 @@ afterEach(() => {
 });
 
 describe("accounts storage", () => {
-  it("returns an empty v2 settings shape when storage is empty", async () => {
+  it("returns an empty v3 settings shape when storage is empty", async () => {
     const { getSettings } = await import("../src/storage/accounts");
     await expect(getSettings()).resolves.toEqual({
-      version: 2,
+      version: 3,
       accounts: [],
     });
   });
 
-  it("overwrites legacy tokenEntries payloads with an empty v2 shape", async () => {
+  it("overwrites legacy tokenEntries payloads with an empty v3 shape", async () => {
     browserMock.browser.storage.local.get.mockResolvedValueOnce({
       settings: {
         tokenEntries: [
@@ -57,7 +57,7 @@ describe("accounts storage", () => {
     });
     const { getSettings } = await import("../src/storage/accounts");
     await expect(getSettings()).resolves.toEqual({
-      version: 2,
+      version: 3,
       accounts: [],
     });
   });
@@ -152,13 +152,13 @@ describe("accounts storage", () => {
   it("rejects malformed account payloads at read time by resetting to empty", async () => {
     browserMock.browser.storage.local.get.mockResolvedValueOnce({
       settings: {
-        version: 2,
+        version: 3,
         accounts: [{ id: 123, login: 456 }],
       },
     });
     const { getSettings } = await import("../src/storage/accounts");
     await expect(getSettings()).resolves.toEqual({
-      version: 2,
+      version: 3,
       accounts: [],
     });
   });
@@ -167,7 +167,7 @@ describe("accounts storage", () => {
 describe("resolveAccountForRepo", () => {
   async function seedAccounts(accounts: unknown[]) {
     browserMock.browser.storage.local.get.mockResolvedValue({
-      settings: { version: 2, accounts },
+      settings: { version: 3, accounts },
     });
   }
 

--- a/tests/accounts.test.ts
+++ b/tests/accounts.test.ts
@@ -8,15 +8,25 @@ function createBrowserMock() {
     if (typeof key === "string") {
       return key in storage ? { [key]: storage[key] } : {};
     }
+    if (Array.isArray(key)) {
+      return Object.fromEntries(
+        key.filter((entry) => entry in storage).map((entry) => [entry, storage[entry]]),
+      );
+    }
     return { ...storage };
   });
   const set = vi.fn(async (items: StorageShape) => {
     storage = { ...storage, ...items };
   });
+  const remove = vi.fn(async (keys: string | string[]) => {
+    for (const key of Array.isArray(keys) ? keys : [keys]) {
+      delete storage[key];
+    }
+  });
   return {
     browser: {
       storage: {
-        local: { get, set },
+        local: { get, set, remove },
       },
     },
     reset() {
@@ -39,15 +49,15 @@ afterEach(() => {
 });
 
 describe("accounts storage", () => {
-  it("returns an empty v3 settings shape when storage is empty", async () => {
+  it("returns an empty v4 settings shape when storage is empty", async () => {
     const { getSettings } = await import("../src/storage/accounts");
     await expect(getSettings()).resolves.toEqual({
-      version: 3,
-      accounts: [],
+      version: 4,
+      accountIds: [],
     });
   });
 
-  it("overwrites legacy tokenEntries payloads with an empty v3 shape", async () => {
+  it("overwrites legacy tokenEntries payloads with an empty v4 shape", async () => {
     browserMock.browser.storage.local.get.mockResolvedValueOnce({
       settings: {
         tokenEntries: [
@@ -57,8 +67,8 @@ describe("accounts storage", () => {
     });
     const { getSettings } = await import("../src/storage/accounts");
     await expect(getSettings()).resolves.toEqual({
-      version: 3,
-      accounts: [],
+      version: 4,
+      accountIds: [],
     });
   });
 
@@ -81,6 +91,19 @@ describe("accounts storage", () => {
     const accounts = await listAccounts();
     expect(accounts).toHaveLength(1);
     expect(accounts[0].login).toBe("hon454");
+    expect(browserMock.browser.storage.local.set).toHaveBeenCalledWith({
+      settings: { version: 4, accountIds: ["acc-1"] },
+      "account:profile:acc-1": expect.objectContaining({
+        id: "acc-1",
+        login: "hon454",
+      }),
+      "account:auth:acc-1": expect.objectContaining({
+        token: "ghu_abc",
+      }),
+      "account:installations:acc-1": expect.objectContaining({
+        installations: [],
+      }),
+    });
   });
 
   it("removeAccount drops the matching id", async () => {
@@ -164,23 +187,108 @@ describe("accounts storage", () => {
   it("rejects malformed account payloads at read time by resetting to empty", async () => {
     browserMock.browser.storage.local.get.mockResolvedValueOnce({
       settings: {
-        version: 3,
+        version: 4,
         accounts: [{ id: 123, login: 456 }],
       },
     });
     const { getSettings } = await import("../src/storage/accounts");
     await expect(getSettings()).resolves.toEqual({
-      version: 3,
-      accounts: [],
+      version: 4,
+      accountIds: [],
     });
   });
 });
 
 describe("resolveAccountForRepo", () => {
   async function seedAccounts(accounts: unknown[]) {
-    browserMock.browser.storage.local.get.mockResolvedValue({
-      settings: { version: 3, accounts },
-    });
+    const storage = Object.fromEntries(
+      accounts.flatMap((account) => {
+        const typed = account as {
+          id: string;
+          login: string;
+          avatarUrl: string | null;
+          token: string;
+          createdAt: number;
+          installations: unknown[];
+          installationsRefreshedAt: number;
+          invalidated: boolean;
+          invalidatedReason: string | null;
+          refreshToken: string | null;
+          expiresAt: number | null;
+          refreshTokenExpiresAt: number | null;
+        };
+        return [
+          [
+            `account:profile:${typed.id}`,
+            {
+              id: typed.id,
+              login: typed.login,
+              avatarUrl: typed.avatarUrl,
+              createdAt: typed.createdAt,
+            },
+          ],
+          [
+            `account:auth:${typed.id}`,
+            {
+              token: typed.token,
+              invalidated: typed.invalidated,
+              invalidatedReason: typed.invalidatedReason,
+              refreshToken: typed.refreshToken,
+              expiresAt: typed.expiresAt,
+              refreshTokenExpiresAt: typed.refreshTokenExpiresAt,
+            },
+          ],
+          [
+            `account:installations:${typed.id}`,
+            {
+              installations: typed.installations,
+              installationsRefreshedAt: typed.installationsRefreshedAt,
+            },
+          ],
+        ];
+      }),
+    );
+    browserMock.browser.storage.local.get.mockImplementation(
+      async (key?: string | string[] | Record<string, unknown>) => {
+        if (typeof key === "string") {
+          if (key === "settings") {
+            return {
+              settings: {
+                version: 4,
+                accountIds: accounts.map((account) => (account as { id: string }).id),
+              },
+            };
+          }
+          return key in storage ? { [key]: storage[key] } : {};
+        }
+        if (Array.isArray(key)) {
+          return Object.fromEntries(
+            key
+              .filter((entry) =>
+                entry === "settings" || entry in storage,
+              )
+              .map((entry) =>
+                entry === "settings"
+                  ? [
+                      "settings",
+                      {
+                        version: 4,
+                        accountIds: accounts.map((account) => (account as { id: string }).id),
+                      },
+                    ]
+                  : [entry, storage[entry]],
+              ),
+          );
+        }
+        return {
+          settings: {
+            version: 4,
+            accountIds: accounts.map((account) => (account as { id: string }).id),
+          },
+          ...storage,
+        };
+      },
+    );
   }
 
   function makeAccount(overrides: Partial<Record<string, unknown>> = {}) {
@@ -194,6 +302,9 @@ describe("resolveAccountForRepo", () => {
       installationsRefreshedAt: 1,
       invalidated: false,
       invalidatedReason: null,
+      refreshToken: null,
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
       ...overrides,
     };
   }

--- a/tests/auth.refresh.test.ts
+++ b/tests/auth.refresh.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RefreshTokenError, refreshAccessToken } from "../src/github/auth";
+
+function fixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(
+      new URL(`./fixtures/github-api/${name}`, import.meta.url),
+      "utf8",
+    ),
+  );
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-04-23T00:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("refreshAccessToken", () => {
+  it("posts grant_type=refresh_token and returns rotated tokens with absolute expiries", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(fixture("refresh-token-success.json")));
+
+    const result = await refreshAccessToken({
+      clientId: "Iv1.test",
+      refreshToken: "ghr_old",
+    });
+
+    expect(result).toEqual({
+      accessToken: "ghu_newaccess",
+      refreshToken: "ghr_newrefresh",
+      expiresAt: Date.UTC(2026, 3, 23, 0, 0, 0) + 28_800_000,
+      refreshTokenExpiresAt: Date.UTC(2026, 3, 23, 0, 0, 0) + 15_897_600_000,
+    });
+
+    const [[url, init]] = fetchMock.mock.calls;
+    expect(url).toBe("https://github.com/login/oauth/access_token");
+    expect(init?.method).toBe("POST");
+    const body = String(init?.body);
+    expect(body).toContain("client_id=Iv1.test");
+    expect(body).toContain("grant_type=refresh_token");
+    expect(body).toContain("refresh_token=ghr_old");
+  });
+
+  it("throws RefreshTokenError(terminal) for bad_refresh_token", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse(fixture("refresh-token-bad.json")),
+    );
+
+    await expect(
+      refreshAccessToken({ clientId: "Iv1.test", refreshToken: "ghr_old" }),
+    ).rejects.toMatchObject({
+      name: "RefreshTokenError",
+      kind: "terminal",
+      code: "bad_refresh_token",
+    });
+  });
+
+  it("throws RefreshTokenError(transient) on a 5xx response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("server down", { status: 503 }),
+    );
+
+    await expect(
+      refreshAccessToken({ clientId: "Iv1.test", refreshToken: "ghr_old" }),
+    ).rejects.toMatchObject({
+      name: "RefreshTokenError",
+      kind: "transient",
+    });
+  });
+
+  it("throws RefreshTokenError(transient) when fetch itself rejects", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("offline"));
+
+    await expect(
+      refreshAccessToken({ clientId: "Iv1.test", refreshToken: "ghr_old" }),
+    ).rejects.toMatchObject({
+      name: "RefreshTokenError",
+      kind: "transient",
+      code: "network_error",
+    });
+  });
+
+  it("throws RefreshTokenError(transient) for malformed JSON", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("<html>not json</html>", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(
+      refreshAccessToken({ clientId: "Iv1.test", refreshToken: "ghr_old" }),
+    ).rejects.toMatchObject({
+      name: "RefreshTokenError",
+      kind: "transient",
+    });
+  });
+
+  it("RefreshTokenError exposes name, kind, and code", () => {
+    const error = new RefreshTokenError("terminal", "bad_refresh_token");
+    expect(error.name).toBe("RefreshTokenError");
+    expect(error.kind).toBe("terminal");
+    expect(error.code).toBe("bad_refresh_token");
+    expect(error.message).toContain("bad_refresh_token");
+  });
+});

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -61,7 +61,32 @@ describe("pollForAccessToken", () => {
       clientId: "Iv1.test",
       deviceCode: "abc",
     });
-    expect(result).toEqual({ status: "success", accessToken: "ghu_exampletoken" });
+    expect(result).toEqual({
+      status: "success",
+      accessToken: "ghu_exampletoken",
+      refreshToken: null,
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
+    });
+  });
+
+  it("captures refresh fields and computes absolute expiry timestamps when present", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-23T00:00:00.000Z"));
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse(fixture("refresh-token-success.json")),
+    );
+    const result = await pollForAccessToken({
+      clientId: "Iv1.test",
+      deviceCode: "abc",
+    });
+    expect(result).toEqual({
+      status: "success",
+      accessToken: "ghu_newaccess",
+      refreshToken: "ghr_newrefresh",
+      expiresAt: Date.UTC(2026, 3, 23, 0, 0, 0) + 28_800_000,
+      refreshTokenExpiresAt: Date.UTC(2026, 3, 23, 0, 0, 0) + 15_897_600_000,
+    });
   });
 
   it("returns a pending status when authorization_pending", async () => {

--- a/tests/device-flow-controller.test.ts
+++ b/tests/device-flow-controller.test.ts
@@ -20,8 +20,10 @@ vi.mock("../src/github/auth", () => ({
   fetchInstallationRepositories: vi.fn(),
 }));
 
+const addAccountMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
 vi.mock("../src/storage/accounts", () => ({
-  addAccount: vi.fn().mockResolvedValue(undefined),
+  addAccount: addAccountMock,
   replaceInstallations: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -29,6 +31,7 @@ const auth = await import("../src/github/auth");
 
 beforeEach(() => {
   vi.useFakeTimers();
+  addAccountMock.mockClear();
 });
 
 afterEach(() => {
@@ -63,6 +66,9 @@ describe("useDeviceFlowController", () => {
     (auth.pollForAccessToken as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       status: "success",
       accessToken: "ghu_token",
+      refreshToken: "ghr_token",
+      expiresAt: 1_000_000,
+      refreshTokenExpiresAt: 2_000_000,
     });
     (auth.fetchAuthenticatedUser as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       login: "hon454",
@@ -89,6 +95,14 @@ describe("useDeviceFlowController", () => {
 
     expect(onConnected).toHaveBeenCalled();
     expect(result.current.state.phase).toBe("connected");
+
+    expect(addAccountMock).toHaveBeenCalledTimes(1);
+    expect(addAccountMock.mock.calls[0][0]).toMatchObject({
+      token: "ghu_token",
+      refreshToken: "ghr_token",
+      expiresAt: 1_000_000,
+      refreshTokenExpiresAt: 2_000_000,
+    });
   });
 
   it("bumps the interval on slow_down", async () => {
@@ -223,6 +237,9 @@ describe("useDeviceFlowController", () => {
     (auth.pollForAccessToken as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       status: "success",
       accessToken: "ghu_token",
+      refreshToken: "ghr_token",
+      expiresAt: 1_000_000,
+      refreshTokenExpiresAt: 2_000_000,
     });
     (auth.fetchAuthenticatedUser as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       () =>

--- a/tests/fixtures/github-api/refresh-token-bad.json
+++ b/tests/fixtures/github-api/refresh-token-bad.json
@@ -1,0 +1,5 @@
+{
+  "error": "bad_refresh_token",
+  "error_description": "The refresh token is invalid.",
+  "error_uri": "https://docs.github.com/apps"
+}

--- a/tests/fixtures/github-api/refresh-token-success.json
+++ b/tests/fixtures/github-api/refresh-token-success.json
@@ -1,0 +1,8 @@
+{
+  "access_token": "ghu_newaccess",
+  "expires_in": 28800,
+  "refresh_token": "ghr_newrefresh",
+  "refresh_token_expires_in": 15897600,
+  "scope": "",
+  "token_type": "bearer"
+}

--- a/tests/options-page.test.ts
+++ b/tests/options-page.test.ts
@@ -149,6 +149,9 @@ describe("OptionsPage", () => {
         installationsRefreshedAt: 1,
         invalidated: false,
         invalidatedReason: null,
+        refreshToken: null,
+        expiresAt: null,
+        refreshTokenExpiresAt: null,
       },
     ]);
     await renderOptionsPage();

--- a/tests/options-page.test.ts
+++ b/tests/options-page.test.ts
@@ -10,6 +10,8 @@ type AccountsModuleType = typeof AccountsModule;
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 const listAccountsMock = vi.fn<() => Promise<Account[]>>(async () => []);
+const getAccountByIdMock = vi.fn<() => Promise<Account | null>>(async () => null);
+const replaceInstallationsMock = vi.fn(async () => {});
 
 const getPreferencesMock = vi.fn(async () => ({
   version: 1 as const,
@@ -30,7 +32,8 @@ vi.mock("../src/storage/accounts", async (importActual) => {
     listAccounts: listAccountsMock,
     addAccount: vi.fn(async () => {}),
     removeAccount: vi.fn(async () => {}),
-    replaceInstallations: vi.fn(async () => {}),
+    replaceInstallations: replaceInstallationsMock,
+    getAccountById: getAccountByIdMock,
     resolveAccountForRepo: vi.fn(async () => null),
   };
 });
@@ -95,13 +98,21 @@ beforeEach(() => {
   // auth mock call history leaks between tests unless cleared here.
   vi.clearAllMocks();
   listAccountsMock.mockReset();
+  getAccountByIdMock.mockReset();
+  replaceInstallationsMock.mockReset();
   listAccountsMock.mockResolvedValue([]);
+  getAccountByIdMock.mockResolvedValue(null);
   getPreferencesMock.mockClear();
   updatePreferencesMock.mockClear();
   getPreferencesMock.mockResolvedValue({
     version: 1,
     showStateBadge: true,
     showReviewerName: false,
+  });
+  vi.stubGlobal("browser", {
+    runtime: {
+      sendMessage: vi.fn(),
+    },
   });
 });
 
@@ -158,6 +169,87 @@ describe("OptionsPage", () => {
     expect(
       document.querySelector('[data-testid="account-card-hon454"]'),
     ).not.toBeNull();
+  });
+
+  it("refreshes installations after a 401 by requesting a new access token", async () => {
+    const account: Account = {
+      id: "acc",
+      login: "hon454",
+      avatarUrl: null,
+      token: "ghu_old",
+      createdAt: 1,
+      installations: [],
+      installationsRefreshedAt: 1,
+      invalidated: false,
+      invalidatedReason: null,
+      refreshToken: "ghr_old",
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
+    };
+    listAccountsMock.mockResolvedValue([account]);
+    getAccountByIdMock.mockResolvedValue({
+      ...account,
+      token: "ghu_new",
+      refreshToken: "ghr_new",
+    });
+
+    await renderOptionsPage();
+
+    const auth = await import("../src/github/auth");
+    const fetchUserInstallations =
+      auth.fetchUserInstallations as unknown as ReturnType<typeof vi.fn>;
+    const fetchInstallationRepositories =
+      auth.fetchInstallationRepositories as unknown as ReturnType<typeof vi.fn>;
+
+    fetchUserInstallations
+      .mockRejectedValueOnce(new Error("GET /user/installations failed with status 401."))
+      .mockResolvedValueOnce([
+        {
+          id: 42,
+          account: { login: "cinev", type: "Organization", avatarUrl: null },
+          repositorySelection: "selected",
+        },
+      ]);
+    fetchInstallationRepositories.mockResolvedValueOnce(["cinev/shotloom"]);
+
+    const sendMessageMock = vi.fn().mockResolvedValue({ ok: true, token: "ghu_new" });
+    vi.stubGlobal("browser", {
+      runtime: {
+        sendMessage: sendMessageMock,
+      },
+    });
+
+    const refreshButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.trim() === "Refresh installations");
+    expect(refreshButton).toBeDefined();
+
+    await act(async () => {
+      refreshButton!.click();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledWith({
+      type: "refreshAccessToken",
+      accountId: "acc",
+    });
+    expect(fetchUserInstallations).toHaveBeenCalledTimes(2);
+    expect(fetchUserInstallations.mock.calls[1][0]).toMatchObject({
+      token: "ghu_new",
+    });
+    expect(fetchInstallationRepositories).toHaveBeenCalledWith({
+      token: "ghu_new",
+      installationId: 42,
+    });
+    expect(replaceInstallationsMock).toHaveBeenCalledWith("acc", [
+      {
+        id: 42,
+        account: { login: "cinev", type: "Organization", avatarUrl: null },
+        repositorySelection: "selected",
+        repoFullNames: ["cinev/shotloom"],
+      },
+    ]);
   });
 
   it("shows a configuration warning instead of blanking the page when production config is missing", async () => {

--- a/tests/preferences.test.ts
+++ b/tests/preferences.test.ts
@@ -97,6 +97,9 @@ describe("storage change classification", () => {
     expect(isAccountsChange({ settings: { oldValue: undefined, newValue: {} } })).toBe(
       true,
     );
+    expect(
+      isAccountsChange({ "account:acc-1": { oldValue: undefined, newValue: {} } }),
+    ).toBe(true);
     expect(isAccountsChange({ preferences: { oldValue: undefined, newValue: {} } })).toBe(
       false,
     );

--- a/tests/refresh-coordinator.test.ts
+++ b/tests/refresh-coordinator.test.ts
@@ -10,13 +10,13 @@ import type { Account } from "../src/storage/accounts";
 
 type AuthModule = typeof authModule;
 
-const listAccountsMock = vi.hoisted(() => vi.fn());
+const getAccountByIdMock = vi.hoisted(() => vi.fn());
 const updateAccountTokensMock = vi.hoisted(() => vi.fn());
 const markAccountInvalidatedMock = vi.hoisted(() => vi.fn());
 const refreshAccessTokenMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../src/storage/accounts", () => ({
-  listAccounts: listAccountsMock,
+  getAccountById: getAccountByIdMock,
   updateAccountTokens: updateAccountTokensMock,
   markAccountInvalidated: markAccountInvalidatedMock,
 }));
@@ -48,7 +48,7 @@ function makeAccount(overrides: Partial<Account> = {}): Account {
 }
 
 beforeEach(() => {
-  listAccountsMock.mockReset();
+  getAccountByIdMock.mockReset();
   updateAccountTokensMock.mockReset().mockResolvedValue(undefined);
   markAccountInvalidatedMock.mockReset().mockResolvedValue(undefined);
   refreshAccessTokenMock.mockReset();
@@ -60,7 +60,7 @@ afterEach(() => {
 
 describe("createRefreshCoordinator", () => {
   it("refreshes, updates storage, and returns the new token on success", async () => {
-    listAccountsMock.mockResolvedValue([makeAccount()]);
+    getAccountByIdMock.mockResolvedValue(makeAccount());
     const fresh: RefreshTokenResult = {
       accessToken: "ghu_new",
       refreshToken: "ghr_new",
@@ -83,7 +83,7 @@ describe("createRefreshCoordinator", () => {
   });
 
   it("dedupes concurrent calls for the same account into a single refresh", async () => {
-    listAccountsMock.mockResolvedValue([makeAccount()]);
+    getAccountByIdMock.mockResolvedValue(makeAccount());
     let resolveRefresh: (value: RefreshTokenResult) => void = () => {};
     refreshAccessTokenMock.mockImplementation(
       () =>
@@ -96,7 +96,7 @@ describe("createRefreshCoordinator", () => {
     const a = coordinator.refreshAccountToken("acc-1");
     const b = coordinator.refreshAccountToken("acc-1");
 
-    // Flush microtasks so listAccounts resolves and refreshAccessToken is called,
+    // Flush microtasks so getAccountById resolves and refreshAccessToken is called,
     // which populates resolveRefresh before we invoke it.
     await Promise.resolve();
     await Promise.resolve();
@@ -116,7 +116,7 @@ describe("createRefreshCoordinator", () => {
   });
 
   it("starts a fresh refresh after the previous one settles", async () => {
-    listAccountsMock.mockResolvedValue([makeAccount()]);
+    getAccountByIdMock.mockResolvedValue(makeAccount());
     refreshAccessTokenMock.mockResolvedValue({
       accessToken: "ghu_new",
       refreshToken: "ghr_new",
@@ -132,7 +132,7 @@ describe("createRefreshCoordinator", () => {
   });
 
   it("marks the account invalidated with refresh_failed on a terminal error", async () => {
-    listAccountsMock.mockResolvedValue([makeAccount()]);
+    getAccountByIdMock.mockResolvedValue(makeAccount());
     refreshAccessTokenMock.mockRejectedValue(
       new RefreshTokenError("terminal", "bad_refresh_token"),
     );
@@ -149,7 +149,7 @@ describe("createRefreshCoordinator", () => {
   });
 
   it("does NOT invalidate on a transient error", async () => {
-    listAccountsMock.mockResolvedValue([makeAccount()]);
+    getAccountByIdMock.mockResolvedValue(makeAccount());
     refreshAccessTokenMock.mockRejectedValue(
       new RefreshTokenError("transient", "network_error"),
     );
@@ -163,7 +163,7 @@ describe("createRefreshCoordinator", () => {
   });
 
   it("returns terminal=true without calling refresh when the account has no refresh token", async () => {
-    listAccountsMock.mockResolvedValue([makeAccount({ refreshToken: null })]);
+    getAccountByIdMock.mockResolvedValue(makeAccount({ refreshToken: null }));
 
     const coordinator = createRefreshCoordinator({ getClientId: () => "Iv1.test" });
     const outcome = await coordinator.refreshAccountToken("acc-1");
@@ -174,7 +174,7 @@ describe("createRefreshCoordinator", () => {
   });
 
   it("returns terminal=true when the account does not exist", async () => {
-    listAccountsMock.mockResolvedValue([]);
+    getAccountByIdMock.mockResolvedValue(null);
 
     const coordinator = createRefreshCoordinator({ getClientId: () => "Iv1.test" });
     const outcome = await coordinator.refreshAccountToken("missing");

--- a/tests/refresh-coordinator.test.ts
+++ b/tests/refresh-coordinator.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as authModule from "../src/github/auth";
+import {
+  RefreshTokenError,
+  type RefreshTokenResult,
+} from "../src/github/auth";
+import { createRefreshCoordinator } from "../src/auth/refresh-coordinator";
+import type { Account } from "../src/storage/accounts";
+
+type AuthModule = typeof authModule;
+
+const listAccountsMock = vi.hoisted(() => vi.fn());
+const updateAccountTokensMock = vi.hoisted(() => vi.fn());
+const markAccountInvalidatedMock = vi.hoisted(() => vi.fn());
+const refreshAccessTokenMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/storage/accounts", () => ({
+  listAccounts: listAccountsMock,
+  updateAccountTokens: updateAccountTokensMock,
+  markAccountInvalidated: markAccountInvalidatedMock,
+}));
+
+vi.mock("../src/github/auth", async () => {
+  const actual = await vi.importActual<AuthModule>("../src/github/auth");
+  return {
+    ...actual,
+    refreshAccessToken: refreshAccessTokenMock,
+  };
+});
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    id: "acc-1",
+    login: "hon454",
+    avatarUrl: null,
+    token: "ghu_old",
+    createdAt: 1,
+    installations: [],
+    installationsRefreshedAt: 1,
+    invalidated: false,
+    invalidatedReason: null,
+    refreshToken: "ghr_old",
+    expiresAt: null,
+    refreshTokenExpiresAt: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  listAccountsMock.mockReset();
+  updateAccountTokensMock.mockReset().mockResolvedValue(undefined);
+  markAccountInvalidatedMock.mockReset().mockResolvedValue(undefined);
+  refreshAccessTokenMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createRefreshCoordinator", () => {
+  it("refreshes, updates storage, and returns the new token on success", async () => {
+    listAccountsMock.mockResolvedValue([makeAccount()]);
+    const fresh: RefreshTokenResult = {
+      accessToken: "ghu_new",
+      refreshToken: "ghr_new",
+      expiresAt: 1234,
+      refreshTokenExpiresAt: 5678,
+    };
+    refreshAccessTokenMock.mockResolvedValue(fresh);
+
+    const coordinator = createRefreshCoordinator({ getClientId: () => "Iv1.test" });
+    const outcome = await coordinator.refreshAccountToken("acc-1");
+
+    expect(outcome).toEqual({ ok: true, token: "ghu_new" });
+    expect(updateAccountTokensMock).toHaveBeenCalledWith("acc-1", {
+      token: "ghu_new",
+      refreshToken: "ghr_new",
+      expiresAt: 1234,
+      refreshTokenExpiresAt: 5678,
+    });
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+  });
+
+  it("dedupes concurrent calls for the same account into a single refresh", async () => {
+    listAccountsMock.mockResolvedValue([makeAccount()]);
+    let resolveRefresh: (value: RefreshTokenResult) => void = () => {};
+    refreshAccessTokenMock.mockImplementation(
+      () =>
+        new Promise<RefreshTokenResult>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    const coordinator = createRefreshCoordinator({ getClientId: () => "Iv1.test" });
+    const a = coordinator.refreshAccountToken("acc-1");
+    const b = coordinator.refreshAccountToken("acc-1");
+
+    // Flush microtasks so listAccounts resolves and refreshAccessToken is called,
+    // which populates resolveRefresh before we invoke it.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    resolveRefresh({
+      accessToken: "ghu_new",
+      refreshToken: "ghr_new",
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
+    });
+
+    const [outcomeA, outcomeB] = await Promise.all([a, b]);
+    expect(outcomeA).toEqual({ ok: true, token: "ghu_new" });
+    expect(outcomeB).toEqual({ ok: true, token: "ghu_new" });
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(1);
+    expect(updateAccountTokensMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts a fresh refresh after the previous one settles", async () => {
+    listAccountsMock.mockResolvedValue([makeAccount()]);
+    refreshAccessTokenMock.mockResolvedValue({
+      accessToken: "ghu_new",
+      refreshToken: "ghr_new",
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
+    });
+
+    const coordinator = createRefreshCoordinator({ getClientId: () => "Iv1.test" });
+    await coordinator.refreshAccountToken("acc-1");
+    await coordinator.refreshAccountToken("acc-1");
+
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks the account invalidated with refresh_failed on a terminal error", async () => {
+    listAccountsMock.mockResolvedValue([makeAccount()]);
+    refreshAccessTokenMock.mockRejectedValue(
+      new RefreshTokenError("terminal", "bad_refresh_token"),
+    );
+
+    const coordinator = createRefreshCoordinator({ getClientId: () => "Iv1.test" });
+    const outcome = await coordinator.refreshAccountToken("acc-1");
+
+    expect(outcome).toEqual({ ok: false, terminal: true });
+    expect(markAccountInvalidatedMock).toHaveBeenCalledWith(
+      "acc-1",
+      "refresh_failed",
+    );
+    expect(updateAccountTokensMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT invalidate on a transient error", async () => {
+    listAccountsMock.mockResolvedValue([makeAccount()]);
+    refreshAccessTokenMock.mockRejectedValue(
+      new RefreshTokenError("transient", "network_error"),
+    );
+
+    const coordinator = createRefreshCoordinator({ getClientId: () => "Iv1.test" });
+    const outcome = await coordinator.refreshAccountToken("acc-1");
+
+    expect(outcome).toEqual({ ok: false, terminal: false });
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+    expect(updateAccountTokensMock).not.toHaveBeenCalled();
+  });
+
+  it("returns terminal=true without calling refresh when the account has no refresh token", async () => {
+    listAccountsMock.mockResolvedValue([makeAccount({ refreshToken: null })]);
+
+    const coordinator = createRefreshCoordinator({ getClientId: () => "Iv1.test" });
+    const outcome = await coordinator.refreshAccountToken("acc-1");
+
+    expect(outcome).toEqual({ ok: false, terminal: true });
+    expect(refreshAccessTokenMock).not.toHaveBeenCalled();
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+  });
+
+  it("returns terminal=true when the account does not exist", async () => {
+    listAccountsMock.mockResolvedValue([]);
+
+    const coordinator = createRefreshCoordinator({ getClientId: () => "Iv1.test" });
+    const outcome = await coordinator.refreshAccountToken("missing");
+
+    expect(outcome).toEqual({ ok: false, terminal: true });
+    expect(refreshAccessTokenMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -6,10 +6,10 @@ import type * as PreferencesModule from "../src/storage/preferences";
 
 const fetchPullReviewerSummaryMock = vi.fn();
 const resolveAccountForRepoMock = vi.fn();
+const getAccountByIdMock = vi.fn();
 const markAccountInvalidatedMock = vi.fn();
 const getPreferencesMock = vi.fn();
 const runtimeSendMessageMock = vi.fn();
-const updateAccountTokensMock = vi.fn();
 
 vi.mock("../src/github/api", () => ({
   fetchPullReviewerSummary: fetchPullReviewerSummaryMock,
@@ -17,8 +17,8 @@ vi.mock("../src/github/api", () => ({
 
 vi.mock("../src/storage/accounts", () => ({
   resolveAccountForRepo: resolveAccountForRepoMock,
+  getAccountById: getAccountByIdMock,
   markAccountInvalidated: markAccountInvalidatedMock,
-  updateAccountTokens: updateAccountTokensMock,
 }));
 
 vi.mock("../src/storage/preferences", async () => {
@@ -58,10 +58,10 @@ beforeEach(() => {
   vi.resetModules();
   fetchPullReviewerSummaryMock.mockReset();
   resolveAccountForRepoMock.mockReset();
+  getAccountByIdMock.mockReset();
   markAccountInvalidatedMock.mockReset();
   getPreferencesMock.mockReset();
   runtimeSendMessageMock.mockReset();
-  updateAccountTokensMock.mockReset();
   getPreferencesMock.mockResolvedValue({
     version: 1,
     showStateBadge: true,
@@ -208,13 +208,13 @@ describe("bootReviewerListPage", () => {
         login: "hon454",
         token: "ghu_old",
         refreshToken: "ghr_old",
-      })
-      .mockResolvedValueOnce({
-        id: "acc-1",
-        login: "hon454",
-        token: "ghu_new",
-        refreshToken: "ghr_new",
       });
+    getAccountByIdMock.mockResolvedValueOnce({
+      id: "acc-1",
+      login: "hon454",
+      token: "ghu_new",
+      refreshToken: "ghr_new",
+    });
 
     fetchPullReviewerSummaryMock
       .mockRejectedValueOnce({ status: 401 })
@@ -285,13 +285,13 @@ describe("bootReviewerListPage", () => {
         login: "hon454",
         token: "ghu_old",
         refreshToken: "ghr_old",
-      })
-      .mockResolvedValueOnce({
-        id: "acc-1",
-        login: "hon454",
-        token: "ghu_new",
-        refreshToken: "ghr_new",
       });
+    getAccountByIdMock.mockResolvedValueOnce({
+      id: "acc-1",
+      login: "hon454",
+      token: "ghu_new",
+      refreshToken: "ghr_new",
+    });
     fetchPullReviewerSummaryMock
       .mockRejectedValueOnce({ status: 401 })
       .mockRejectedValueOnce({ status: 401 });

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -8,6 +8,8 @@ const fetchPullReviewerSummaryMock = vi.fn();
 const resolveAccountForRepoMock = vi.fn();
 const markAccountInvalidatedMock = vi.fn();
 const getPreferencesMock = vi.fn();
+const runtimeSendMessageMock = vi.fn();
+const updateAccountTokensMock = vi.fn();
 
 vi.mock("../src/github/api", () => ({
   fetchPullReviewerSummary: fetchPullReviewerSummaryMock,
@@ -16,6 +18,7 @@ vi.mock("../src/github/api", () => ({
 vi.mock("../src/storage/accounts", () => ({
   resolveAccountForRepo: resolveAccountForRepoMock,
   markAccountInvalidated: markAccountInvalidatedMock,
+  updateAccountTokens: updateAccountTokensMock,
 }));
 
 vi.mock("../src/storage/preferences", async () => {
@@ -57,6 +60,8 @@ beforeEach(() => {
   resolveAccountForRepoMock.mockReset();
   markAccountInvalidatedMock.mockReset();
   getPreferencesMock.mockReset();
+  runtimeSendMessageMock.mockReset();
+  updateAccountTokensMock.mockReset();
   getPreferencesMock.mockResolvedValue({
     version: 1,
     showStateBadge: true,
@@ -73,6 +78,9 @@ beforeEach(() => {
         }),
         removeListener: vi.fn(),
       },
+    },
+    runtime: {
+      sendMessage: runtimeSendMessageMock,
     },
   });
 
@@ -93,11 +101,12 @@ afterEach(() => {
 });
 
 describe("bootReviewerListPage", () => {
-  it("invalidates the matched account when GitHub rejects it with 401", async () => {
+  it("marks the account revoked on 401 when there is no refresh token", async () => {
     resolveAccountForRepoMock.mockResolvedValue({
       id: "acc-1",
       login: "hon454",
       token: "ghu_abc",
+      refreshToken: null,
     });
     fetchPullReviewerSummaryMock.mockRejectedValue({ status: 401 });
 
@@ -108,6 +117,7 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
 
     expect(markAccountInvalidatedMock).toHaveBeenCalledWith("acc-1", "revoked");
+    expect(runtimeSendMessageMock).not.toHaveBeenCalled();
   });
 
   it("rerenders on preferences change without refetching reviewer data", async () => {
@@ -182,5 +192,118 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
 
     expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes the access token on 401 and retries with the new token", async () => {
+    const summary: PullReviewerSummary = {
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: [],
+      completedReviews: [],
+    };
+
+    resolveAccountForRepoMock
+      .mockResolvedValueOnce({
+        id: "acc-1",
+        login: "hon454",
+        token: "ghu_old",
+        refreshToken: "ghr_old",
+      })
+      .mockResolvedValueOnce({
+        id: "acc-1",
+        login: "hon454",
+        token: "ghu_new",
+        refreshToken: "ghr_new",
+      });
+
+    fetchPullReviewerSummaryMock
+      .mockRejectedValueOnce({ status: 401 })
+      .mockResolvedValueOnce(summary);
+
+    runtimeSendMessageMock.mockResolvedValueOnce({ ok: true, token: "ghu_new" });
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(runtimeSendMessageMock).toHaveBeenCalledWith({
+      type: "refreshAccessToken",
+      accountId: "acc-1",
+    });
+    expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(2);
+    expect(fetchPullReviewerSummaryMock.mock.calls[1][0]).toMatchObject({
+      githubToken: "ghu_new",
+    });
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+  });
+
+  it("does not invalidate when the BG refresh returns terminal=true (BG already marked the account)", async () => {
+    resolveAccountForRepoMock.mockResolvedValue({
+      id: "acc-1",
+      login: "hon454",
+      token: "ghu_old",
+      refreshToken: "ghr_old",
+    });
+    fetchPullReviewerSummaryMock.mockRejectedValue({ status: 401 });
+    runtimeSendMessageMock.mockResolvedValueOnce({ ok: false, terminal: true });
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+  });
+
+  it("does not invalidate on a transient refresh failure", async () => {
+    resolveAccountForRepoMock.mockResolvedValue({
+      id: "acc-1",
+      login: "hon454",
+      token: "ghu_old",
+      refreshToken: "ghr_old",
+    });
+    fetchPullReviewerSummaryMock.mockRejectedValue({ status: 401 });
+    runtimeSendMessageMock.mockResolvedValueOnce({ ok: false, terminal: false });
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+  });
+
+  it("marks the account revoked when the retry after refresh also returns 401", async () => {
+    resolveAccountForRepoMock
+      .mockResolvedValueOnce({
+        id: "acc-1",
+        login: "hon454",
+        token: "ghu_old",
+        refreshToken: "ghr_old",
+      })
+      .mockResolvedValueOnce({
+        id: "acc-1",
+        login: "hon454",
+        token: "ghu_new",
+        refreshToken: "ghr_new",
+      });
+    fetchPullReviewerSummaryMock
+      .mockRejectedValueOnce({ status: 401 })
+      .mockRejectedValueOnce({ status: 401 });
+    runtimeSendMessageMock.mockResolvedValueOnce({ ok: true, token: "ghu_new" });
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(markAccountInvalidatedMock).toHaveBeenCalledWith("acc-1", "revoked");
   });
 });


### PR DESCRIPTION
## Summary

- Persist GitHub App refresh-token metadata from Device Flow sign-in and refresh expired access tokens on 401.
- Coordinate refreshes through the background script and move account storage to v4 per-account fragments so token updates do not overwrite other accounts.
- Reuse the same refresh-and-retry behavior for both reviewer-list fetches and the options-page installation refresh flow.

## Why

GitHub App user-to-server access tokens expire after about 8 hours by default. Before this change, the extension dropped the refresh token on sign-in, so the first 401 after expiry invalidated the account and forced the user through Device Flow again. The initial implementation also stored all accounts in one `settings.accounts[]` blob, which made concurrent token refreshes vulnerable to lost updates.

## Changes

- **Auth flow:** `src/github/auth.ts` now captures refresh-token fields from the access-token response and adds `refreshAccessToken()` with terminal vs. transient refresh failure handling.
- **Storage model:** `src/storage/accounts.ts` now migrates to `extensionSettings` v4, keeps account ids in `settings`, and stores each account across `account:profile:*`, `account:auth:*`, and `account:installations:*` keys so account-scoped writes stay isolated.
- **Refresh coordinator:** `src/auth/refresh-coordinator.ts` still dedupes per account in-flight refreshes, but now reads and writes only the target account record.
- **Shared retry path:** `src/auth/account-token-refresh.ts` centralizes 401 refresh-and-retry behavior, invalidation rules, and retry-after-refresh handling.
- **Reviewer UI + options UI:** reviewer list fetches and options-page installation refreshes both use the shared refresh helper, so expired access tokens recover transparently in both flows.
- **Docs and diagnostics:** README, implementation notes, privacy policy, and manual Chrome testing docs now reflect refresh-token storage, v4 account storage, and the new manual refresh scenarios.

## Impact

- User-facing impact: signed-in users stay signed in across normal access-token expiry, and the options page installation refresh path now recovers from expired access tokens as well.
- API/schema impact: storage moved from `extensionSettings` v3 `accounts[]` to v4 `accountIds[]` plus per-account storage fragments; `refresh_failed` remains an explicit invalidation reason.
- Performance impact: the first request after expiry may pay one refresh round trip; subsequent requests reuse the refreshed token.
- Operational or rollout impact: v2/v3 account storage migrates automatically on first read; old builds that only understand the legacy schema should not be used after upgrading.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- Added or expanded automated coverage for refresh token exchange, v2/v3 -> v4 account storage migration, isolated account token updates, refresh coordinator behavior, reviewer-path retry, and options-page installation refresh retry.
- Ran `pnpm typecheck` and `pnpm test` locally after the storage/auth changes.
- GitHub Actions `verify` check is green on the PR branch.
- Manual Chrome smoke for the new expired-token scenarios is documented in `docs/manual-chrome-testing.md` but was not run as part of this PR.

## Breaking Changes

- None for users on the forward upgrade path. This is an internal storage-schema migration.

## Related Issues

Resolves #5
