### PR TITLE
refactor(auth): move reviewer fetch into background

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,6 @@ Agents working in this repository should preserve that narrow product scope. Do 
 - Update `README.md` and `docs/implementation-notes.md` when MVP behavior or scope changes.
 - Keep review-state semantics explicit. If review states are shown, document which GitHub states are included and how they are mapped in the UI.
 - Prefer fixture-backed regression coverage for GitHub DOM behavior and reserve placeholder end-to-end tests for bootstrapping only.
-- Never force-add ignored files. `git add -f` is prohibited in this repository.
-- Treat ignored files as non-trackable workspace artifacts. Do not convert them into tracked files unless the maintainer first changes the ignore rules in a normal reviewed change.
 
 ## Workflow
 

--- a/docs/manual-chrome-testing.md
+++ b/docs/manual-chrome-testing.md
@@ -135,6 +135,9 @@ This extension is intentionally narrow. Manual verification should stay focused 
 4. Reload the private PR list.
 5. Confirm reviewer chips still render and the extension performs exactly one
    refresh-token exchange against `https://github.com/login/oauth/access_token`.
+   The reviewer fetch now retries from the background worker, so this check
+   belongs in the extension service worker DevTools rather than the page
+   DevTools alone.
 6. Open the options page and click **Refresh installations**.
 7. Confirm the installation refresh also succeeds without requiring a fresh
    sign-in.
@@ -219,8 +222,11 @@ If the extension appears loaded but does not work:
 - Refresh the GitHub page after reloading.
 - Open the `Errors` button on the extension card in `chrome://extensions` if Chrome reports runtime issues.
 - For content-script debugging, inspect the target GitHub page in DevTools and check the console for extension-related errors.
+- For authenticated reviewer-fetch debugging, also inspect the extension
+  service worker DevTools because the private-repository GitHub fetch and
+  refresh-retry path now run there.
 
 If reviewer data is missing only on private repositories:
 
 - Re-check that the signed-in account has the GitHub App installed for the target repository.
-- Use the options page diagnostics to confirm the same GitHub API paths used by the content script can be reached.
+- Use the options page diagnostics to confirm the same GitHub API paths used by the background reviewer fetch can be reached.

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,11 +1,17 @@
 import { createRefreshCoordinator } from "../src/auth/refresh-coordinator";
-import { handleFetchPullReviewerSummaryMessage } from "../src/background/reviewer-fetch";
+import { createReviewerFetchService } from "../src/background/reviewer-fetch";
 import { getGitHubAppConfig } from "../src/config/github-app";
