### PR TITLE
fix(auth): harden token refresh and align diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,5 @@ The current MVP is already implemented around a few explicit constraints:
 - [Privacy policy draft](./docs/privacy-policy.md)
 - [ADR: Keep no-token support for public repositories](./docs/adr/0001-keep-no-token-support-for-public-repositories.md)
 - [ADR: Interim auth (superseded)](./docs/adr/0002-classic-pat-interim-auth.md)
+- [ADR: GitHub App + Device Flow](./docs/adr/0003-github-app-device-flow.md)
+- [ADR: GitHub App access token refresh](./docs/adr/0004-github-app-token-refresh.md)

--- a/docs/adr/0003-github-app-device-flow.md
+++ b/docs/adr/0003-github-app-device-flow.md
@@ -1,6 +1,6 @@
 # ADR 0003: GitHub App + Device Flow
 
-- Status: Accepted
+- Status: Accepted — token lifecycle amended by [ADR 0004](./0004-github-app-token-refresh.md)
 - Date: 2026-04-21
 
 ## Context
@@ -57,6 +57,9 @@ Ship a maintainer-owned GitHub App plus OAuth Device Flow.
 - User-to-server tokens have no refresh in a pure-client setting (the refresh
   endpoint requires a client secret). Users sign in again when a token is
   revoked — detected lazily and surfaced through the banner and options page.
+  *(Amended by [ADR 0004](./0004-github-app-token-refresh.md): GitHub's
+  device-flow refresh grant does work without a client secret; the extension
+  now exchanges refresh tokens in the service worker before invalidating.)*
 
 ### Neutral
 

--- a/docs/adr/0004-github-app-token-refresh.md
+++ b/docs/adr/0004-github-app-token-refresh.md
@@ -1,0 +1,93 @@
+# ADR 0004: GitHub App Access Token Refresh
+
+- Status: Accepted — amends [ADR 0003](./0003-github-app-device-flow.md) on token lifecycle
+- Date: 2026-04-23
+
+## Context
+
+[ADR 0003](./0003-github-app-device-flow.md) shipped a GitHub App plus OAuth
+Device Flow and explicitly accepted that *user-to-server tokens have no refresh
+in a pure-client setting (the refresh endpoint requires a client secret)*. In
+practice GitHub's OAuth device-flow refresh grant works without a client secret
+when the app is configured for device flow, which leaves access-token expiry as
+an avoidable re-authentication tax: before this change, the options page surfaced
+a revoked-style prompt and every PR row silently failed every eight hours until
+the user signed in again.
+
+## Decision
+
+Exchange the stored `refresh_token` for a new access token inside the MV3
+service worker before invalidating an account.
+
+- `src/github/auth.ts::refreshAccessToken` posts `grant_type=refresh_token` and
+  classifies the response.
+- `src/auth/refresh-coordinator.ts` de-duplicates in-flight refreshes per account
+  and routes terminal outcomes to `markAccountInvalidated(id, "refresh_failed")`.
+- Content scripts request refresh via `browser.runtime.sendMessage({ type:
+  "refreshAccessToken", accountId })` when a reviewer fetch returns 401 and the
+  account still has a refresh token.
+- The storage schema carries `refreshToken`, `expiresAt`, and
+  `refreshTokenExpiresAt` (`v4`, migrated from `v3`/`v2`).
+
+Refresh outcomes are classified into two kinds:
+
+- `terminal` — `bad_refresh_token`, `unauthorized_client`, `invalid_grant`,
+  `unsupported_grant_type`, or HTTP 400/401 from the refresh endpoint. The
+  account is marked invalidated with reason `refresh_failed` and the banner
+  prompts re-authentication.
+- `transient` — 5xx, 429, network errors, or malformed bodies. The account is
+  left valid and the row-level failure surfaces; rows self-heal on the next
+  refresh attempt once GitHub recovers.
+
+Diagnostics in the options page use the same retry-with-refresh path
+(`validateRepositoryAccessWithAccount`) so "Check matched account" mirrors
+runtime behavior — an expired access token is not reported as a failure while
+the runtime recovers silently.
+
+## Rationale
+
+- Users stay signed in across 8-hour access-token expiry without acting.
+- Revoked authorization and expired refresh tokens still surface clearly: the
+  banner and options page prompt re-authentication when `refresh_failed` is
+  stored.
+- Service-worker-side coordination avoids thundering-herd refreshes when multi-
+  ple PR rows hit 401 simultaneously — the first request wins and the others
+  reuse the outcome.
+- Diagnostics that match runtime behavior prevent user confusion when the
+  "Check matched account" button reports a failure the extension silently
+  recovered from.
+
+## Consequences
+
+### Positive
+
+- 8-hour expiry is invisible to users unless the refresh token itself expires
+  or is revoked.
+- Diagnostics no longer emit false negatives for accounts with stale access
+  tokens.
+- Terminal classification in `refreshAccessToken` now covers non-2xx responses
+  that still carry an OAuth error envelope, so revoked authorization is
+  detected on the first failed exchange instead of after repeated transient
+  classifications.
+
+### Negative
+
+- Adds a stored refresh token in `browser.storage.local`. Privacy policy and
+  Chrome Web Store submission copy reflect this.
+- A GitHub-side outage during refresh surfaces as per-row failures without
+  invalidating the account — same user-visible behavior as before, with the
+  addition that rows self-heal once GitHub recovers.
+
+### Neutral
+
+- The storage schema migration (`v3` → `v4`) adds refresh-token fields in place;
+  older schemas continue to migrate lazily on read.
+
+## Links
+
+- [ADR 0003](./0003-github-app-device-flow.md) — this ADR amends its "no
+  refresh" constraint.
+- `src/github/auth.ts::refreshAccessToken`
+- `src/auth/refresh-coordinator.ts`
+- `src/auth/account-token-refresh.ts::retryWithAccountRefresh`,
+  `validateRepositoryAccessWithAccount`

