### PR TITLE
chore(reviewers): prune stale cancel entries on fetch entry

### DIFF
--- a/src/background/reviewer-fetch.ts
+++ b/src/background/reviewer-fetch.ts
@@ -7,6 +7,8 @@ import {
   type FetchPullReviewerSummaryResponse,
 } from "../runtime/reviewer-fetch";
 
+export const CANCELED_REQUEST_TTL_MS = 60_000;
+
 export type ReviewerFetchService = {
   cancelRequest(requestId: string): void;
   handleFetchMessage(
@@ -22,9 +24,8 @@ export function createReviewerFetchService(input: {
   const canceledRequestIds = new Map<string, number>();
 
   function pruneCanceledRequestIds(now: number): void {
-    const maxAgeMs = 60_000;
     for (const [requestId, createdAt] of canceledRequestIds) {
-      if (now - createdAt > maxAgeMs) {
+      if (now - createdAt > CANCELED_REQUEST_TTL_MS) {
         canceledRequestIds.delete(requestId);
       }
     }
@@ -45,6 +46,8 @@ export function createReviewerFetchService(input: {
     async handleFetchMessage(
       message: FetchPullReviewerSummaryMessage,
     ): Promise<FetchPullReviewerSummaryResponse> {
+      // Prune on both cancel and fetch entry so the TTL applies symmetrically
+      // even when a cancel's matching fetch never arrives.
       pruneCanceledRequestIds(Date.now());
 
       const controller = new AbortController();

--- a/src/background/reviewer-fetch.ts
+++ b/src/background/reviewer-fetch.ts
@@ -45,6 +45,8 @@ export function createReviewerFetchService(input: {
     async handleFetchMessage(
       message: FetchPullReviewerSummaryMessage,
     ): Promise<FetchPullReviewerSummaryResponse> {
+      pruneCanceledRequestIds(Date.now());
+
       const controller = new AbortController();
       inFlightControllers.set(message.requestId, controller);
 

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -1,14 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type * as GithubApiModule from "../src/github/api";
+import { CANCELED_REQUEST_TTL_MS } from "../src/background/reviewer-fetch";
 
-const refreshAccountTokenMock = vi.fn();
-const fetchPullReviewerSummaryMock = vi.fn();
-const getAccountByIdMock = vi.fn();
-const markAccountInvalidatedMock = vi.fn();
-const createRefreshCoordinatorMock = vi.fn(() => ({
+const {
+  refreshAccountTokenMock,
+  fetchPullReviewerSummaryMock,
+  getAccountByIdMock,
+  markAccountInvalidatedMock,
+  createRefreshCoordinatorMock,
+  getGitHubAppConfigMock,
+} = vi.hoisted(() => ({
+  refreshAccountTokenMock: vi.fn(),
+  fetchPullReviewerSummaryMock: vi.fn(),
+  getAccountByIdMock: vi.fn(),
+  markAccountInvalidatedMock: vi.fn(),
+  createRefreshCoordinatorMock: vi.fn(),
+  getGitHubAppConfigMock: vi.fn(() => ({ clientId: "test-client-id" })),
+}));
+createRefreshCoordinatorMock.mockImplementation(() => ({
   refreshAccountToken: refreshAccountTokenMock,
 }));
-const getGitHubAppConfigMock = vi.fn(() => ({ clientId: "test-client-id" }));
 
 vi.mock("../src/auth/refresh-coordinator", () => ({
   createRefreshCoordinator: createRefreshCoordinatorMock,
@@ -397,10 +408,14 @@ describe("background runtime.onMessage handler", () => {
     expect(signal.aborted).toBe(true);
   });
 
-  it("prunes TTL-expired queued cancels when a later cancel arrives", async () => {
-    vi.useFakeTimers({ toFake: ["Date"] });
-    try {
-      const baseTime = 1_700_000_000_000;
+  describe("prunes TTL-expired queued cancels", () => {
+    const baseTime = 1_700_000_000_000;
+    const pastTtl = baseTime + CANCELED_REQUEST_TTL_MS + 1_000;
+
+    async function setupTtlScenario(): Promise<{
+      listener: MessageListener;
+      getCapturedSignal: () => AbortSignal;
+    }> {
       vi.setSystemTime(new Date(baseTime));
       const listener = await bootBackground();
       getAccountByIdMock.mockResolvedValue({
@@ -423,92 +438,65 @@ describe("background runtime.onMessage handler", () => {
         () => {},
       );
 
-      // Advance past the 60s TTL. A subsequent cancel must prune `req-stale`.
-      vi.setSystemTime(new Date(baseTime + 61_000));
+      return {
+        listener,
+        getCapturedSignal: () => {
+          if (capturedSignal == null) {
+            throw new Error("expected background fetch signal");
+          }
+          return capturedSignal;
+        },
+      };
+    }
+
+    function dispatchStaleFetch(listener: MessageListener): void {
+      void listener(
+        {
+          type: "fetchPullReviewerSummary",
+          requestId: "req-stale",
+          owner: "cinev",
+          repo: "shotloom",
+          pullNumber: "42",
+          accountId: "acc-1",
+        },
+        { id: SELF_RUNTIME_ID },
+        () => {},
+      );
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("prunes when a later cancel arrives past the TTL", async () => {
+      const { listener, getCapturedSignal } = await setupTtlScenario();
+
+      vi.setSystemTime(new Date(pastTtl));
       listener(
         { type: "cancelPullReviewerSummary", requestId: "req-other" },
         { id: SELF_RUNTIME_ID },
         () => {},
       );
 
-      void listener(
-        {
-          type: "fetchPullReviewerSummary",
-          requestId: "req-stale",
-          owner: "cinev",
-          repo: "shotloom",
-          pullNumber: "42",
-          accountId: "acc-1",
-        },
-        { id: SELF_RUNTIME_ID },
-        () => {},
-      );
+      dispatchStaleFetch(listener);
 
       await flushMicrotasks();
-      expect(capturedSignal).not.toBeNull();
-      const signal = capturedSignal as AbortSignal | null;
-      if (signal == null) {
-        throw new Error("expected background fetch signal");
-      }
-      expect(signal.aborted).toBe(false);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+      expect(getCapturedSignal().aborted).toBe(false);
+    });
 
-  it("prunes TTL-expired queued cancels on fetch entry even without another cancel", async () => {
-    vi.useFakeTimers({ toFake: ["Date"] });
-    try {
-      const baseTime = 1_700_000_000_000;
-      vi.setSystemTime(new Date(baseTime));
-      const listener = await bootBackground();
-      getAccountByIdMock.mockResolvedValue({
-        id: "acc-1",
-        token: "ghu_old",
-        refreshToken: "ghr_old",
-      });
+    it("prunes on fetch entry even without another cancel", async () => {
+      const { listener, getCapturedSignal } = await setupTtlScenario();
 
-      let capturedSignal: AbortSignal | null = null;
-      fetchPullReviewerSummaryMock.mockImplementationOnce(
-        (input: { signal?: AbortSignal }) => {
-          capturedSignal = input.signal ?? null;
-          return new Promise(() => {});
-        },
-      );
-
-      listener(
-        { type: "cancelPullReviewerSummary", requestId: "req-stale" },
-        { id: SELF_RUNTIME_ID },
-        () => {},
-      );
-
-      // Advance past the 60s TTL without another cancel. The fetch itself
-      // must prune the stale entry and run normally.
-      vi.setSystemTime(new Date(baseTime + 61_000));
-
-      void listener(
-        {
-          type: "fetchPullReviewerSummary",
-          requestId: "req-stale",
-          owner: "cinev",
-          repo: "shotloom",
-          pullNumber: "42",
-          accountId: "acc-1",
-        },
-        { id: SELF_RUNTIME_ID },
-        () => {},
-      );
+      vi.setSystemTime(new Date(pastTtl));
+      dispatchStaleFetch(listener);
 
       await flushMicrotasks();
-      expect(capturedSignal).not.toBeNull();
-      const signal = capturedSignal as AbortSignal | null;
-      if (signal == null) {
-        throw new Error("expected background fetch signal");
-      }
-      expect(signal.aborted).toBe(false);
-    } finally {
-      vi.useRealTimers();
-    }
+      expect(getCapturedSignal().aborted).toBe(false);
+    });
   });
 
   it("consumes a queued cancel when it arrives before the reviewer fetch message", async () => {

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -397,6 +397,120 @@ describe("background runtime.onMessage handler", () => {
     expect(signal.aborted).toBe(true);
   });
 
+  it("prunes TTL-expired queued cancels when a later cancel arrives", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      const baseTime = 1_700_000_000_000;
+      vi.setSystemTime(new Date(baseTime));
+      const listener = await bootBackground();
+      getAccountByIdMock.mockResolvedValue({
+        id: "acc-1",
+        token: "ghu_old",
+        refreshToken: "ghr_old",
+      });
+
+      let capturedSignal: AbortSignal | null = null;
+      fetchPullReviewerSummaryMock.mockImplementationOnce(
+        (input: { signal?: AbortSignal }) => {
+          capturedSignal = input.signal ?? null;
+          return new Promise(() => {});
+        },
+      );
+
+      listener(
+        { type: "cancelPullReviewerSummary", requestId: "req-stale" },
+        { id: SELF_RUNTIME_ID },
+        () => {},
+      );
+
+      // Advance past the 60s TTL. A subsequent cancel must prune `req-stale`.
+      vi.setSystemTime(new Date(baseTime + 61_000));
+      listener(
+        { type: "cancelPullReviewerSummary", requestId: "req-other" },
+        { id: SELF_RUNTIME_ID },
+        () => {},
+      );
+
+      void listener(
+        {
+          type: "fetchPullReviewerSummary",
+          requestId: "req-stale",
+          owner: "cinev",
+          repo: "shotloom",
+          pullNumber: "42",
+          accountId: "acc-1",
+        },
+        { id: SELF_RUNTIME_ID },
+        () => {},
+      );
+
+      await flushMicrotasks();
+      expect(capturedSignal).not.toBeNull();
+      const signal = capturedSignal as AbortSignal | null;
+      if (signal == null) {
+        throw new Error("expected background fetch signal");
+      }
+      expect(signal.aborted).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("prunes TTL-expired queued cancels on fetch entry even without another cancel", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      const baseTime = 1_700_000_000_000;
+      vi.setSystemTime(new Date(baseTime));
+      const listener = await bootBackground();
+      getAccountByIdMock.mockResolvedValue({
+        id: "acc-1",
+        token: "ghu_old",
+        refreshToken: "ghr_old",
+      });
+
+      let capturedSignal: AbortSignal | null = null;
+      fetchPullReviewerSummaryMock.mockImplementationOnce(
+        (input: { signal?: AbortSignal }) => {
+          capturedSignal = input.signal ?? null;
+          return new Promise(() => {});
+        },
+      );
+
+      listener(
+        { type: "cancelPullReviewerSummary", requestId: "req-stale" },
+        { id: SELF_RUNTIME_ID },
+        () => {},
+      );
+
+      // Advance past the 60s TTL without another cancel. The fetch itself
+      // must prune the stale entry and run normally.
+      vi.setSystemTime(new Date(baseTime + 61_000));
+
+      void listener(
+        {
+          type: "fetchPullReviewerSummary",
+          requestId: "req-stale",
+          owner: "cinev",
+          repo: "shotloom",
+          pullNumber: "42",
+          accountId: "acc-1",
+        },
+        { id: SELF_RUNTIME_ID },
+        () => {},
+      );
+
+      await flushMicrotasks();
+      expect(capturedSignal).not.toBeNull();
+      const signal = capturedSignal as AbortSignal | null;
+      if (signal == null) {
+        throw new Error("expected background fetch signal");
+      }
+      expect(signal.aborted).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("consumes a queued cancel when it arrives before the reviewer fetch message", async () => {
     const listener = await bootBackground();
     getAccountByIdMock.mockResolvedValue({


### PR DESCRIPTION
## Summary

- Run `pruneCanceledRequestIds` at the top of `handleFetchMessage` so orphaned queued-cancel entries evict themselves even when no follow-up cancel ever arrives.
- Add regression coverage for the 60s TTL pruning that previously had no explicit test.

## Why

Follow-up polish on #15. The reviewer-fetch service's `canceledRequestIds` map is pruned only inside `cancelRequest`. In the edge case where a cancel arrives for a fetch that never comes back (extension reload, dropped message), that entry sits in the map until another cancel event fires the prune. Running the prune at the top of `handleFetchMessage` makes the 60s TTL apply uniformly on both sides of the cancel-vs-fetch race, and adding a test for the TTL itself locks the expiration contract so future refactors cannot regress it.

## Changes

- `src/background/reviewer-fetch.ts`: call `pruneCanceledRequestIds(Date.now())` as the first statement of `handleFetchMessage`.
- `tests/background.test.ts`: add two fake-timer-backed tests — (a) pruning triggered by a later cancel after the TTL window, (b) pruning triggered by an incoming fetch after the TTL window.

## Impact

- User-facing impact: None. Behavior only differs for a stale cancel entry (>60s old) whose matching fetch arrives later — previously that honored the ancient cancel and aborted the fetch; now the fetch runs normally.
- API/schema impact: None.
- Performance impact: One `Map` scan per fetch message. Map size is bounded by the number of outstanding queued cancels over the last 60s, which is effectively zero in steady state.
- Operational or rollout impact: None.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`

## Breaking Changes

- None

## Related Issues

No issue: follow-up polish identified during #15 review.