### PR TITLE
fix(runtime): preserve PR-list navigation and validate background sender

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -26,17 +26,27 @@ export default defineBackground(() => {
     });
   });
 
-  browser.runtime.onMessage.addListener((message: unknown) => {
-    if (
-      message != null &&
-      typeof message === "object" &&
-      (message as { type?: unknown }).type === "refreshAccessToken" &&
-      typeof (message as { accountId?: unknown }).accountId === "string"
-    ) {
-      return coordinator.refreshAccountToken(
-        (message as { accountId: string }).accountId,
-      );
-    }
-    return undefined;
-  });
+  browser.runtime.onMessage.addListener(
+    (message: unknown, sender: { id?: string } | undefined) => {
+      // Reject messages from other extensions or extension pages. Only
+      // components of this extension (content scripts, options page) are
+      // allowed to trigger a token refresh — otherwise a third party could
+      // ask us to refresh an arbitrary accountId and observe the returned
+      // token.
+      if (sender?.id !== browser.runtime.id) {
+        return undefined;
+      }
+      if (
+        message != null &&
+        typeof message === "object" &&
+        (message as { type?: unknown }).type === "refreshAccessToken" &&
+        typeof (message as { accountId?: unknown }).accountId === "string"
+      ) {
+        return coordinator.refreshAccountToken(
+          (message as { accountId: string }).accountId,
+        );
+      }
+      return undefined;
+    },
+  );
 });

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -2,7 +2,7 @@ import { bootAccessBanner } from "../src/features/access-banner";
 import { bootReviewerListPage } from "../src/features/reviewers";
 
 export default defineContentScript({
-  matches: ["https://github.com/*/*"],
+  matches: ["https://github.com/*/*/pulls*"],
   runAt: "document_idle",
   main(ctx) {
     let aggregator = bootAccessBanner(ctx);

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -1,43 +1,58 @@
-import { bootAccessBanner } from "../src/features/access-banner";
+import {
+  bootAccessBanner,
+  type AccessBannerHandle,
+} from "../src/features/access-banner";
 import { bootReviewerListPage } from "../src/features/reviewers";
+import { parsePullListRoute } from "../src/github/routes";
 
 export default defineContentScript({
-  matches: ["https://github.com/*/*/pulls*"],
+  matches: ["https://github.com/*/*"],
   runAt: "document_idle",
   main(ctx) {
-    let aggregator = bootAccessBanner(ctx);
+    let aggregator: AccessBannerHandle | null = null;
+    let reviewerListBooted = false;
 
-    const refreshAccessBanner = () => {
+    const syncRouteFeatures = () => {
       aggregator?.teardown();
+      aggregator = null;
+
+      if (parsePullListRoute(window.location.pathname) == null) {
+        return;
+      }
+
       aggregator = bootAccessBanner(ctx);
+      if (!reviewerListBooted) {
+        reviewerListBooted = true;
+        bootReviewerListPage(ctx, {
+          onRowFailure({ owner, account, error }) {
+            if (aggregator == null) {
+              aggregator = bootAccessBanner(ctx);
+            }
+            if (aggregator == null) {
+              return;
+            }
+            const status = extractStatus(error);
+            if (status === 429 || (account == null && status === 403)) {
+              aggregator.reportUnauthRateLimit();
+              return;
+            }
+            if (status === 404 || status === 403 || account == null) {
+              aggregator.reportUncoveredOwner(owner);
+              return;
+            }
+            // 401 and other errors — still flag uncovered so the banner can guide the user.
+            aggregator.reportUncoveredOwner(owner);
+          },
+        });
+      }
     };
 
-    ctx.addEventListener(window, "wxt:locationchange", refreshAccessBanner);
-    ctx.addEventListener(window, "popstate", refreshAccessBanner);
-    ctx.addEventListener(document, "turbo:render", refreshAccessBanner);
-    ctx.addEventListener(document, "pjax:end", refreshAccessBanner);
+    syncRouteFeatures();
 
-    bootReviewerListPage(ctx, {
-      onRowFailure({ owner, account, error }) {
-        if (aggregator == null) {
-          aggregator = bootAccessBanner(ctx);
-        }
-        if (aggregator == null) {
-          return;
-        }
-        const status = extractStatus(error);
-        if (status === 429 || (account == null && status === 403)) {
-          aggregator.reportUnauthRateLimit();
-          return;
-        }
-        if (status === 404 || status === 403 || account == null) {
-          aggregator.reportUncoveredOwner(owner);
-          return;
-        }
-        // 401 and other errors — still flag uncovered so the banner can guide the user.
-        aggregator.reportUncoveredOwner(owner);
-      },
-    });
+    ctx.addEventListener(window, "wxt:locationchange", syncRouteFeatures);
+    ctx.addEventListener(window, "popstate", syncRouteFeatures);
+    ctx.addEventListener(document, "turbo:render", syncRouteFeatures);
+    ctx.addEventListener(document, "pjax:end", syncRouteFeatures);
   },
 });
 

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const refreshAccountTokenMock = vi.fn();
+const createRefreshCoordinatorMock = vi.fn(() => ({
+  refreshAccountToken: refreshAccountTokenMock,
+}));
+const getGitHubAppConfigMock = vi.fn(() => ({ clientId: "test-client-id" }));
+
+vi.mock("../src/auth/refresh-coordinator", () => ({
+  createRefreshCoordinator: createRefreshCoordinatorMock,
+}));
+
+vi.mock("../src/config/github-app", () => ({
+  getGitHubAppConfig: getGitHubAppConfigMock,
+}));
+
+type MessageSender = { id?: string };
+type MessageListener = (
+  message: unknown,
+  sender: MessageSender | undefined,
+  sendResponse: () => void,
+) => unknown;
+
+const SELF_RUNTIME_ID = "self-extension-id";
+
+let capturedMessageListener: MessageListener | null;
+
+beforeEach(() => {
+  vi.resetModules();
+  refreshAccountTokenMock.mockReset();
+  refreshAccountTokenMock.mockResolvedValue({ ok: true, token: "new-token" });
+  createRefreshCoordinatorMock.mockClear();
+  getGitHubAppConfigMock.mockClear();
+  capturedMessageListener = null;
+
+  vi.stubGlobal("defineBackground", (main: () => void) => ({ main }));
+  vi.stubGlobal("browser", {
+    runtime: {
+      id: SELF_RUNTIME_ID,
+      onInstalled: { addListener: vi.fn() },
+      onMessage: {
+        addListener: vi.fn((listener: MessageListener) => {
+          capturedMessageListener = listener;
+        }),
+      },
+      openOptionsPage: vi.fn(),
+    },
+    action: {
+      onClicked: { addListener: vi.fn() },
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function bootBackground(): Promise<MessageListener> {
+  const { default: background } = await import("../entrypoints/background");
+  background.main!();
+  if (capturedMessageListener == null) {
+    throw new Error("background did not register a runtime.onMessage listener");
+  }
+  return capturedMessageListener;
+}
+
+describe("background runtime.onMessage handler", () => {
+  it("dispatches valid refresh messages that originate from this extension", async () => {
+    const listener = await bootBackground();
+
+    const result = listener(
+      { type: "refreshAccessToken", accountId: "acc-1" },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+
+    expect(refreshAccountTokenMock).toHaveBeenCalledTimes(1);
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-1");
+    await expect(result as Promise<unknown>).resolves.toEqual({
+      ok: true,
+      token: "new-token",
+    });
+  });
+
+  it("rejects valid refresh messages from a different extension id", async () => {
+    const listener = await bootBackground();
+
+    const result = listener(
+      { type: "refreshAccessToken", accountId: "acc-1" },
+      { id: "some-other-extension-id" },
+      () => {},
+    );
+
+    expect(result).toBeUndefined();
+    expect(refreshAccountTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed envelopes even when sent from this extension", async () => {
+    const listener = await bootBackground();
+
+    const missingAccountId = listener(
+      { type: "refreshAccessToken" },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+    const wrongType = listener(
+      { type: "somethingElse", accountId: "acc-1" },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+    const notAnObject = listener(
+      "refreshAccessToken",
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+
+    expect(missingAccountId).toBeUndefined();
+    expect(wrongType).toBeUndefined();
+    expect(notAnObject).toBeUndefined();
+    expect(refreshAccountTokenMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -34,6 +34,11 @@ afterEach(() => {
 });
 
 describe("content entrypoint", () => {
+  it("narrows its content-script match pattern to PR list routes", async () => {
+    const { default: content } = await import("../entrypoints/content");
+    expect(content.matches).toEqual(["https://github.com/*/*/pulls*"]);
+  });
+
   it("re-initializes the access banner when navigation enters a PR list", async () => {
     const aggregator = {
       reportUncoveredOwner: vi.fn(),

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -34,19 +34,18 @@ afterEach(() => {
 });
 
 describe("content entrypoint", () => {
-  it("narrows its content-script match pattern to PR list routes", async () => {
+  it("keeps a broad content-script match so same-document PR-list navigation stays supported", async () => {
     const { default: content } = await import("../entrypoints/content");
-    expect(content.matches).toEqual(["https://github.com/*/*/pulls*"]);
+    expect(content.matches).toEqual(["https://github.com/*/*"]);
   });
 
-  it("re-initializes the access banner when navigation enters a PR list", async () => {
+  it("waits to boot PR-list features until navigation enters a PR list", async () => {
     const aggregator = {
       reportUncoveredOwner: vi.fn(),
       reportUnauthRateLimit: vi.fn(),
+      teardown: vi.fn(),
     };
-    bootAccessBannerMock
-      .mockReturnValueOnce(null)
-      .mockReturnValueOnce(aggregator);
+    bootAccessBannerMock.mockReturnValue(aggregator);
 
     const listeners = new Map<string, Listener[]>();
     const ctx = {
@@ -60,7 +59,8 @@ describe("content entrypoint", () => {
     const { default: content } = await import("../entrypoints/content");
     content.main(ctx as never);
 
-    expect(bootAccessBannerMock).toHaveBeenCalledTimes(1);
+    expect(bootAccessBannerMock).not.toHaveBeenCalled();
+    expect(bootReviewerListPageMock).not.toHaveBeenCalled();
 
     window.history.replaceState(
       {},
@@ -69,6 +69,7 @@ describe("content entrypoint", () => {
     );
     listeners.get("wxt:locationchange")?.forEach((listener) => listener());
 
-    expect(bootAccessBannerMock).toHaveBeenCalledTimes(2);
+    expect(bootAccessBannerMock).toHaveBeenCalledTimes(1);
+    expect(bootReviewerListPageMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Keep the content script on `https://github.com/*/*` so GitHub's same-document navigation into PR list pages still has the extension injected, while delaying reviewer-list and access-banner boot until the route actually matches a pull list.
- Require `sender.id === browser.runtime.id` before dispatching `refreshAccessToken` messages.

## Why

GitHub can reach `/{owner}/{repo}/pulls` through Turbo/PJAX from other repository pages. Narrowing the MV3 content-script match to `/pulls*` breaks that path because content scripts only inject on document loads, so reviewer badges and the access banner can disappear until a hard refresh. Separately, the refresh coordinator only needs to accept messages from this extension's own components, so the background listener should reject anything outside that scope before attempting a token refresh.

## Changes

- **Content script bootstrap** (`entrypoints/content.ts`): keep `matches: ["https://github.com/*/*"]`, add route-gated `syncRouteFeatures`, and boot `bootAccessBanner` / `bootReviewerListPage` only after `parsePullListRoute(window.location.pathname)` succeeds. `tests/content.test.ts` now locks in the broad match and the regression path that starts outside `/pulls` and navigates into the PR list.
- **Background sender validation** (`entrypoints/background.ts`): the `runtime.onMessage` listener now returns `undefined` unless `sender?.id === browser.runtime.id`, before applying the existing envelope shape check. `tests/background.test.ts` captures the registered handler and covers valid same-extension dispatches, other-id rejection, and malformed-envelope rejection.

## Impact

- User-facing impact: Reviewer badges and the access banner continue to appear after in-page navigation into `/{owner}/{repo}/pulls`, while unrelated repository pages avoid booting PR-list UI work until the route changes into a pull list.
- API/schema impact: None. The `refreshAccessToken` envelope is unchanged; only the sender gate is new.
- Performance impact: The content script still loads on matched repository pages so SPA navigation remains supported, but access-banner bootstrap and reviewer polling do not start until a pull list route is active.
- Operational or rollout impact: `host_permissions` stay the same, and the content-script match remains broad by design to preserve GitHub SPA navigation.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint` clean.
- `pnpm typecheck` clean.
- `pnpm test` 156 passed (includes the same-document navigation regression coverage for `content.ts`).
- `pnpm test:e2e` intentionally skipped — the changes are covered by unit tests for route bootstrap and background message gating.

## Breaking Changes

- None. The content script remains injected on repository pages, but PR-list behavior is deferred until the route matches a pull list. The sender gate only rejects refresh messages that are not scoped to this extension.

## Related Issues

Part of #9