--- a/docs/manual-chrome-testing.md
+++ b/docs/manual-chrome-testing.md
@@ -134,6 +134,10 @@ This extension is intentionally narrow. Manual verification should stay focused 
 6. Open the options page and click **Refresh installations**.
 7. Confirm the installation refresh also succeeds without requiring a fresh
    sign-in.
+8. In the options page, enter a covered repository and click
+   **Check matched account**. Confirm diagnostics reports success — it uses
+   the same refresh path as the runtime, so a stale access token must not
+   produce a false negative here.
 
 ### Expired access token with invalid refresh token
 

--- a/entrypoints/options/components/DiagnosticsPanel.tsx
+++ b/entrypoints/options/components/DiagnosticsPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, type CSSProperties } from "react";
 
+import { validateRepositoryAccessWithAccount } from "../../../src/auth/account-token-refresh";
 import { validateGitHubRepositoryAccess } from "../../../src/github/api";
 import {
   resolveAccountForRepo,
@@ -37,7 +38,10 @@ export function DiagnosticsPanel() {
         });
         return;
       }
-      const result = await validateGitHubRepositoryAccess(account, trimmed);
+      const result = await validateRepositoryAccessWithAccount({
+        account,
+        repository: trimmed,
+      });
       setStatus({ tone: result.ok ? "success" : "error", message: result.message });
     } finally {
       setBusy(false);

--- a/src/auth/account-token-refresh.ts
+++ b/src/auth/account-token-refresh.ts
@@ -1,4 +1,12 @@
-import { getAccountById, markAccountInvalidated, type Account } from "../storage/accounts";
+import {
+  validateGitHubRepositoryAccess,
+  type RepositoryValidationResult,
+} from "../github/api";
+import {
+  getAccountById,
+  markAccountInvalidated,
+  type Account,
+} from "../storage/accounts";
 
 function extractStatus(error: unknown): number | null {
   if (error && typeof error === "object" && "status" in error) {
@@ -24,6 +32,45 @@ function extractStatus(error: unknown): number | null {
   }
 
   return null;
+}
+
+export async function validateRepositoryAccessWithAccount(input: {
+  account: Account;
+  repository: string;
+}): Promise<RepositoryValidationResult> {
+  const { account, repository } = input;
+  const first = await validateGitHubRepositoryAccess(account, repository);
+
+  if (first.ok || first.outcome !== "token-invalid") {
+    return first;
+  }
+
+  if (account.refreshToken == null) {
+    await markAccountInvalidated(account.id, "revoked");
+    return first;
+  }
+
+  const outcome = (await browser.runtime.sendMessage({
+    type: "refreshAccessToken",
+    accountId: account.id,
+  })) as
+    | { ok: true; token: string }
+    | { ok: false; terminal: boolean }
+    | undefined;
+
+  if (!outcome || outcome.ok !== true) {
+    return first;
+  }
+
+  const refreshed = (await getAccountById(account.id)) ?? {
+    ...account,
+    token: outcome.token,
+  };
+  const retry = await validateGitHubRepositoryAccess(refreshed, repository);
+  if (!retry.ok && retry.outcome === "token-invalid") {
+    await markAccountInvalidated(account.id, "revoked");
+  }
+  return retry;
 }
 
 export async function retryWithAccountRefresh<T>(input: {

--- a/src/github/auth.ts
+++ b/src/github/auth.ts
@@ -241,35 +241,25 @@ export async function refreshAccessToken(input: {
     );
   }
 
-  if (!response.ok) {
-    throw new RefreshTokenError(
-      "transient",
-      "network_error",
-      `Refresh request failed with status ${response.status}.`,
-    );
-  }
-
-  let json: unknown;
+  let json: unknown = null;
+  let readJsonError: unknown = null;
   try {
     json = await response.json();
   } catch (cause) {
-    throw new RefreshTokenError(
-      "transient",
-      "invalid_response",
-      cause instanceof Error ? cause.message : undefined,
-    );
+    readJsonError = cause;
   }
 
   const parsed = accessTokenResponseSchema.safeParse(json);
-  if (!parsed.success) {
-    throw new RefreshTokenError(
-      "transient",
-      "invalid_response",
-      "Malformed refresh-token response.",
-    );
-  }
 
-  if ("access_token" in parsed.data) {
+  if (parsed.success && "access_token" in parsed.data) {
+    if (!response.ok) {
+      // Success envelope on a non-2xx response is unexpected; treat as transient.
+      throw new RefreshTokenError(
+        "transient",
+        "invalid_response",
+        `Refresh succeeded with status ${response.status} but the response was unexpected.`,
+      );
+    }
     const now = Date.now();
     return {
       accessToken: parsed.data.access_token,
@@ -285,11 +275,35 @@ export async function refreshAccessToken(input: {
     };
   }
 
-  const code = parsed.data.error;
-  const kind: RefreshTokenErrorKind = TERMINAL_REFRESH_ERRORS.has(code)
-    ? "terminal"
-    : "transient";
-  throw new RefreshTokenError(kind, code, parsed.data.error_description);
+  if (parsed.success && "error" in parsed.data) {
+    const code = parsed.data.error;
+    const kind: RefreshTokenErrorKind = TERMINAL_REFRESH_ERRORS.has(code)
+      ? "terminal"
+      : "transient";
+    throw new RefreshTokenError(kind, code, parsed.data.error_description);
+  }
+
+  if (!response.ok) {
+    // HTTP 400/401 on refresh_token grant indicate bad client credentials or an
+    // invalid/revoked refresh token per OAuth2 and GitHub App device-flow docs.
+    const kind: RefreshTokenErrorKind =
+      response.status === 400 || response.status === 401
+        ? "terminal"
+        : "transient";
+    throw new RefreshTokenError(
+      kind,
+      "http_error",
+      `Refresh request failed with status ${response.status}.`,
+    );
+  }
+
+  throw new RefreshTokenError(
+    "transient",
+    "invalid_response",
+    readJsonError instanceof Error
+      ? readJsonError.message
+      : "Malformed refresh-token response.",
+  );
 }
 
 function createAuthHeaders(token: string): Headers {

--- a/tests/account-token-refresh.test.ts
+++ b/tests/account-token-refresh.test.ts
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const validateGitHubRepositoryAccessMock = vi.fn();
+const getAccountByIdMock = vi.fn();
+const markAccountInvalidatedMock = vi.fn();
+const runtimeSendMessageMock = vi.fn();
+
+vi.mock("../src/github/api", () => ({
+  validateGitHubRepositoryAccess: validateGitHubRepositoryAccessMock,
+  GitHubApiError: class GitHubApiError extends Error {
+    constructor(
+      public readonly status: number,
+      public readonly details?: string,
+    ) {
+      super(`GitHub API request failed with status ${status}.`);
+      this.name = "GitHubApiError";
+    }
+  },
+  GitHubPullRequestEndpointsError: class GitHubPullRequestEndpointsError extends Error {
+    constructor(public readonly failures: unknown[]) {
+      super("GitHub pull request endpoint diagnostics failed.");
+      this.name = "GitHubPullRequestEndpointsError";
+    }
+  },
+}));
+
+vi.mock("../src/storage/accounts", () => ({
+  getAccountById: getAccountByIdMock,
+  markAccountInvalidated: markAccountInvalidatedMock,
+}));
+
+const { validateRepositoryAccessWithAccount } = await import(
+  "../src/auth/account-token-refresh"
+);
+
+type StoredAccount = {
+  id: string;
+  login: string;
+  token: string;
+  refreshToken: string | null;
+};
+
+const baseAccount: StoredAccount = {
+  id: "acc-1",
+  login: "octocat",
+  token: "ghu_stale",
+  refreshToken: "ghr_valid",
+};
+
+beforeEach(() => {
+  validateGitHubRepositoryAccessMock.mockReset();
+  getAccountByIdMock.mockReset();
+  markAccountInvalidatedMock.mockReset();
+  runtimeSendMessageMock.mockReset();
+  vi.stubGlobal("browser", {
+    runtime: { sendMessage: runtimeSendMessageMock },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("validateRepositoryAccessWithAccount", () => {
+  it("returns the first result when validation succeeds", async () => {
+    const success = {
+      ok: true,
+      authMode: "token",
+      outcome: "accessible",
+      fullName: "octo/repo",
+      pullNumber: "1",
+      message: "ok",
+    };
+    validateGitHubRepositoryAccessMock.mockResolvedValueOnce(success);
+
+    const result = await validateRepositoryAccessWithAccount({
+      account: baseAccount as never,
+      repository: "octo/repo",
+    });
+
+    expect(result).toBe(success);
+    expect(runtimeSendMessageMock).not.toHaveBeenCalled();
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the first result when the failure is not token-invalid", async () => {
+    const failure = {
+      ok: false,
+      authMode: "token",
+      outcome: "token-not-found",
+      fullName: "octo/repo",
+      message: "not found",
+    };
+    validateGitHubRepositoryAccessMock.mockResolvedValueOnce(failure);
+
+    const result = await validateRepositoryAccessWithAccount({
+      account: baseAccount as never,
+      repository: "octo/repo",
+    });
+
+    expect(result).toBe(failure);
+    expect(runtimeSendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes and retries on token-invalid, returning the retry success", async () => {
+    validateGitHubRepositoryAccessMock
+      .mockResolvedValueOnce({
+        ok: false,
+        authMode: "token",
+        outcome: "token-invalid",
+        fullName: "octo/repo",
+        message: "token invalid",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        authMode: "token",
+        outcome: "accessible",
+        fullName: "octo/repo",
+        pullNumber: "1",
+        message: "ok",
+      });
+    runtimeSendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      token: "ghu_fresh",
+    });
+    getAccountByIdMock.mockResolvedValueOnce({
+      ...baseAccount,
+      token: "ghu_fresh",
+    });
+
+    const result = await validateRepositoryAccessWithAccount({
+      account: baseAccount as never,
+      repository: "octo/repo",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(runtimeSendMessageMock).toHaveBeenCalledWith({
+      type: "refreshAccessToken",
+      accountId: "acc-1",
+    });
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+    const retryCall = validateGitHubRepositoryAccessMock.mock.calls[1];
+    expect((retryCall[0] as { token: string }).token).toBe("ghu_fresh");
+  });
+
+  it("invalidates the account when retry still returns token-invalid", async () => {
+    const retryFailure = {
+      ok: false,
+      authMode: "token",
+      outcome: "token-invalid",
+      fullName: "octo/repo",
+      message: "still bad",
+    };
+    validateGitHubRepositoryAccessMock
+      .mockResolvedValueOnce({
+        ok: false,
+        authMode: "token",
+        outcome: "token-invalid",
+        fullName: "octo/repo",
+        message: "token invalid",
+      })
+      .mockResolvedValueOnce(retryFailure);
+    runtimeSendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      token: "ghu_fresh",
+    });
+    getAccountByIdMock.mockResolvedValueOnce({
+      ...baseAccount,
+      token: "ghu_fresh",
+    });
+
+    const result = await validateRepositoryAccessWithAccount({
+      account: baseAccount as never,
+      repository: "octo/repo",
+    });
+
+    expect(result).toBe(retryFailure);
+    expect(markAccountInvalidatedMock).toHaveBeenCalledWith(
+      "acc-1",
+      "revoked",
+    );
+  });
+
+  it("returns the first failure when refresh responds with ok:false", async () => {
+    const firstFailure = {
+      ok: false,
+      authMode: "token",
+      outcome: "token-invalid",
+      fullName: "octo/repo",
+      message: "token invalid",
+    };
+    validateGitHubRepositoryAccessMock.mockResolvedValueOnce(firstFailure);
+    runtimeSendMessageMock.mockResolvedValueOnce({
+      ok: false,
+      terminal: true,
+    });
+
+    const result = await validateRepositoryAccessWithAccount({
+      account: baseAccount as never,
+      repository: "octo/repo",
+    });
+
+    expect(result).toBe(firstFailure);
+    expect(validateGitHubRepositoryAccessMock).toHaveBeenCalledTimes(1);
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+  });
+
+  it("invalidates immediately when the account has no refresh token", async () => {
+    const failure = {
+      ok: false,
+      authMode: "token",
+      outcome: "token-invalid",
+      fullName: "octo/repo",
+      message: "token invalid",
+    };
+    validateGitHubRepositoryAccessMock.mockResolvedValueOnce(failure);
+
+    const result = await validateRepositoryAccessWithAccount({
+      account: { ...baseAccount, refreshToken: null } as never,
+      repository: "octo/repo",
+    });
+
+    expect(result).toBe(failure);
+    expect(runtimeSendMessageMock).not.toHaveBeenCalled();
+    expect(markAccountInvalidatedMock).toHaveBeenCalledWith("acc-1", "revoked");
+  });
+});

--- a/tests/auth.refresh.test.ts
+++ b/tests/auth.refresh.test.ts
@@ -83,6 +83,62 @@ describe("refreshAccessToken", () => {
     });
   });
 
+  it("throws RefreshTokenError(terminal) when a 4xx body carries a terminal OAuth error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse(fixture("refresh-token-bad.json"), 401),
+    );
+
+    await expect(
+      refreshAccessToken({ clientId: "Iv1.test", refreshToken: "ghr_old" }),
+    ).rejects.toMatchObject({
+      name: "RefreshTokenError",
+      kind: "terminal",
+      code: "bad_refresh_token",
+    });
+  });
+
+  it("throws RefreshTokenError(terminal) for HTTP 400 without a parseable body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("bad request", { status: 400 }),
+    );
+
+    await expect(
+      refreshAccessToken({ clientId: "Iv1.test", refreshToken: "ghr_old" }),
+    ).rejects.toMatchObject({
+      name: "RefreshTokenError",
+      kind: "terminal",
+      code: "http_error",
+    });
+  });
+
+  it("throws RefreshTokenError(terminal) for HTTP 401 without a parseable body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("unauthorized", { status: 401 }),
+    );
+
+    await expect(
+      refreshAccessToken({ clientId: "Iv1.test", refreshToken: "ghr_old" }),
+    ).rejects.toMatchObject({
+      name: "RefreshTokenError",
+      kind: "terminal",
+      code: "http_error",
+    });
+  });
+
+  it("throws RefreshTokenError(transient) for HTTP 429 (rate limit)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("slow down", { status: 429 }),
+    );
+
+    await expect(
+      refreshAccessToken({ clientId: "Iv1.test", refreshToken: "ghr_old" }),
+    ).rejects.toMatchObject({
+      name: "RefreshTokenError",
+      kind: "transient",
+      code: "http_error",
+    });
+  });
+
   it("throws RefreshTokenError(transient) when fetch itself rejects", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("offline"));
 