-import { isFetchPullReviewerSummaryMessage } from "../src/runtime/reviewer-fetch";
+import {
+  isCancelPullReviewerSummaryMessage,
+  isFetchPullReviewerSummaryMessage,
+} from "../src/runtime/reviewer-fetch";
 
 export default defineBackground(() => {
   const coordinator = createRefreshCoordinator({
     getClientId: () => getGitHubAppConfig().clientId,
+  });
+  const reviewerFetchService = createReviewerFetchService({
+    refreshCoordinator: coordinator,
   });
 
   browser.runtime.onInstalled.addListener((details) => {
@@ -49,10 +55,11 @@ export default defineBackground(() => {
         );
       }
       if (isFetchPullReviewerSummaryMessage(message)) {
-        return handleFetchPullReviewerSummaryMessage({
-          message,
-          refreshCoordinator: coordinator,
-        });
+        return reviewerFetchService.handleFetchMessage(message);
+      }
+      if (isCancelPullReviewerSummaryMessage(message)) {
+        reviewerFetchService.cancelRequest(message.requestId);
+        return undefined;
       }
       return undefined;
     },

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,5 +1,7 @@
 import { createRefreshCoordinator } from "../src/auth/refresh-coordinator";
+import { handleFetchPullReviewerSummaryMessage } from "../src/background/reviewer-fetch";
 import { getGitHubAppConfig } from "../src/config/github-app";
+import { isFetchPullReviewerSummaryMessage } from "../src/runtime/reviewer-fetch";
 
 export default defineBackground(() => {
   const coordinator = createRefreshCoordinator({
@@ -45,6 +47,12 @@ export default defineBackground(() => {
         return coordinator.refreshAccountToken(
           (message as { accountId: string }).accountId,
         );
+      }
+      if (isFetchPullReviewerSummaryMessage(message)) {
+        return handleFetchPullReviewerSummaryMessage({
+          message,
+          refreshCoordinator: coordinator,
+        });
       }
       return undefined;
     },

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -4,10 +4,7 @@ import {
 } from "../src/features/access-banner";
 import { bootReviewerListPage } from "../src/features/reviewers";
 import { parsePullListRoute } from "../src/github/routes";
-import {
-  GitHubApiError,
-  GitHubPullRequestEndpointsError,
-} from "../src/github/api";
+import { extractReviewerFetchFailures } from "../src/runtime/reviewer-fetch";
 
 export default defineContentScript({
   matches: ["https://github.com/*/*"],
@@ -70,6 +67,10 @@ type RowFailureClassification = {
   uncovered: boolean;
 };
 
+type ApiFailure = {
+  status: number;
+};
+
 function classifyRowFailure(
   error: unknown,
   account: { id?: string } | null,
@@ -104,12 +105,6 @@ function classifyRowFailure(
   return { rateLimited: false, uncovered: false };
 }
 
-function collectApiFailures(error: unknown): GitHubApiError[] {
-  if (error instanceof GitHubPullRequestEndpointsError) {
-    return error.failures;
-  }
-  if (error instanceof GitHubApiError) {
-    return [error];
-  }
-  return [];
+function collectApiFailures(error: unknown): ApiFailure[] {
+  return extractReviewerFetchFailures(error);
 }

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -4,7 +4,10 @@ import {
 } from "../src/features/access-banner";
 import { bootReviewerListPage } from "../src/features/reviewers";
 import { parsePullListRoute } from "../src/github/routes";
-import { extractReviewerFetchFailures } from "../src/runtime/reviewer-fetch";
+import {
+  type ReviewerFetchFailure,
+  extractReviewerFetchFailures,
+} from "../src/runtime/reviewer-fetch";
 
 export default defineContentScript({
   matches: ["https://github.com/*/*"],
@@ -67,10 +70,6 @@ type RowFailureClassification = {
   uncovered: boolean;
 };
 
-type ApiFailure = {
-  status: number;
-};
-
 function classifyRowFailure(
   error: unknown,
   account: { id?: string } | null,
@@ -105,6 +104,6 @@ function classifyRowFailure(
   return { rateLimited: false, uncovered: false };
 }
 
-function collectApiFailures(error: unknown): ApiFailure[] {
+function collectApiFailures(error: unknown): ReviewerFetchFailure[] {
   return extractReviewerFetchFailures(error);
 }

--- a/src/background/reviewer-fetch.ts
+++ b/src/background/reviewer-fetch.ts
@@ -1,0 +1,70 @@
+import type { RefreshCoordinator } from "../auth/refresh-coordinator";
+import { fetchPullReviewerSummary, extractGitHubApiStatus } from "../github/api";
+import {
+  getAccountById,
+  markAccountInvalidated,
+} from "../storage/accounts";
+import {
+  serializeReviewerFetchError,
+  type FetchPullReviewerSummaryMessage,
+  type FetchPullReviewerSummaryResponse,
+} from "../runtime/reviewer-fetch";
+
+export async function handleFetchPullReviewerSummaryMessage(input: {
+  message: FetchPullReviewerSummaryMessage;
+  refreshCoordinator: RefreshCoordinator;
+}): Promise<FetchPullReviewerSummaryResponse> {
+  const { message, refreshCoordinator } = input;
+  const account =
+    message.accountId == null ? null : await getAccountById(message.accountId);
+
+  const execute = (token: string | null) =>
+    fetchPullReviewerSummary({
+      owner: message.owner,
+      repo: message.repo,
+      pullNumber: message.pullNumber,
+      githubToken: token,
+    });
+
+  try {
+    const summary = await execute(account?.token ?? null);
+    return { ok: true, summary };
+  } catch (error) {
+    if (extractGitHubApiStatus(error) !== 401 || account == null) {
+      return {
+        ok: false,
+        error: serializeReviewerFetchError(error),
+      };
+    }
+
+    if (account.refreshToken == null) {
+      await markAccountInvalidated(account.id, "revoked");
+      return {
+        ok: false,
+        error: serializeReviewerFetchError(error),
+      };
+    }
+
+    const outcome = await refreshCoordinator.refreshAccountToken(account.id);
+    if (outcome.ok !== true) {
+      return {
+        ok: false,
+        error: serializeReviewerFetchError(error),
+      };
+    }
+
+    const refreshed = await getAccountById(account.id);
+    try {
+      const summary = await execute(refreshed?.token ?? outcome.token);
+      return { ok: true, summary };
+    } catch (retryError) {
+      if (extractGitHubApiStatus(retryError) === 401) {
+        await markAccountInvalidated(account.id, "revoked");
+      }
+      return {
+        ok: false,
+        error: serializeReviewerFetchError(retryError),
+      };
+    }
+  }
+}

--- a/src/background/reviewer-fetch.ts
+++ b/src/background/reviewer-fetch.ts
@@ -19,12 +19,28 @@ export function createReviewerFetchService(input: {
 }): ReviewerFetchService {
   const { refreshCoordinator } = input;
   const inFlightControllers = new Map<string, AbortController>();
-  const canceledRequestIds = new Set<string>();
+  const canceledRequestIds = new Map<string, number>();
+
+  function pruneCanceledRequestIds(now: number): void {
+    const maxAgeMs = 60_000;
+    for (const [requestId, createdAt] of canceledRequestIds) {
+      if (now - createdAt > maxAgeMs) {
+        canceledRequestIds.delete(requestId);
+      }
+    }
+  }
 
   return {
     cancelRequest(requestId: string): void {
-      canceledRequestIds.add(requestId);
-      inFlightControllers.get(requestId)?.abort();
+      const controller = inFlightControllers.get(requestId);
+      if (controller != null) {
+        controller.abort();
+        return;
+      }
+
+      const now = Date.now();
+      pruneCanceledRequestIds(now);
+      canceledRequestIds.set(requestId, now);
     },
     async handleFetchMessage(
       message: FetchPullReviewerSummaryMessage,
@@ -32,7 +48,7 @@ export function createReviewerFetchService(input: {
       const controller = new AbortController();
       inFlightControllers.set(message.requestId, controller);
 
-      if (canceledRequestIds.has(message.requestId)) {
+      if (canceledRequestIds.delete(message.requestId)) {
         controller.abort();
       }
 
@@ -92,7 +108,6 @@ export function createReviewerFetchService(input: {
         }
       } finally {
         inFlightControllers.delete(message.requestId);
-        canceledRequestIds.delete(message.requestId);
       }
     },
   };

--- a/src/background/reviewer-fetch.ts
+++ b/src/background/reviewer-fetch.ts
@@ -1,70 +1,99 @@
 import type { RefreshCoordinator } from "../auth/refresh-coordinator";
 import { fetchPullReviewerSummary, extractGitHubApiStatus } from "../github/api";
-import {
-  getAccountById,
-  markAccountInvalidated,
-} from "../storage/accounts";
+import { getAccountById, markAccountInvalidated } from "../storage/accounts";
 import {
   serializeReviewerFetchError,
   type FetchPullReviewerSummaryMessage,
   type FetchPullReviewerSummaryResponse,
 } from "../runtime/reviewer-fetch";
 
-export async function handleFetchPullReviewerSummaryMessage(input: {
-  message: FetchPullReviewerSummaryMessage;
+export type ReviewerFetchService = {
+  cancelRequest(requestId: string): void;
+  handleFetchMessage(
+    message: FetchPullReviewerSummaryMessage,
+  ): Promise<FetchPullReviewerSummaryResponse>;
+};
+
+export function createReviewerFetchService(input: {
   refreshCoordinator: RefreshCoordinator;
-}): Promise<FetchPullReviewerSummaryResponse> {
-  const { message, refreshCoordinator } = input;
-  const account =
-    message.accountId == null ? null : await getAccountById(message.accountId);
+}): ReviewerFetchService {
+  const { refreshCoordinator } = input;
+  const inFlightControllers = new Map<string, AbortController>();
+  const canceledRequestIds = new Set<string>();
 
-  const execute = (token: string | null) =>
-    fetchPullReviewerSummary({
-      owner: message.owner,
-      repo: message.repo,
-      pullNumber: message.pullNumber,
-      githubToken: token,
-    });
+  return {
+    cancelRequest(requestId: string): void {
+      canceledRequestIds.add(requestId);
+      inFlightControllers.get(requestId)?.abort();
+    },
+    async handleFetchMessage(
+      message: FetchPullReviewerSummaryMessage,
+    ): Promise<FetchPullReviewerSummaryResponse> {
+      const controller = new AbortController();
+      inFlightControllers.set(message.requestId, controller);
 
-  try {
-    const summary = await execute(account?.token ?? null);
-    return { ok: true, summary };
-  } catch (error) {
-    if (extractGitHubApiStatus(error) !== 401 || account == null) {
-      return {
-        ok: false,
-        error: serializeReviewerFetchError(error),
-      };
-    }
-
-    if (account.refreshToken == null) {
-      await markAccountInvalidated(account.id, "revoked");
-      return {
-        ok: false,
-        error: serializeReviewerFetchError(error),
-      };
-    }
-
-    const outcome = await refreshCoordinator.refreshAccountToken(account.id);
-    if (outcome.ok !== true) {
-      return {
-        ok: false,
-        error: serializeReviewerFetchError(error),
-      };
-    }
-
-    const refreshed = await getAccountById(account.id);
-    try {
-      const summary = await execute(refreshed?.token ?? outcome.token);
-      return { ok: true, summary };
-    } catch (retryError) {
-      if (extractGitHubApiStatus(retryError) === 401) {
-        await markAccountInvalidated(account.id, "revoked");
+      if (canceledRequestIds.has(message.requestId)) {
+        controller.abort();
       }
-      return {
-        ok: false,
-        error: serializeReviewerFetchError(retryError),
-      };
-    }
-  }
+
+      try {
+        const account =
+          message.accountId == null ? null : await getAccountById(message.accountId);
+
+        const execute = (token: string | null) =>
+          fetchPullReviewerSummary({
+            owner: message.owner,
+            repo: message.repo,
+            pullNumber: message.pullNumber,
+            githubToken: token,
+            signal: controller.signal,
+          });
+
+        try {
+          const summary = await execute(account?.token ?? null);
+          return { ok: true, summary };
+        } catch (error) {
+          if (extractGitHubApiStatus(error) !== 401 || account == null) {
+            return {
+              ok: false,
+              error: serializeReviewerFetchError(error),
+            };
+          }
+
+          if (account.refreshToken == null) {
+            await markAccountInvalidated(account.id, "revoked");
+            return {
+              ok: false,
+              error: serializeReviewerFetchError(error),
+            };
+          }
+
+          const outcome = await refreshCoordinator.refreshAccountToken(account.id);
+          if (outcome.ok !== true) {
+            return {
+              ok: false,
+              error: serializeReviewerFetchError(error),
+            };
+          }
+
+          const refreshed = await getAccountById(account.id);
+          try {
+            const summary = await execute(refreshed?.token ?? outcome.token);
+            return { ok: true, summary };
+          } catch (retryError) {
+            if (extractGitHubApiStatus(retryError) === 401) {
+              await markAccountInvalidated(account.id, "revoked");
+            }
+            return {
+              ok: false,
+              error: serializeReviewerFetchError(retryError),
+            };
+          }
+        }
+      } finally {
+        inFlightControllers.delete(message.requestId);
+        canceledRequestIds.delete(message.requestId);
+      }
+    },
+  };
 }

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -1,15 +1,15 @@
 import type { ContentScriptContext } from "wxt/utils/content-script-context";
 
-import { retryWithAccountRefresh } from "../../auth/account-token-refresh";
 import {
   buildReviewerCacheKey,
   clearReviewerCache,
   getCachedReviewerSummary,
   setCachedReviewerSummary,
 } from "../../cache/reviewer-cache";
-import { fetchPullReviewerSummary } from "../../github/api";
+import type { PullReviewerSummary } from "../../github/api";
 import { parsePullListRoute } from "../../github/routes";
 import { githubSelectors } from "../../github/selectors";
+import type { FetchPullReviewerSummaryResponse } from "../../runtime/reviewer-fetch";
 import { resolveAccountForRepo, type Account } from "../../storage/accounts";
 import {
   DEFAULT_PREFERENCES,
@@ -256,20 +256,22 @@ async function fetchWithRefresh(args: {
   repo: string;
   pullNumber: string;
   signal?: AbortSignal;
-}): Promise<Awaited<ReturnType<typeof fetchPullReviewerSummary>>> {
-  const { account, owner, repo, pullNumber, signal } = args;
+}): Promise<PullReviewerSummary> {
+  const { account, owner, repo, pullNumber } = args;
 
-  return retryWithAccountRefresh({
-    account,
-    execute: async (token) =>
-      fetchPullReviewerSummary({
-        owner,
-        repo,
-        pullNumber,
-        githubToken: token,
-        signal,
-      }),
-  });
+  const response = (await browser.runtime.sendMessage({
+    type: "fetchPullReviewerSummary",
+    owner,
+    repo,
+    pullNumber,
+    accountId: account?.id ?? null,
+  })) as FetchPullReviewerSummaryResponse | undefined;
+
+  if (response?.ok === true) {
+    return response.summary;
+  }
+
+  throw response?.error ?? new Error("Background reviewer fetch failed.");
 }
 
 function isAbortError(error: unknown): boolean {

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -258,11 +258,11 @@ async function fetchWithRefresh(args: {
   owner: string;
   repo: string;
   pullNumber: string;
-  signal?: AbortSignal;
+  signal: AbortSignal;
 }): Promise<PullReviewerSummary> {
   const { account, owner, repo, pullNumber, signal } = args;
 
-  if (signal?.aborted) {
+  if (signal.aborted) {
     throw createAbortError();
   }
 
@@ -276,11 +276,7 @@ async function fetchWithRefresh(args: {
     accountId: account?.id ?? null,
   }) as Promise<FetchPullReviewerSummaryResponse | undefined>;
 
-  if (signal == null) {
-    return unwrapReviewerFetchResponse(await responsePromise);
-  }
-
-  let removeAbortListener: (() => void) | null = null;
+  const abortListenerController = new AbortController();
   const abortPromise = new Promise<never>((_, reject) => {
     const onAbort = () => {
       void browser.runtime
@@ -297,18 +293,17 @@ async function fetchWithRefresh(args: {
       return;
     }
 
-    signal.addEventListener("abort", onAbort, { once: true });
-    removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, {
+      once: true,
+      signal: abortListenerController.signal,
+    });
   });
 
   try {
     const response = await Promise.race([responsePromise, abortPromise]);
     return unwrapReviewerFetchResponse(response);
   } finally {
-    const cleanup = removeAbortListener as (() => void) | null;
-    if (cleanup != null) {
-      cleanup();
-    }
+    abortListenerController.abort();
   }
 }
 
@@ -344,6 +339,13 @@ function unwrapReviewerFetchResponse(
 let reviewerFetchRequestCounter = 0;
 
 function createReviewerFetchRequestId(): string {
+  if (
+    typeof globalThis.crypto !== "undefined" &&
+    typeof globalThis.crypto.randomUUID === "function"
+  ) {
+    return `reviewer-fetch-${globalThis.crypto.randomUUID()}`;
+  }
+
   reviewerFetchRequestCounter += 1;
   return `reviewer-fetch-${Date.now()}-${reviewerFetchRequestCounter}`;
 }

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -9,7 +9,10 @@ import {
 import type { PullReviewerSummary } from "../../github/api";
 import { parsePullListRoute } from "../../github/routes";
 import { githubSelectors } from "../../github/selectors";
-import type { FetchPullReviewerSummaryResponse } from "../../runtime/reviewer-fetch";
+import {
+  ReviewerFetchRuntimeError,
+  type FetchPullReviewerSummaryResponse,
+} from "../../runtime/reviewer-fetch";
 import { resolveAccountForRepo, type Account } from "../../storage/accounts";
 import {
   DEFAULT_PREFERENCES,
@@ -257,21 +260,56 @@ async function fetchWithRefresh(args: {
   pullNumber: string;
   signal?: AbortSignal;
 }): Promise<PullReviewerSummary> {
-  const { account, owner, repo, pullNumber } = args;
+  const { account, owner, repo, pullNumber, signal } = args;
 
-  const response = (await browser.runtime.sendMessage({
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+
+  const requestId = createReviewerFetchRequestId();
+  const responsePromise = browser.runtime.sendMessage({
     type: "fetchPullReviewerSummary",
+    requestId,
     owner,
     repo,
     pullNumber,
     accountId: account?.id ?? null,
-  })) as FetchPullReviewerSummaryResponse | undefined;
+  }) as Promise<FetchPullReviewerSummaryResponse | undefined>;
 
-  if (response?.ok === true) {
-    return response.summary;
+  if (signal == null) {
+    return unwrapReviewerFetchResponse(await responsePromise);
   }
 
-  throw response?.error ?? new Error("Background reviewer fetch failed.");
+  let removeAbortListener: (() => void) | null = null;
+  const abortPromise = new Promise<never>((_, reject) => {
+    const onAbort = () => {
+      void browser.runtime
+        .sendMessage({
+          type: "cancelPullReviewerSummary",
+          requestId,
+        })
+        .catch(() => undefined);
+      reject(createAbortError());
+    };
+
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+  });
+
+  try {
+    const response = await Promise.race([responsePromise, abortPromise]);
+    return unwrapReviewerFetchResponse(response);
+  } finally {
+    const cleanup = removeAbortListener as (() => void) | null;
+    if (cleanup != null) {
+      cleanup();
+    }
+  }
 }
 
 function isAbortError(error: unknown): boolean {
@@ -287,4 +325,35 @@ function isAbortError(error: unknown): boolean {
     return true;
   }
   return false;
+}
+
+function unwrapReviewerFetchResponse(
+  response: FetchPullReviewerSummaryResponse | undefined,
+): PullReviewerSummary {
+  if (response?.ok === true) {
+    return response.summary;
+  }
+
+  if (response?.ok === false) {
+    throw new ReviewerFetchRuntimeError(response.error);
+  }
+
+  throw new Error("Background reviewer fetch failed.");
+}
+
+let reviewerFetchRequestCounter = 0;
+
+function createReviewerFetchRequestId(): string {
+  reviewerFetchRequestCounter += 1;
+  return `reviewer-fetch-${Date.now()}-${reviewerFetchRequestCounter}`;
+}
+
+function createAbortError(): Error {
+  if (typeof DOMException === "function") {
+    return new DOMException("The operation was aborted.", "AbortError");
+  }
+
+  const error = new Error("The operation was aborted.");
+  error.name = "AbortError";
+  return error;
 }

--- a/src/runtime/reviewer-fetch.ts
+++ b/src/runtime/reviewer-fetch.ts
@@ -8,10 +8,16 @@ import {
 
 export type FetchPullReviewerSummaryMessage = {
   type: "fetchPullReviewerSummary";
+  requestId: string;
   owner: string;
   repo: string;
   pullNumber: string;
   accountId: string | null;
+};
+
+export type CancelPullReviewerSummaryMessage = {
+  type: "cancelPullReviewerSummary";
+  requestId: string;
 };
 
 export type ReviewerFetchFailure = {
@@ -36,6 +42,13 @@ export type FetchPullReviewerSummaryResponse =
       error: ReviewerFetchErrorEnvelope;
     };
 
+export class ReviewerFetchRuntimeError extends Error {
+  constructor(public readonly envelope: ReviewerFetchErrorEnvelope) {
+    super(envelope.message ?? "Background reviewer fetch failed.");
+    this.name = "ReviewerFetchRuntimeError";
+  }
+}
+
 export function isFetchPullReviewerSummaryMessage(
   value: unknown,
 ): value is FetchPullReviewerSummaryMessage {
@@ -43,11 +56,23 @@ export function isFetchPullReviewerSummaryMessage(
     value != null &&
     typeof value === "object" &&
     (value as { type?: unknown }).type === "fetchPullReviewerSummary" &&
-    typeof (value as { owner?: unknown }).owner === "string" &&
-    typeof (value as { repo?: unknown }).repo === "string" &&
-    typeof (value as { pullNumber?: unknown }).pullNumber === "string" &&
+    hasNonEmptyString((value as { requestId?: unknown }).requestId) &&
+    hasNonEmptyString((value as { owner?: unknown }).owner) &&
+    hasNonEmptyString((value as { repo?: unknown }).repo) &&
+    hasNonEmptyString((value as { pullNumber?: unknown }).pullNumber) &&
     (((value as { accountId?: unknown }).accountId === null) ||
       typeof (value as { accountId?: unknown }).accountId === "string")
+  );
+}
+
+export function isCancelPullReviewerSummaryMessage(
+  value: unknown,
+): value is CancelPullReviewerSummaryMessage {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    (value as { type?: unknown }).type === "cancelPullReviewerSummary" &&
+    hasNonEmptyString((value as { requestId?: unknown }).requestId)
   );
 }
 
@@ -105,6 +130,10 @@ export function serializeReviewerFetchError(
 export function extractReviewerFetchFailures(
   error: unknown,
 ): ReviewerFetchFailure[] {
+  if (error instanceof ReviewerFetchRuntimeError) {
+    return extractReviewerFetchFailures(error.envelope);
+  }
+
   if (error instanceof GitHubPullRequestEndpointsError) {
     return error.failures.map((failure) => ({
       status: failure.status,
@@ -154,4 +183,8 @@ export function extractReviewerFetchFailures(
   }
 
   return [];
+}
+
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
 }

--- a/src/runtime/reviewer-fetch.ts
+++ b/src/runtime/reviewer-fetch.ts
@@ -1,0 +1,157 @@
+import {
+  GitHubApiError,
+  GitHubApiSchemaError,
+  GitHubPullRequestEndpointsError,
+  extractGitHubApiStatus,
+  type PullReviewerSummary,
+} from "../github/api";
+
+export type FetchPullReviewerSummaryMessage = {
+  type: "fetchPullReviewerSummary";
+  owner: string;
+  repo: string;
+  pullNumber: string;
+  accountId: string | null;
+};
+
+export type ReviewerFetchFailure = {
+  status: number;
+  endpoint: string | null;
+};
+
+export type ReviewerFetchErrorEnvelope = {
+  kind: "github-api" | "github-endpoints" | "schema" | "unknown";
+  status: number | null;
+  failures?: ReviewerFetchFailure[];
+  message?: string;
+};
+
+export type FetchPullReviewerSummaryResponse =
+  | {
+      ok: true;
+      summary: PullReviewerSummary;
+    }
+  | {
+      ok: false;
+      error: ReviewerFetchErrorEnvelope;
+    };
+
+export function isFetchPullReviewerSummaryMessage(
+  value: unknown,
+): value is FetchPullReviewerSummaryMessage {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    (value as { type?: unknown }).type === "fetchPullReviewerSummary" &&
+    typeof (value as { owner?: unknown }).owner === "string" &&
+    typeof (value as { repo?: unknown }).repo === "string" &&
+    typeof (value as { pullNumber?: unknown }).pullNumber === "string" &&
+    (((value as { accountId?: unknown }).accountId === null) ||
+      typeof (value as { accountId?: unknown }).accountId === "string")
+  );
+}
+
+export function serializeReviewerFetchError(
+  error: unknown,
+): ReviewerFetchErrorEnvelope {
+  if (error instanceof GitHubPullRequestEndpointsError) {
+    return {
+      kind: "github-endpoints",
+      status: extractGitHubApiStatus(error),
+      failures: error.failures.map((failure) => ({
+        status: failure.status,
+        endpoint: failure.endpoint?.path ?? null,
+      })),
+      message: error.message,
+    };
+  }
+
+  if (error instanceof GitHubApiError) {
+    return {
+      kind: "github-api",
+      status: error.status,
+      failures: [
+        {
+          status: error.status,
+          endpoint: error.endpoint?.path ?? null,
+        },
+      ],
+      message: error.message,
+    };
+  }
+
+  if (error instanceof GitHubApiSchemaError) {
+    return {
+      kind: "schema",
+      status: null,
+      message: error.message,
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      kind: "unknown",
+      status: extractGitHubApiStatus(error),
+      message: error.message,
+    };
+  }
+
+  return {
+    kind: "unknown",
+    status: extractGitHubApiStatus(error),
+  };
+}
+
+export function extractReviewerFetchFailures(
+  error: unknown,
+): ReviewerFetchFailure[] {
+  if (error instanceof GitHubPullRequestEndpointsError) {
+    return error.failures.map((failure) => ({
+      status: failure.status,
+      endpoint: failure.endpoint?.path ?? null,
+    }));
+  }
+
+  if (error instanceof GitHubApiError) {
+    return [
+      {
+        status: error.status,
+        endpoint: error.endpoint?.path ?? null,
+      },
+    ];
+  }
+
+  if (
+    error != null &&
+    typeof error === "object" &&
+    "failures" in error &&
+    Array.isArray((error as { failures: unknown }).failures)
+  ) {
+    return (error as { failures: Array<{ status?: unknown; endpoint?: unknown }> }).failures
+      .filter(
+        (failure): failure is { status: number; endpoint?: string | null } =>
+          typeof failure?.status === "number",
+      )
+      .map((failure) => ({
+        status: failure.status,
+        endpoint:
+          typeof failure.endpoint === "string" ? failure.endpoint : null,
+      }));
+  }
+
+  if (
+    error != null &&
+    typeof error === "object" &&
+    "status" in error &&
+    typeof (error as { status: unknown }).status === "number"
+  ) {
+    return [
+      {
+        status: (error as { status: number }).status,
+        endpoint: null,
+      },
+    ];
+  }
+
+  return [];
+}

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as GithubApiModule from "../src/github/api";
 
 const refreshAccountTokenMock = vi.fn();
+const fetchPullReviewerSummaryMock = vi.fn();
+const getAccountByIdMock = vi.fn();
+const markAccountInvalidatedMock = vi.fn();
 const createRefreshCoordinatorMock = vi.fn(() => ({
   refreshAccountToken: refreshAccountTokenMock,
 }));
@@ -13,6 +17,21 @@ vi.mock("../src/auth/refresh-coordinator", () => ({
 vi.mock("../src/config/github-app", () => ({
   getGitHubAppConfig: getGitHubAppConfigMock,
 }));
+
+vi.mock("../src/storage/accounts", () => ({
+  getAccountById: getAccountByIdMock,
+  markAccountInvalidated: markAccountInvalidatedMock,
+}));
+
+vi.mock("../src/github/api", async () => {
+  const actual = await vi.importActual<typeof GithubApiModule>(
+    "../src/github/api",
+  );
+  return {
+    ...actual,
+    fetchPullReviewerSummary: fetchPullReviewerSummaryMock,
+  };
+});
 
 type MessageSender = { id?: string };
 type MessageListener = (
@@ -28,6 +47,9 @@ let capturedMessageListener: MessageListener | null;
 beforeEach(() => {
   vi.resetModules();
   refreshAccountTokenMock.mockReset();
+  fetchPullReviewerSummaryMock.mockReset();
+  getAccountByIdMock.mockReset();
+  markAccountInvalidatedMock.mockReset();
   refreshAccountTokenMock.mockResolvedValue({ ok: true, token: "new-token" });
   createRefreshCoordinatorMock.mockClear();
   getGitHubAppConfigMock.mockClear();
@@ -118,5 +140,157 @@ describe("background runtime.onMessage handler", () => {
     expect(wrongType).toBeUndefined();
     expect(notAnObject).toBeUndefined();
     expect(refreshAccountTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches reviewer fetch messages through the background handler", async () => {
+    const listener = await bootBackground();
+    const summary = {
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: [],
+      completedReviews: [],
+    };
+    getAccountByIdMock.mockResolvedValue({
+      id: "acc-1",
+      token: "ghu_123",
+      refreshToken: "ghr_123",
+    });
+    fetchPullReviewerSummaryMock.mockResolvedValue(summary);
+
+    const result = listener(
+      {
+        type: "fetchPullReviewerSummary",
+        owner: "cinev",
+        repo: "shotloom",
+        pullNumber: "42",
+        accountId: "acc-1",
+      },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+
+    await expect(result as Promise<unknown>).resolves.toEqual({
+      ok: true,
+      summary,
+    });
+    expect(fetchPullReviewerSummaryMock).toHaveBeenCalledWith({
+      owner: "cinev",
+      repo: "shotloom",
+      pullNumber: "42",
+      githubToken: "ghu_123",
+    });
+  });
+
+  it("refreshes on reviewer fetch 401 and retries with the updated token", async () => {
+    const listener = await bootBackground();
+    const summary = {
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: [],
+      completedReviews: [],
+    };
+    getAccountByIdMock
+      .mockResolvedValueOnce({
+        id: "acc-1",
+        token: "ghu_old",
+        refreshToken: "ghr_old",
+      })
+      .mockResolvedValueOnce({
+        id: "acc-1",
+        token: "ghu_new",
+        refreshToken: "ghr_new",
+      });
+    fetchPullReviewerSummaryMock
+      .mockRejectedValueOnce({ status: 401 })
+      .mockResolvedValueOnce(summary);
+
+    const result = listener(
+      {
+        type: "fetchPullReviewerSummary",
+        owner: "cinev",
+        repo: "shotloom",
+        pullNumber: "42",
+        accountId: "acc-1",
+      },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+
+    await expect(result as Promise<unknown>).resolves.toEqual({
+      ok: true,
+      summary,
+    });
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-1");
+    expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(2);
+    expect(fetchPullReviewerSummaryMock.mock.calls[1][0]).toMatchObject({
+      githubToken: "ghu_new",
+    });
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+  });
+
+  it("marks the account revoked when reviewer fetch 401s without a refresh token", async () => {
+    const listener = await bootBackground();
+    getAccountByIdMock.mockResolvedValue({
+      id: "acc-1",
+      token: "ghu_old",
+      refreshToken: null,
+    });
+    fetchPullReviewerSummaryMock.mockRejectedValueOnce({ status: 401 });
+
+    const result = listener(
+      {
+        type: "fetchPullReviewerSummary",
+        owner: "cinev",
+        repo: "shotloom",
+        pullNumber: "42",
+        accountId: "acc-1",
+      },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+
+    await expect(result as Promise<unknown>).resolves.toMatchObject({
+      ok: false,
+      error: { kind: "unknown", status: 401 },
+    });
+    expect(markAccountInvalidatedMock).toHaveBeenCalledWith("acc-1", "revoked");
+    expect(refreshAccountTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("marks the account revoked when the retry after refresh also returns 401", async () => {
+    const listener = await bootBackground();
+    getAccountByIdMock
+      .mockResolvedValueOnce({
+        id: "acc-1",
+        token: "ghu_old",
+        refreshToken: "ghr_old",
+      })
+      .mockResolvedValueOnce({
+        id: "acc-1",
+        token: "ghu_new",
+        refreshToken: "ghr_new",
+      });
+    fetchPullReviewerSummaryMock
+      .mockRejectedValueOnce({ status: 401 })
+      .mockRejectedValueOnce({ status: 401 });
+
+    const result = listener(
+      {
+        type: "fetchPullReviewerSummary",
+        owner: "cinev",
+        repo: "shotloom",
+        pullNumber: "42",
+        accountId: "acc-1",
+      },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+
+    await expect(result as Promise<unknown>).resolves.toMatchObject({
+      ok: false,
+      error: { kind: "unknown", status: 401 },
+    });
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-1");
+    expect(markAccountInvalidatedMock).toHaveBeenCalledWith("acc-1", "revoked");
   });
 });

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -44,6 +44,10 @@ const SELF_RUNTIME_ID = "self-extension-id";
 
 let capturedMessageListener: MessageListener | null;
 
+function flushMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 beforeEach(() => {
   vi.resetModules();
   refreshAccountTokenMock.mockReset();
@@ -372,7 +376,7 @@ describe("background runtime.onMessage handler", () => {
       () => {},
     );
 
-    await Promise.resolve();
+    await flushMicrotasks();
     expect(capturedSignal).not.toBeNull();
     const signal = capturedSignal as AbortSignal | null;
     if (signal == null) {
@@ -390,6 +394,54 @@ describe("background runtime.onMessage handler", () => {
     );
 
     expect(cancelResult).toBeUndefined();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("consumes a queued cancel when it arrives before the reviewer fetch message", async () => {
+    const listener = await bootBackground();
+    getAccountByIdMock.mockResolvedValue({
+      id: "acc-1",
+      token: "ghu_old",
+      refreshToken: "ghr_old",
+    });
+
+    let capturedSignal: AbortSignal | null = null;
+    fetchPullReviewerSummaryMock.mockImplementationOnce(
+      (input: { signal?: AbortSignal }) => {
+        capturedSignal = input.signal ?? null;
+        return new Promise(() => {});
+      },
+    );
+
+    const cancelResult = listener(
+      {
+        type: "cancelPullReviewerSummary",
+        requestId: "req-pre-cancel",
+      },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+    expect(cancelResult).toBeUndefined();
+
+    void listener(
+      {
+        type: "fetchPullReviewerSummary",
+        requestId: "req-pre-cancel",
+        owner: "cinev",
+        repo: "shotloom",
+        pullNumber: "42",
+        accountId: "acc-1",
+      },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+
+    await flushMicrotasks();
+    expect(capturedSignal).not.toBeNull();
+    const signal = capturedSignal as AbortSignal | null;
+    if (signal == null) {
+      throw new Error("expected background fetch signal");
+    }
     expect(signal.aborted).toBe(true);
   });
 });

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -135,10 +135,23 @@ describe("background runtime.onMessage handler", () => {
       { id: SELF_RUNTIME_ID },
       () => {},
     );
+    const emptyReviewerFetch = listener(
+      {
+        type: "fetchPullReviewerSummary",
+        requestId: "req-1",
+        owner: "",
+        repo: "shotloom",
+        pullNumber: "42",
+        accountId: null,
+      },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
 
     expect(missingAccountId).toBeUndefined();
     expect(wrongType).toBeUndefined();
     expect(notAnObject).toBeUndefined();
+    expect(emptyReviewerFetch).toBeUndefined();
     expect(refreshAccountTokenMock).not.toHaveBeenCalled();
   });
 
@@ -160,6 +173,7 @@ describe("background runtime.onMessage handler", () => {
     const result = listener(
       {
         type: "fetchPullReviewerSummary",
+        requestId: "req-1",
         owner: "cinev",
         repo: "shotloom",
         pullNumber: "42",
@@ -178,6 +192,7 @@ describe("background runtime.onMessage handler", () => {
       repo: "shotloom",
       pullNumber: "42",
       githubToken: "ghu_123",
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -207,6 +222,7 @@ describe("background runtime.onMessage handler", () => {
     const result = listener(
       {
         type: "fetchPullReviewerSummary",
+        requestId: "req-1",
         owner: "cinev",
         repo: "shotloom",
         pullNumber: "42",
@@ -228,6 +244,37 @@ describe("background runtime.onMessage handler", () => {
     expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
   });
 
+  it("returns the original error without invalidating when refresh is transiently unavailable", async () => {
+    const listener = await bootBackground();
+    getAccountByIdMock.mockResolvedValue({
+      id: "acc-1",
+      token: "ghu_old",
+      refreshToken: "ghr_old",
+    });
+    refreshAccountTokenMock.mockResolvedValueOnce({ ok: false, terminal: false });
+    fetchPullReviewerSummaryMock.mockRejectedValueOnce({ status: 401 });
+
+    const result = listener(
+      {
+        type: "fetchPullReviewerSummary",
+        requestId: "req-1",
+        owner: "cinev",
+        repo: "shotloom",
+        pullNumber: "42",
+        accountId: "acc-1",
+      },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+
+    await expect(result as Promise<unknown>).resolves.toMatchObject({
+      ok: false,
+      error: { kind: "unknown", status: 401 },
+    });
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-1");
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+  });
+
   it("marks the account revoked when reviewer fetch 401s without a refresh token", async () => {
     const listener = await bootBackground();
     getAccountByIdMock.mockResolvedValue({
@@ -240,6 +287,7 @@ describe("background runtime.onMessage handler", () => {
     const result = listener(
       {
         type: "fetchPullReviewerSummary",
+        requestId: "req-1",
         owner: "cinev",
         repo: "shotloom",
         pullNumber: "42",
@@ -277,6 +325,7 @@ describe("background runtime.onMessage handler", () => {
     const result = listener(
       {
         type: "fetchPullReviewerSummary",
+        requestId: "req-1",
         owner: "cinev",
         repo: "shotloom",
         pullNumber: "42",
@@ -292,5 +341,55 @@ describe("background runtime.onMessage handler", () => {
     });
     expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-1");
     expect(markAccountInvalidatedMock).toHaveBeenCalledWith("acc-1", "revoked");
+  });
+
+  it("aborts an in-flight reviewer fetch when a cancel message arrives", async () => {
+    const listener = await bootBackground();
+    getAccountByIdMock.mockResolvedValue({
+      id: "acc-1",
+      token: "ghu_old",
+      refreshToken: "ghr_old",
+    });
+
+    let capturedSignal: AbortSignal | null = null;
+    fetchPullReviewerSummaryMock.mockImplementationOnce(
+      (input: { signal?: AbortSignal }) => {
+        capturedSignal = input.signal ?? null;
+        return new Promise(() => {});
+      },
+    );
+
+    void listener(
+      {
+        type: "fetchPullReviewerSummary",
+        requestId: "req-cancel",
+        owner: "cinev",
+        repo: "shotloom",
+        pullNumber: "42",
+        accountId: "acc-1",
+      },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+
+    await Promise.resolve();
+    expect(capturedSignal).not.toBeNull();
+    const signal = capturedSignal as AbortSignal | null;
+    if (signal == null) {
+      throw new Error("expected background fetch signal");
+    }
+    expect(signal.aborted).toBe(false);
+
+    const cancelResult = listener(
+      {
+        type: "cancelPullReviewerSummary",
+        requestId: "req-cancel",
+      },
+      { id: SELF_RUNTIME_ID },
+      () => {},
+    );
+
+    expect(cancelResult).toBeUndefined();
+    expect(signal.aborted).toBe(true);
   });
 });

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -207,5 +207,27 @@ describe("content entrypoint", () => {
       expect(aggregator.reportUncoveredOwner).toHaveBeenCalledWith("cinev");
       expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
     });
+
+    it("classifies serialized reviewer-fetch failures the same way as GitHubApiError instances", async () => {
+      const aggregator = makeAggregator();
+      const { onRowFailure } = await bootContent(aggregator);
+
+      onRowFailure({
+        owner: "cinev",
+        repo: "shotloom",
+        account: { id: "acc-1" },
+        error: {
+          kind: "github-endpoints",
+          status: 404,
+          failures: [
+            { status: 404, endpoint: "/repos/cinev/shotloom/pulls/42" },
+            { status: 403, endpoint: "/repos/cinev/shotloom/pulls/42/reviews" },
+          ],
+        },
+      });
+
+      expect(aggregator.reportUncoveredOwner).toHaveBeenCalledWith("cinev");
+      expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -203,13 +203,16 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(runtimeSendMessageMock).toHaveBeenCalledWith({
-      type: "fetchPullReviewerSummary",
-      owner: "cinev",
-      repo: "shotloom",
-      pullNumber: "42",
-      accountId: "acc-1",
-    });
+    expect(runtimeSendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "fetchPullReviewerSummary",
+        owner: "cinev",
+        repo: "shotloom",
+        pullNumber: "42",
+        accountId: "acc-1",
+        requestId: expect.any(String),
+      }),
+    );
     expect(runtimeSendMessageMock).toHaveBeenCalledTimes(1);
   });
 
@@ -249,14 +252,16 @@ describe("bootReviewerListPage", () => {
   it("aborts in-flight summary fetches on storage (accounts) change and drops the late result", async () => {
     resolveAccountForRepoMock.mockResolvedValue(null);
 
-    // Capture the signal so we can assert abort() is called by the boot code.
     let resolveFetch: ((summary: PullReviewerSummary) => void) | null = null;
-    runtimeSendMessageMock.mockImplementationOnce(
-      () =>
+    runtimeSendMessageMock
+      .mockImplementationOnce(
+        () =>
         new Promise<{ ok: true; summary: PullReviewerSummary }>((resolve) => {
           resolveFetch = (summary) => resolve({ ok: true, summary });
         }),
-    );
+      )
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(() => new Promise<void>(() => {}));
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
     bootReviewerListPage(makeCtx());
@@ -284,14 +289,19 @@ describe("bootReviewerListPage", () => {
       requestedTeams: [],
       completedReviews: [],
     };
-    // Second fetch (triggered by the storage change) also pends — no render.
-    runtimeSendMessageMock.mockImplementationOnce(
-      () => new Promise<void>(() => {}),
-    );
     resolveFetch!(latePayload);
 
     await flushMicrotasks();
     await flushMicrotasks();
+
+    expect(runtimeSendMessageMock.mock.calls[1]?.[0]).toMatchObject({
+      type: "cancelPullReviewerSummary",
+      requestId: expect.any(String),
+    });
+    expect(runtimeSendMessageMock.mock.calls[2]?.[0]).toMatchObject({
+      type: "fetchPullReviewerSummary",
+      requestId: expect.any(String),
+    });
 
     // The aborted fetch must not have written its summary into the cache.
     // Easiest proxy: the mount should still show the loading text from the
@@ -306,10 +316,10 @@ describe("bootReviewerListPage", () => {
     runtimeSendMessageMock.mockResolvedValueOnce({
       ok: true,
       summary: {
-      status: "ok",
-      requestedUsers: [{ login: "alice", avatarUrl: null }],
-      requestedTeams: [],
-      completedReviews: [],
+        status: "ok",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+        completedReviews: [],
       },
     });
 
@@ -360,9 +370,9 @@ describe("bootReviewerListPage", () => {
   it("aborts in-flight summary fetches when navigation leaves the pull-list route", async () => {
     resolveAccountForRepoMock.mockResolvedValue(null);
 
-    runtimeSendMessageMock.mockImplementationOnce(
-      () => new Promise<void>(() => {}),
-    );
+    runtimeSendMessageMock
+      .mockImplementationOnce(() => new Promise<void>(() => {}))
+      .mockResolvedValueOnce(undefined);
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
     const ctx = makeCtx();
@@ -375,5 +385,10 @@ describe("bootReviewerListPage", () => {
     getRegisteredListener(ctx, "wxt:locationchange")?.();
 
     await flushMicrotasks();
+
+    expect(runtimeSendMessageMock.mock.calls[1]?.[0]).toMatchObject({
+      type: "cancelPullReviewerSummary",
+      requestId: expect.any(String),
+    });
   });
 });

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -3,30 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ContentScriptContext } from "wxt/utils/content-script-context";
 
 import type { PullReviewerSummary } from "../src/github/api";
-import type * as GithubApiModule from "../src/github/api";
 import type * as PreferencesModule from "../src/storage/preferences";
 
-const fetchPullReviewerSummaryMock = vi.fn();
 const resolveAccountForRepoMock = vi.fn();
-const getAccountByIdMock = vi.fn();
-const markAccountInvalidatedMock = vi.fn();
 const getPreferencesMock = vi.fn();
 const runtimeSendMessageMock = vi.fn();
 
-vi.mock("../src/github/api", async () => {
-  const actual = await vi.importActual<typeof GithubApiModule>(
-    "../src/github/api",
-  );
-  return {
-    ...actual,
-    fetchPullReviewerSummary: fetchPullReviewerSummaryMock,
-  };
-});
-
 vi.mock("../src/storage/accounts", () => ({
   resolveAccountForRepo: resolveAccountForRepoMock,
-  getAccountById: getAccountByIdMock,
-  markAccountInvalidated: markAccountInvalidatedMock,
 }));
 
 vi.mock("../src/storage/preferences", async () => {
@@ -81,10 +65,7 @@ function getRegisteredListener(
 
 beforeEach(() => {
   vi.resetModules();
-  fetchPullReviewerSummaryMock.mockReset();
   resolveAccountForRepoMock.mockReset();
-  getAccountByIdMock.mockReset();
-  markAccountInvalidatedMock.mockReset();
   getPreferencesMock.mockReset();
   runtimeSendMessageMock.mockReset();
   getPreferencesMock.mockResolvedValue({
@@ -126,25 +107,6 @@ afterEach(() => {
 });
 
 describe("bootReviewerListPage", () => {
-  it("marks the account revoked on 401 when there is no refresh token", async () => {
-    resolveAccountForRepoMock.mockResolvedValue({
-      id: "acc-1",
-      login: "hon454",
-      token: "ghu_abc",
-      refreshToken: null,
-    });
-    fetchPullReviewerSummaryMock.mockRejectedValue({ status: 401 });
-
-    const { bootReviewerListPage } = await import("../src/features/reviewers");
-    bootReviewerListPage(makeCtx());
-
-    await flushMicrotasks();
-    await flushMicrotasks();
-
-    expect(markAccountInvalidatedMock).toHaveBeenCalledWith("acc-1", "revoked");
-    expect(runtimeSendMessageMock).not.toHaveBeenCalled();
-  });
-
   it("rerenders on preferences change without refetching reviewer data", async () => {
     resolveAccountForRepoMock.mockResolvedValue(null);
     const summary: PullReviewerSummary = {
@@ -153,14 +115,14 @@ describe("bootReviewerListPage", () => {
       requestedTeams: [],
       completedReviews: [],
     };
-    fetchPullReviewerSummaryMock.mockResolvedValue(summary);
+    runtimeSendMessageMock.mockResolvedValue({ ok: true, summary });
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
     bootReviewerListPage(makeCtx());
 
     await flushMicrotasks();
     await flushMicrotasks();
-    expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(1);
+    expect(runtimeSendMessageMock).toHaveBeenCalledTimes(1);
     expect(document.querySelector("a.ghpsr-pill")).toBeNull();
     expect(document.querySelector("a.ghpsr-avatar")).not.toBeNull();
 
@@ -182,7 +144,7 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(1);
+    expect(runtimeSendMessageMock).toHaveBeenCalledTimes(1);
     expect(document.querySelector("a.ghpsr-pill")).not.toBeNull();
   });
 
@@ -194,14 +156,14 @@ describe("bootReviewerListPage", () => {
       requestedTeams: [],
       completedReviews: [],
     };
-    fetchPullReviewerSummaryMock.mockResolvedValue(summary);
+    runtimeSendMessageMock.mockResolvedValue({ ok: true, summary });
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
     bootReviewerListPage(makeCtx());
 
     await flushMicrotasks();
     await flushMicrotasks();
-    expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(1);
+    expect(runtimeSendMessageMock).toHaveBeenCalledTimes(1);
 
     capturedStorageListener!(
       {
@@ -216,10 +178,10 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(2);
+    expect(runtimeSendMessageMock).toHaveBeenCalledTimes(2);
   });
 
-  it("refreshes the access token on 401 and retries with the new token", async () => {
+  it("sends reviewer fetch requests through the background runtime contract", async () => {
     const summary: PullReviewerSummary = {
       status: "ok",
       requestedUsers: [],
@@ -227,80 +189,28 @@ describe("bootReviewerListPage", () => {
       completedReviews: [],
     };
 
-    resolveAccountForRepoMock
-      .mockResolvedValueOnce({
-        id: "acc-1",
-        login: "hon454",
-        token: "ghu_old",
-        refreshToken: "ghr_old",
-      });
-    getAccountByIdMock.mockResolvedValueOnce({
+    resolveAccountForRepoMock.mockResolvedValueOnce({
       id: "acc-1",
       login: "hon454",
-      token: "ghu_new",
-      refreshToken: "ghr_new",
+      token: "ghu_old",
+      refreshToken: "ghr_old",
     });
-
-    fetchPullReviewerSummaryMock
-      .mockRejectedValueOnce({ status: 401 })
-      .mockResolvedValueOnce(summary);
-
-    runtimeSendMessageMock.mockResolvedValueOnce({ ok: true, token: "ghu_new" });
+    runtimeSendMessageMock.mockResolvedValueOnce({ ok: true, summary });
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
     bootReviewerListPage(makeCtx());
 
-    await flushMicrotasks();
     await flushMicrotasks();
     await flushMicrotasks();
 
     expect(runtimeSendMessageMock).toHaveBeenCalledWith({
-      type: "refreshAccessToken",
+      type: "fetchPullReviewerSummary",
+      owner: "cinev",
+      repo: "shotloom",
+      pullNumber: "42",
       accountId: "acc-1",
     });
-    expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(2);
-    expect(fetchPullReviewerSummaryMock.mock.calls[1][0]).toMatchObject({
-      githubToken: "ghu_new",
-    });
-    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
-  });
-
-  it("does not invalidate when the BG refresh returns terminal=true (BG already marked the account)", async () => {
-    resolveAccountForRepoMock.mockResolvedValue({
-      id: "acc-1",
-      login: "hon454",
-      token: "ghu_old",
-      refreshToken: "ghr_old",
-    });
-    fetchPullReviewerSummaryMock.mockRejectedValue({ status: 401 });
-    runtimeSendMessageMock.mockResolvedValueOnce({ ok: false, terminal: true });
-
-    const { bootReviewerListPage } = await import("../src/features/reviewers");
-    bootReviewerListPage(makeCtx());
-
-    await flushMicrotasks();
-    await flushMicrotasks();
-
-    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
-  });
-
-  it("does not invalidate on a transient refresh failure", async () => {
-    resolveAccountForRepoMock.mockResolvedValue({
-      id: "acc-1",
-      login: "hon454",
-      token: "ghu_old",
-      refreshToken: "ghr_old",
-    });
-    fetchPullReviewerSummaryMock.mockRejectedValue({ status: 401 });
-    runtimeSendMessageMock.mockResolvedValueOnce({ ok: false, terminal: false });
-
-    const { bootReviewerListPage } = await import("../src/features/reviewers");
-    bootReviewerListPage(makeCtx());
-
-    await flushMicrotasks();
-    await flushMicrotasks();
-
-    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+    expect(runtimeSendMessageMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not flash loading text on a cache-hit re-render", async () => {
@@ -328,7 +238,7 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(fetchPullReviewerSummaryMock).not.toHaveBeenCalled();
+    expect(runtimeSendMessageMock).not.toHaveBeenCalled();
     // The row should render reviewer chips straight from cache; no loading text.
     expect(document.body.textContent).not.toContain("Loading reviewers");
     expect(document.querySelector("a.ghpsr-avatar")).not.toBeNull();
@@ -340,15 +250,12 @@ describe("bootReviewerListPage", () => {
     resolveAccountForRepoMock.mockResolvedValue(null);
 
     // Capture the signal so we can assert abort() is called by the boot code.
-    let capturedSignal: AbortSignal | null = null;
     let resolveFetch: ((summary: PullReviewerSummary) => void) | null = null;
-    fetchPullReviewerSummaryMock.mockImplementationOnce(
-      (input: { signal?: AbortSignal }) => {
-        capturedSignal = input.signal ?? null;
-        return new Promise<PullReviewerSummary>((resolve) => {
-          resolveFetch = resolve;
-        });
-      },
+    runtimeSendMessageMock.mockImplementationOnce(
+      () =>
+        new Promise<{ ok: true; summary: PullReviewerSummary }>((resolve) => {
+          resolveFetch = (summary) => resolve({ ok: true, summary });
+        }),
     );
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
@@ -356,8 +263,6 @@ describe("bootReviewerListPage", () => {
 
     await flushMicrotasks();
     await flushMicrotasks();
-    expect(capturedSignal).not.toBeNull();
-    expect(capturedSignal!.aborted).toBe(false);
 
     capturedStorageListener!(
       {
@@ -370,7 +275,6 @@ describe("bootReviewerListPage", () => {
     );
 
     await flushMicrotasks();
-    expect(capturedSignal!.aborted).toBe(true);
 
     // The stale fetch resolves AFTER the abort — it must not poison the cache
     // and must not render anything into the mount.
@@ -381,8 +285,8 @@ describe("bootReviewerListPage", () => {
       completedReviews: [],
     };
     // Second fetch (triggered by the storage change) also pends — no render.
-    fetchPullReviewerSummaryMock.mockImplementationOnce(
-      () => new Promise<PullReviewerSummary>(() => {}),
+    runtimeSendMessageMock.mockImplementationOnce(
+      () => new Promise<void>(() => {}),
     );
     resolveFetch!(latePayload);
 
@@ -399,11 +303,14 @@ describe("bootReviewerListPage", () => {
 
   it("shows loading again after a failed refetch clears a previously rendered row", async () => {
     resolveAccountForRepoMock.mockResolvedValue(null);
-    fetchPullReviewerSummaryMock.mockResolvedValueOnce({
+    runtimeSendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      summary: {
       status: "ok",
       requestedUsers: [{ login: "alice", avatarUrl: null }],
       requestedTeams: [],
       completedReviews: [],
+      },
     });
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
@@ -413,7 +320,10 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
     expect(document.querySelector("a.ghpsr-avatar")).not.toBeNull();
 
-    fetchPullReviewerSummaryMock.mockRejectedValueOnce(new Error("boom"));
+    runtimeSendMessageMock.mockResolvedValueOnce({
+      ok: false,
+      error: { kind: "unknown", status: null, message: "boom" },
+    });
     capturedStorageListener!(
       {
         settings: {
@@ -429,8 +339,8 @@ describe("bootReviewerListPage", () => {
     expect(document.body.textContent).not.toContain("alice");
     expect(document.body.textContent).not.toContain("Loading reviewers");
 
-    fetchPullReviewerSummaryMock.mockImplementationOnce(
-      () => new Promise<PullReviewerSummary>(() => {}),
+    runtimeSendMessageMock.mockImplementationOnce(
+      () => new Promise<never>(() => {}),
     );
     capturedStorageListener!(
       {
@@ -450,12 +360,8 @@ describe("bootReviewerListPage", () => {
   it("aborts in-flight summary fetches when navigation leaves the pull-list route", async () => {
     resolveAccountForRepoMock.mockResolvedValue(null);
 
-    let capturedSignal: AbortSignal | null = null;
-    fetchPullReviewerSummaryMock.mockImplementationOnce(
-      (input: { signal?: AbortSignal }) => {
-        capturedSignal = input.signal ?? null;
-        return new Promise<PullReviewerSummary>(() => {});
-      },
+    runtimeSendMessageMock.mockImplementationOnce(
+      () => new Promise<void>(() => {}),
     );
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
@@ -464,43 +370,10 @@ describe("bootReviewerListPage", () => {
 
     await flushMicrotasks();
     await flushMicrotasks();
-    expect(capturedSignal).not.toBeNull();
-    expect(capturedSignal!.aborted).toBe(false);
 
     window.history.replaceState({}, "", "/cinev/shotloom/pull/42");
     getRegisteredListener(ctx, "wxt:locationchange")?.();
 
     await flushMicrotasks();
-
-    expect(capturedSignal!.aborted).toBe(true);
-  });
-
-  it("marks the account revoked when the retry after refresh also returns 401", async () => {
-    resolveAccountForRepoMock
-      .mockResolvedValueOnce({
-        id: "acc-1",
-        login: "hon454",
-        token: "ghu_old",
-        refreshToken: "ghr_old",
-      });
-    getAccountByIdMock.mockResolvedValueOnce({
-      id: "acc-1",
-      login: "hon454",
-      token: "ghu_new",
-      refreshToken: "ghr_new",
-    });
-    fetchPullReviewerSummaryMock
-      .mockRejectedValueOnce({ status: 401 })
-      .mockRejectedValueOnce({ status: 401 });
-    runtimeSendMessageMock.mockResolvedValueOnce({ ok: true, token: "ghu_new" });
-
-    const { bootReviewerListPage } = await import("../src/features/reviewers");
-    bootReviewerListPage(makeCtx());
-
-    await flushMicrotasks();
-    await flushMicrotasks();
-    await flushMicrotasks();
-
-    expect(markAccountInvalidatedMock).toHaveBeenCalledWith("acc-1", "revoked");
   });
 });


### PR DESCRIPTION
## Summary

- Move authenticated reviewer fetches behind the MV3 background worker instead of calling GitHub directly from the content script.
- Add a shared runtime message contract so reviewer fetch success, failure, and cancellation semantics stay typed across the message boundary.
- Document the new background-owned auth path in manual Chrome testing.

## Why

Issue #7 tracks a follow-up to the reactive token refresh work from #6. The reviewer flow still performed authenticated GitHub API calls from the content-script context, which left the token in the page-adjacent execution path and kept the auth retry logic split across layers. This PR moves the reviewer fetch boundary into the background worker first, without changing reviewer UI behavior, so the auth path has a clearer ownership model before proactive refresh work lands.

## Changes

- Background auth ownership:
  add a background reviewer-fetch service that loads the latest account state, performs the authenticated reviewer fetch, supports cancellation, and handles `401 -> refresh -> retry once` through the existing refresh coordinator.
- Runtime contract:
  introduce a shared message contract for `fetchPullReviewerSummary` and `cancelPullReviewerSummary` plus a serializable error envelope so content-side failure routing still distinguishes rate-limit and uncovered-access cases.
- Reviewer orchestration and tests:
  switch the reviewer feature to request summaries through `browser.runtime.sendMessage`, restore abort propagation to the underlying GitHub fetch, wrap runtime failures in an `Error`, and update background/content/reviewer tests to cover the new message boundary.
- Docs:
  update manual Chrome testing notes for the background-owned auth path.

## Impact

- User-facing impact: No intentional reviewer UX change; private-repo reviewer fetches should behave the same while keeping auth work in the background.
- API/schema impact: Adds internal runtime message contracts for reviewer fetch and cancellation plus serialized failures; no external API changes.
- Performance impact: Adds one extension message hop for reviewer fetches, but restores abort-driven request cancellation so stale row work does not continue spending authenticated API budget.
- Operational or rollout impact: Manual auth debugging should now include service worker DevTools because authenticated reviewer fetches run there.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

### Test details

- `pnpm exec tsc --noEmit`
- `pnpm test`

## Breaking Changes

- None

## Related Issues

Part of #7

<!-- Co-location note: auth behavior changed, so `docs/manual-chrome-testing.md` was updated. No other co-location checklist items applied. -->
