### PR TITLE
docs(agents): ban force-adding ignored files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ Agents working in this repository should preserve that narrow product scope. Do 
 - Update `README.md` and `docs/implementation-notes.md` when MVP behavior or scope changes.
 - Keep review-state semantics explicit. If review states are shown, document which GitHub states are included and how they are mapped in the UI.
 - Prefer fixture-backed regression coverage for GitHub DOM behavior and reserve placeholder end-to-end tests for bootstrapping only.
+- Never force-add ignored files. `git add -f` is prohibited in this repository.
+- Treat ignored files as non-trackable workspace artifacts. Do not convert them into tracked files unless the maintainer first changes the ignore rules in a normal reviewed change.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- Add a repository-level rule in `AGENTS.md` that `git add -f` must not be used.
- Clarify that ignored files stay non-trackable unless the ignore rules are changed in a normal reviewed diff.

## Why

This policy came up during the auth-background-fetch work, but it is orthogonal to that PR's product and architecture scope. Splitting it out keeps the auth PR focused while still documenting the repo rule in the right source-of-truth document.

## Changes

- Add two implementation-guideline bullets in `AGENTS.md` covering the `git add -f` ban and the handling of ignored files.

## Impact

- User-facing impact: None.
- API/schema impact: None.
- Performance impact: None.
- Operational or rollout impact: Contributors and agents now have an explicit repo policy for ignored files.

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- Not applicable; docs-only change.

## Breaking Changes

- None

## Related Issues

No issue: split from PR #15 review feedback to keep auth work focused

<!-- Co-location note: none. This is a docs-only repository policy update in the AGENTS source-of-truth file. -->