### PR DESCRIPTION
## Summary

- Classify 4xx OAuth refresh responses as terminal so revoked refresh tokens invalidate the account instead of looping as transient network errors.
- Route the options-page diagnostics ("Check matched account") through the same retry-with-refresh path the runtime uses, removing the false negative that appeared when only the access token had expired.
- Add ADR 0004 documenting the token-refresh decision and mark ADR 0003's "no refresh" consequence as amended.

## Why

Commit 2989281 added service-worker-side refresh, but the classifier only handled 200 OAuth error envelopes. A GitHub response with status 400/401 carrying the same envelope fell into the transient branch, so an account whose user revoked App authorization stayed marked valid indefinitely and every PR row silently failed. Separately, the diagnostics panel called `validateGitHubRepositoryAccess` directly, so a stale access token that the runtime silently recovered from produced a `token-invalid` error in "Check matched account" — the two code paths disagreed on whether the account was healthy.

## Changes

- `src/github/auth.ts`: `refreshAccessToken` now parses the response body regardless of status, reuses `TERMINAL_REFRESH_ERRORS` when an OAuth error envelope is present, and defaults HTTP 400/401 to terminal when the body is unparseable. 5xx/429/network errors remain transient.
- `src/auth/account-token-refresh.ts`: new `validateRepositoryAccessWithAccount` helper mirrors `retryWithAccountRefresh` for the validate-result shape — refresh on `token-invalid`, retry once, invalidate on second `token-invalid`.
- `entrypoints/options/components/DiagnosticsPanel.tsx`: `runMatched` calls the new helper so diagnostics reports what the runtime actually sees.
- `docs/adr/0004-github-app-token-refresh.md`: new ADR capturing the refresh decision, classification contract, and diagnostics alignment. ADR 0003 gains amendment pointers.
- `docs/manual-chrome-testing.md`: "Expired access token with valid refresh token" scenario walks through the new diagnostics alignment.
- `README.md`: links both ADR 0003 and the new ADR 0004 in Related Docs.

## Impact

- User-facing impact: revoked GitHub App authorization now surfaces the "Sign in again" prompt immediately instead of after repeated silent failures; diagnostics no longer emits false negatives for accounts with an expired access token.
- API/schema impact: none (no storage or API shape changes).
- Performance impact: none; extra work only runs in the failure path.
- Operational or rollout impact: none. Behavior change is strictly additive to the existing refresh flow.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm typecheck` — clean.
- `pnpm lint` — clean.
- `pnpm test` — 18 files / 162 tests passed (was 152; +4 cover 4xx refresh classification in `tests/auth.refresh.test.ts`, +6 cover the new helper in `tests/account-token-refresh.test.ts`).
- Manual verification against a live revoked GitHub App authorization is deferred to the pre-tag smoke described in #9.

## Breaking Changes

- None.

## Related Issues

Part of #9