### PR TITLE
feat(auth): proactively refresh access tokens via chrome.alarms

### DIFF
--- a/docs/adr/0005-proactive-refresh.md
+++ b/docs/adr/0005-proactive-refresh.md
@@ -85,15 +85,15 @@ proactive and reactive paths race.
 - Terminal refresh-token failures surface promptly without a failed network
   call every 15 minutes.
 
-### Negative (known limitation)
+### Negative
 
-- `browser.alarms.onAlarm` listeners do not extend service-worker lifetime
-  for async work. `handleAlarmFire` completes multiple refreshes via
-  `Promise.allSettled`; at current product scale (few accounts, fast refresh
-  endpoint) the work fits comfortably inside the ~30s SW-alive window after
-  the event, but this is not a structural guarantee. A truncated run is
-  bounded-harm: the reactive refresh path still serves as the safety net,
-  and the next 15-minute alarm retries.
+- Known limitation: `browser.alarms.onAlarm` listeners do not extend
+  service-worker lifetime for async work. `handleAlarmFire` completes
+  multiple refreshes via `Promise.allSettled`; at current product scale (few
+  accounts, fast refresh endpoint) the work fits comfortably inside the ~30s
+  SW-alive window after the event, but this is not a structural guarantee.
+  A truncated run is bounded-harm: the reactive refresh path still serves as
+  the safety net, and the next 15-minute alarm retries.
 
 ### Neutral
 

--- a/docs/adr/0005-proactive-refresh.md
+++ b/docs/adr/0005-proactive-refresh.md
@@ -1,0 +1,125 @@
+# ADR 0005: Proactive Access Token Refresh via chrome.alarms
+
+- Status: Accepted — extends [ADR 0004](./0004-github-app-token-refresh.md) with a proactive refresh path
+- Date: 2026-04-24
+
+## Context
+
+[ADR 0004](./0004-github-app-token-refresh.md) made 8-hour access-token expiry
+invisible by exchanging a stored `refresh_token` inside the MV3 service worker
+the moment a reviewer fetch hits 401. Two gaps remained:
+
+- The unlucky first row after expiry still paid the refresh round-trip in the
+  user's view.
+- Access tokens that expired while no GitHub tab was open were never refreshed
+  until the user browsed back to a PR list.
+
+`chrome.alarms` persists registrations across MV3 service-worker activations,
+so a recurring alarm can drive refreshes independently of tab state and close
+both gaps.
+
+## Decision
+
+Register a single recurring alarm that pre-warms soon-to-expire access tokens
+and drops terminal accounts early.
+
+- `src/config/proactive-refresh.ts` exports
+  `PROACTIVE_REFRESH_ALARM_NAME`, `PROACTIVE_REFRESH_PERIOD_MINUTES = 15`, and
+  `PROACTIVE_REFRESH_THRESHOLD_MS = 30 * 60 * 1000`. Threshold exceeds the
+  period so no expiry window slips between fires.
+- `src/background/proactive-refresh.ts` exposes two pure selectors —
+  `selectAccountsDueForRefresh` and `selectAccountsWithExpiredRefreshToken` —
+  plus `createProactiveRefreshService` that schedules the alarm and routes
+  eligible accounts through the shared refresh coordinator.
+- Accounts whose `refreshTokenExpiresAt` is already in the past are not sent
+  to the coordinator; the proactive path calls `markAccountInvalidated(id,
+  "expired")` directly because the refresh network call is guaranteed to fail.
+- `entrypoints/background.ts` wires the service, schedules the alarm on every
+  SW boot (`scheduleAlarm` guards against SW-restart resets by calling
+  `browser.alarms.get` and skipping re-creation when the existing period
+  matches), and routes `browser.alarms.onAlarm` into the handler.
+- The `alarms` manifest permission is added via `wxt.config.ts`.
+
+Refresh dispatch uses `Promise.allSettled` so one account's failure does not
+abort others. The shared in-flight dedupe in
+`src/auth/refresh-coordinator.ts` prevents thundering-herd refreshes when
+proactive and reactive paths race.
+
+## Rationale
+
+- First-row refresh latency is eliminated for the common case: tokens are
+  refreshed 30 minutes before expiry, well before any reviewer fetch triggers
+  reactive retry.
+- Closed-tab expiry is covered because the alarm wakes the SW on its own.
+- Accounts with a terminal refresh-token failure surface "sign in again" in
+  the options UI without waiting for a user action, removing a silent dead-
+  account class.
+- The reactive refresh path remains the safety net, so a missed or truncated
+  proactive fire does not break the first reviewer row.
+
+## Alternatives considered
+
+- **Per-account alarms (structurally ideal for MV3)** — register one alarm
+  per account so each fire handles exactly one account in a single network
+  call, guaranteed to finish within the ~30s SW-alive window. Eliminates a
+  class of timing risk by construction. Rejected **for now** because the
+  extra complexity (alarm/account lifecycle sync, naming scheme) is not
+  justified at current product scale (small number of connected accounts per
+  user). See *Revisit trigger* below.
+
+- **Service-worker keepalive workarounds** — repeated port reconnects,
+  periodic `chrome.runtime.getPlatformInfo()` calls, or ping loops to stretch
+  SW life during a multi-account `Promise.allSettled`. Rejected because
+  `alarms.onAlarm` has no official lifetime extension for async work and
+  these workarounds are routinely broken by Chrome updates, carrying high
+  maintenance cost.
+
+## Consequences
+
+### Positive
+
+- Users stop paying the reactive refresh round-trip on the first row after
+  each 8-hour expiry window.
+- Access tokens expiring while every GitHub tab is closed still get refreshed
+  from background, so re-opening a PR list is instant again.
+- Terminal refresh-token failures surface promptly without a failed network
+  call every 15 minutes.
+
+### Negative (known limitation)
+
+- `browser.alarms.onAlarm` listeners do not extend service-worker lifetime
+  for async work. `handleAlarmFire` completes multiple refreshes via
+  `Promise.allSettled`; at current product scale (few accounts, fast refresh
+  endpoint) the work fits comfortably inside the ~30s SW-alive window after
+  the event, but this is not a structural guarantee. A truncated run is
+  bounded-harm: the reactive refresh path still serves as the safety net,
+  and the next 15-minute alarm retries.
+
+### Neutral
+
+- Adds the `"alarms"` manifest permission. Existing installs receive it on
+  extension update; Chrome does not disable the extension for adding
+  `"alarms"`. `host_permissions` are unchanged.
+- Adds one `listAccounts` read per 15-minute fire and up to one refresh
+  request per eligible account per fire. Coordinator dedupe absorbs races
+  with reactive refreshes.
+
+## Revisit trigger
+
+Move to per-account alarms (new ADR superseding this one) if any of the
+following is observed:
+
+- Active account count on typical installs reaches 5 or more, so a single
+  fire increasingly risks exceeding the SW-alive window.
+- Proactive refresh failures or missed runs are observed in practice.
+- Average single-fire execution time crosses ~10 seconds.
+
+Until one of those triggers fires, the single-alarm design is retained.
+
+## Links
+
+- [ADR 0004](./0004-github-app-token-refresh.md) — this ADR extends its
+  reactive refresh path.
+- `src/config/proactive-refresh.ts`
+- `src/background/proactive-refresh.ts`
+- `entrypoints/background.ts` — alarm wiring

--- a/docs/adr/0005-proactive-refresh.md
+++ b/docs/adr/0005-proactive-refresh.md
@@ -106,12 +106,12 @@ proactive and reactive paths race.
 
 ## Revisit trigger
 
-The "5 accounts" threshold below is not arbitrary: at an empirical
-refresh-endpoint latency of ~1–2s per account, a single fire with 5 eligible
+The "5 accounts" threshold below is not arbitrary: at a typical GitHub OAuth
+refresh round-trip of ~1–2s per account, a single fire with 5 eligible
 accounts consumes ~5–10s of the ~30s SW-alive window (roughly one-third).
 Beyond that, the margin for storage writes and one-off stalls shrinks fast,
-and the three triggers below start correlating (account count → per-fire
-time → observed failures).
+and the three triggers below tend to co-occur — observed misses can also
+stem from GitHub-side 5xx independent of load.
 
 Move to per-account alarms (new ADR superseding this one) if any of the
 following is observed:

--- a/docs/adr/0005-proactive-refresh.md
+++ b/docs/adr/0005-proactive-refresh.md
@@ -106,6 +106,13 @@ proactive and reactive paths race.
 
 ## Revisit trigger
 
+The "5 accounts" threshold below is not arbitrary: at an empirical
+refresh-endpoint latency of ~1–2s per account, a single fire with 5 eligible
+accounts consumes ~5–10s of the ~30s SW-alive window (roughly one-third).
+Beyond that, the margin for storage writes and one-off stalls shrinks fast,
+and the three triggers below start correlating (account count → per-fire
+time → observed failures).
+
 Move to per-account alarms (new ADR superseding this one) if any of the
 following is observed:
 

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -60,6 +60,11 @@
 | Matched account    | 401 then refresh succeeds then 401 again      | New access token rejected (app revoked or scope changed) — marked `revoked`, sign in again |
 | Matched account    | 403 / 404 without rate-limit signal           | Installation does not cover this repository — install the GitHub App on the owner |
 
+## Proactive token refresh
+
+- A recurring `chrome.alarms` job (15-minute period, 30-minute refresh threshold) pre-warms access tokens before the reactive 401 path is needed, and invalidates accounts whose refresh token has already expired.
+- Design rationale, alternatives, and the revisit trigger live in [ADR 0005](./adr/0005-proactive-refresh.md).
+
 ## Next implementation targets
 
 - Collapse request volume further where practical.

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,10 +1,12 @@
 import { createRefreshCoordinator } from "../src/auth/refresh-coordinator";
+import { createProactiveRefreshService } from "../src/background/proactive-refresh";
 import { createReviewerFetchService } from "../src/background/reviewer-fetch";
 import { getGitHubAppConfig } from "../src/config/github-app";
 import {
   isCancelPullReviewerSummaryMessage,
   isFetchPullReviewerSummaryMessage,
 } from "../src/runtime/reviewer-fetch";
+import { listAccounts } from "../src/storage/accounts";
 
 export default defineBackground(() => {
   const coordinator = createRefreshCoordinator({
@@ -12,6 +14,27 @@ export default defineBackground(() => {
   });
   const reviewerFetchService = createReviewerFetchService({
     refreshCoordinator: coordinator,
+  });
+  const proactiveRefreshService = createProactiveRefreshService({
+    refreshCoordinator: coordinator,
+    listAccounts,
+    now: () => Date.now(),
+  });
+
+  proactiveRefreshService.scheduleAlarm().catch((error) => {
+    console.error(
+      "[GitHub Pulls Show Reviewers] Failed to schedule proactive refresh alarm.",
+      error,
+    );
+  });
+
+  browser.alarms.onAlarm.addListener((alarm) => {
+    proactiveRefreshService.handleAlarmFire(alarm.name).catch((error) => {
+      console.error(
+        "[GitHub Pulls Show Reviewers] Proactive refresh alarm failed.",
+        error,
+      );
+    });
   });
 
   browser.runtime.onInstalled.addListener((details) => {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -6,7 +6,10 @@ import {
   isCancelPullReviewerSummaryMessage,
   isFetchPullReviewerSummaryMessage,
 } from "../src/runtime/reviewer-fetch";
-import { listAccounts } from "../src/storage/accounts";
+import {
+  listAccounts,
+  markAccountInvalidated,
+} from "../src/storage/accounts";
 
 export default defineBackground(() => {
   const coordinator = createRefreshCoordinator({
@@ -18,6 +21,7 @@ export default defineBackground(() => {
   const proactiveRefreshService = createProactiveRefreshService({
     refreshCoordinator: coordinator,
     listAccounts,
+    markAccountInvalidated,
     now: () => Date.now(),
   });
 

--- a/src/background/proactive-refresh.ts
+++ b/src/background/proactive-refresh.ts
@@ -11,6 +11,22 @@ export type ProactiveRefreshService = {
   handleAlarmFire(alarmName: string): Promise<void>;
 };
 
+/**
+ * Select account ids whose access token should be proactively refreshed.
+ *
+ * Rules:
+ * - Skip invalidated accounts.
+ * - Skip accounts without a refreshToken (nothing to refresh with).
+ * - Skip accounts without an expiresAt (legacy tokens with no known
+ *   expiry, treated as long-lived).
+ * - Skip accounts whose refreshTokenExpiresAt is already in the past;
+ *   those are terminal and are handled by
+ *   selectAccountsWithExpiredRefreshToken instead.
+ * - Already-expired access tokens (expiresAt <= now) are INTENTIONALLY
+ *   included. The reactive 401 path might not fire soon enough — e.g.
+ *   the user closed every GitHub tab — so the proactive alarm still
+ *   tries to pre-warm the token.
+ */
 export function selectAccountsDueForRefresh(
   accounts: Account[],
   now: number,
@@ -31,6 +47,12 @@ export function selectAccountsDueForRefresh(
   return dueIds;
 }
 
+/**
+ * Select account ids whose refresh token itself has already expired.
+ * These cannot be recovered without a fresh OAuth device-flow login,
+ * so the proactive path marks them invalidated immediately rather than
+ * burning a network call guaranteed to fail.
+ */
 export function selectAccountsWithExpiredRefreshToken(
   accounts: Account[],
   now: number,

--- a/src/background/proactive-refresh.ts
+++ b/src/background/proactive-refresh.ts
@@ -21,15 +21,37 @@ export function selectAccountsDueForRefresh(
     if (account.invalidated) continue;
     if (account.refreshToken == null) continue;
     if (account.expiresAt == null) continue;
+    if (
+      account.refreshTokenExpiresAt != null &&
+      account.refreshTokenExpiresAt <= now
+    ) continue;
     if (account.expiresAt - now >= thresholdMs) continue;
     dueIds.push(account.id);
   }
   return dueIds;
 }
 
+export function selectAccountsWithExpiredRefreshToken(
+  accounts: Account[],
+  now: number,
+): string[] {
+  const expiredIds: string[] = [];
+  for (const account of accounts) {
+    if (account.invalidated) continue;
+    if (account.refreshTokenExpiresAt == null) continue;
+    if (account.refreshTokenExpiresAt > now) continue;
+    expiredIds.push(account.id);
+  }
+  return expiredIds;
+}
+
 export function createProactiveRefreshService(input: {
   refreshCoordinator: RefreshCoordinator;
   listAccounts: () => Promise<Account[]>;
+  markAccountInvalidated: (
+    accountId: string,
+    reason: "expired",
+  ) => Promise<void>;
   now: () => number;
 }): ProactiveRefreshService {
   return {
@@ -47,18 +69,23 @@ export function createProactiveRefreshService(input: {
       if (alarmName !== PROACTIVE_REFRESH_ALARM_NAME) return;
 
       const accounts = await input.listAccounts();
+      const now = input.now();
       const dueIds = selectAccountsDueForRefresh(
         accounts,
-        input.now(),
+        now,
         PROACTIVE_REFRESH_THRESHOLD_MS,
       );
-      if (dueIds.length === 0) return;
+      const expiredIds = selectAccountsWithExpiredRefreshToken(accounts, now);
+      if (dueIds.length === 0 && expiredIds.length === 0) return;
 
-      await Promise.allSettled(
-        dueIds.map((accountId) =>
+      await Promise.allSettled([
+        ...dueIds.map((accountId) =>
           input.refreshCoordinator.refreshAccountToken(accountId),
         ),
-      );
+        ...expiredIds.map((accountId) =>
+          input.markAccountInvalidated(accountId, "expired"),
+        ),
+      ]);
     },
   };
 }

--- a/src/background/proactive-refresh.ts
+++ b/src/background/proactive-refresh.ts
@@ -34,6 +34,10 @@ export function createProactiveRefreshService(input: {
 }): ProactiveRefreshService {
   return {
     async scheduleAlarm(): Promise<void> {
+      const existing = await browser.alarms.get(PROACTIVE_REFRESH_ALARM_NAME);
+      if (existing?.periodInMinutes === PROACTIVE_REFRESH_PERIOD_MINUTES) {
+        return;
+      }
       await browser.alarms.create(PROACTIVE_REFRESH_ALARM_NAME, {
         periodInMinutes: PROACTIVE_REFRESH_PERIOD_MINUTES,
       });

--- a/src/background/proactive-refresh.ts
+++ b/src/background/proactive-refresh.ts
@@ -1,0 +1,60 @@
+import type { RefreshCoordinator } from "../auth/refresh-coordinator";
+import {
+  PROACTIVE_REFRESH_ALARM_NAME,
+  PROACTIVE_REFRESH_PERIOD_MINUTES,
+  PROACTIVE_REFRESH_THRESHOLD_MS,
+} from "../config/proactive-refresh";
+import type { Account } from "../storage/accounts";
+
+export type ProactiveRefreshService = {
+  scheduleAlarm(): Promise<void>;
+  handleAlarmFire(alarmName: string): Promise<void>;
+};
+
+export function selectAccountsDueForRefresh(
+  accounts: Account[],
+  now: number,
+  thresholdMs: number,
+): string[] {
+  const dueIds: string[] = [];
+  for (const account of accounts) {
+    if (account.invalidated) continue;
+    if (account.refreshToken == null) continue;
+    if (account.expiresAt == null) continue;
+    if (account.expiresAt - now >= thresholdMs) continue;
+    dueIds.push(account.id);
+  }
+  return dueIds;
+}
+
+export function createProactiveRefreshService(input: {
+  refreshCoordinator: RefreshCoordinator;
+  listAccounts: () => Promise<Account[]>;
+  now: () => number;
+}): ProactiveRefreshService {
+  return {
+    async scheduleAlarm(): Promise<void> {
+      await browser.alarms.create(PROACTIVE_REFRESH_ALARM_NAME, {
+        periodInMinutes: PROACTIVE_REFRESH_PERIOD_MINUTES,
+      });
+    },
+
+    async handleAlarmFire(alarmName: string): Promise<void> {
+      if (alarmName !== PROACTIVE_REFRESH_ALARM_NAME) return;
+
+      const accounts = await input.listAccounts();
+      const dueIds = selectAccountsDueForRefresh(
+        accounts,
+        input.now(),
+        PROACTIVE_REFRESH_THRESHOLD_MS,
+      );
+      if (dueIds.length === 0) return;
+
+      await Promise.allSettled(
+        dueIds.map((accountId) =>
+          input.refreshCoordinator.refreshAccountToken(accountId),
+        ),
+      );
+    },
+  };
+}

--- a/src/config/proactive-refresh.ts
+++ b/src/config/proactive-refresh.ts
@@ -1,0 +1,9 @@
+export const PROACTIVE_REFRESH_ALARM_NAME =
+  "github-pulls-show-reviewers.proactive-refresh";
+
+export const PROACTIVE_REFRESH_PERIOD_MINUTES = 15;
+
+// Must exceed the alarm period plus refresh latency so no expiry window slips
+// between fires. Access tokens expire after ~8 hours, so refreshing 30 minutes
+// early is not wasteful.
+export const PROACTIVE_REFRESH_THRESHOLD_MS = 30 * 60 * 1_000;

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -1,11 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type * as GithubApiModule from "../src/github/api";
 import { CANCELED_REQUEST_TTL_MS } from "../src/background/reviewer-fetch";
+import {
+  PROACTIVE_REFRESH_ALARM_NAME,
+  PROACTIVE_REFRESH_PERIOD_MINUTES,
+  PROACTIVE_REFRESH_THRESHOLD_MS,
+} from "../src/config/proactive-refresh";
 
 const {
   refreshAccountTokenMock,
   fetchPullReviewerSummaryMock,
   getAccountByIdMock,
+  listAccountsMock,
   markAccountInvalidatedMock,
   createRefreshCoordinatorMock,
   getGitHubAppConfigMock,
@@ -13,6 +19,7 @@ const {
   refreshAccountTokenMock: vi.fn(),
   fetchPullReviewerSummaryMock: vi.fn(),
   getAccountByIdMock: vi.fn(),
+  listAccountsMock: vi.fn<() => Promise<unknown[]>>(),
   markAccountInvalidatedMock: vi.fn(),
   createRefreshCoordinatorMock: vi.fn(),
   getGitHubAppConfigMock: vi.fn(() => ({ clientId: "test-client-id" })),
@@ -31,6 +38,7 @@ vi.mock("../src/config/github-app", () => ({
 
 vi.mock("../src/storage/accounts", () => ({
   getAccountById: getAccountByIdMock,
+  listAccounts: listAccountsMock,
   markAccountInvalidated: markAccountInvalidatedMock,
 }));
 
@@ -59,16 +67,22 @@ function flushMicrotasks() {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+let capturedAlarmListener: ((alarm: { name: string }) => void) | null;
+const alarmsCreateMock = vi.fn(async () => undefined);
+
 beforeEach(() => {
   vi.resetModules();
   refreshAccountTokenMock.mockReset();
   fetchPullReviewerSummaryMock.mockReset();
   getAccountByIdMock.mockReset();
+  listAccountsMock.mockReset().mockResolvedValue([]);
   markAccountInvalidatedMock.mockReset();
   refreshAccountTokenMock.mockResolvedValue({ ok: true, token: "new-token" });
   createRefreshCoordinatorMock.mockClear();
   getGitHubAppConfigMock.mockClear();
+  alarmsCreateMock.mockClear();
   capturedMessageListener = null;
+  capturedAlarmListener = null;
 
   vi.stubGlobal("defineBackground", (main: () => void) => ({ main }));
   vi.stubGlobal("browser", {
@@ -84,6 +98,14 @@ beforeEach(() => {
     },
     action: {
       onClicked: { addListener: vi.fn() },
+    },
+    alarms: {
+      create: alarmsCreateMock,
+      onAlarm: {
+        addListener: vi.fn((listener: (alarm: { name: string }) => void) => {
+          capturedAlarmListener = listener;
+        }),
+      },
     },
   });
 });
@@ -545,5 +567,62 @@ describe("background runtime.onMessage handler", () => {
       throw new Error("expected background fetch signal");
     }
     expect(signal.aborted).toBe(true);
+  });
+});
+
+describe("background proactive refresh wiring", () => {
+  it("schedules the proactive refresh alarm on boot", async () => {
+    await bootBackground();
+
+    expect(alarmsCreateMock).toHaveBeenCalledWith(
+      PROACTIVE_REFRESH_ALARM_NAME,
+      { periodInMinutes: PROACTIVE_REFRESH_PERIOD_MINUTES },
+    );
+  });
+
+  it("refreshes eligible accounts when the proactive alarm fires", async () => {
+    const now = 1_700_000_000_000;
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(now));
+    listAccountsMock.mockResolvedValue([
+      {
+        id: "acc-due",
+        login: "due",
+        avatarUrl: null,
+        token: "ghu",
+        createdAt: 1,
+        installations: [],
+        installationsRefreshedAt: 1,
+        invalidated: false,
+        invalidatedReason: null,
+        refreshToken: "ghr",
+        expiresAt: now + PROACTIVE_REFRESH_THRESHOLD_MS - 1_000,
+        refreshTokenExpiresAt: null,
+      },
+    ]);
+
+    await bootBackground();
+    if (capturedAlarmListener == null) {
+      throw new Error("background did not register an alarms.onAlarm listener");
+    }
+    capturedAlarmListener({ name: PROACTIVE_REFRESH_ALARM_NAME });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-due");
+    vi.useRealTimers();
+  });
+
+  it("ignores alarms that do not match the proactive refresh name", async () => {
+    await bootBackground();
+    if (capturedAlarmListener == null) {
+      throw new Error("background did not register an alarms.onAlarm listener");
+    }
+
+    capturedAlarmListener({ name: "unrelated-alarm" });
+    await flushMicrotasks();
+
+    expect(listAccountsMock).not.toHaveBeenCalled();
+    expect(refreshAccountTokenMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -626,4 +626,41 @@ describe("background proactive refresh wiring", () => {
     expect(listAccountsMock).not.toHaveBeenCalled();
     expect(refreshAccountTokenMock).not.toHaveBeenCalled();
   });
+
+  it("invalidates accounts whose refresh token has already expired", async () => {
+    const now = 1_700_000_000_000;
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(now));
+    listAccountsMock.mockResolvedValue([
+      {
+        id: "acc-refresh-expired",
+        login: "expired-user",
+        avatarUrl: null,
+        token: "ghu",
+        createdAt: 1,
+        installations: [],
+        installationsRefreshedAt: 1,
+        invalidated: false,
+        invalidatedReason: null,
+        refreshToken: "ghr",
+        expiresAt: now + 60_000,
+        refreshTokenExpiresAt: now - 1,
+      },
+    ]);
+
+    await bootBackground();
+    if (capturedAlarmListener == null) {
+      throw new Error("background did not register an alarms.onAlarm listener");
+    }
+    capturedAlarmListener({ name: PROACTIVE_REFRESH_ALARM_NAME });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(markAccountInvalidatedMock).toHaveBeenCalledWith(
+      "acc-refresh-expired",
+      "expired",
+    );
+    expect(refreshAccountTokenMock).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
 });

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -101,6 +101,7 @@ beforeEach(() => {
     },
     alarms: {
       create: alarmsCreateMock,
+      get: vi.fn(async () => undefined),
       onAlarm: {
         addListener: vi.fn((listener: (alarm: { name: string }) => void) => {
           capturedAlarmListener = listener;

--- a/tests/proactive-refresh.test.ts
+++ b/tests/proactive-refresh.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createProactiveRefreshService,
   selectAccountsDueForRefresh,
+  selectAccountsWithExpiredRefreshToken,
 } from "../src/background/proactive-refresh";
 import {
   PROACTIVE_REFRESH_ALARM_NAME,
@@ -35,15 +36,39 @@ describe("selectAccountsDueForRefresh", () => {
 
   it("selects accounts whose expiresAt is within the threshold window", () => {
     const accounts: Account[] = [
-      makeAccount({ id: "due-soon", expiresAt: now + threshold - 60_000 }),
-      makeAccount({ id: "already-expired", expiresAt: now - 1 }),
-      makeAccount({ id: "plenty-of-time", expiresAt: now + threshold + 60_000 }),
+      makeAccount({
+        id: "due-soon",
+        expiresAt: now + threshold - 60_000,
+        refreshTokenExpiresAt: now + 7 * 24 * 60 * 60 * 1_000,
+      }),
+      makeAccount({
+        id: "already-expired",
+        expiresAt: now - 1,
+        refreshTokenExpiresAt: now + 7 * 24 * 60 * 60 * 1_000,
+      }),
+      makeAccount({
+        id: "plenty-of-time",
+        expiresAt: now + threshold + 60_000,
+        refreshTokenExpiresAt: now + 7 * 24 * 60 * 60 * 1_000,
+      }),
     ];
 
     expect(selectAccountsDueForRefresh(accounts, now, threshold)).toEqual([
       "due-soon",
       "already-expired",
     ]);
+  });
+
+  it("skips accounts whose refreshTokenExpiresAt is in the past", () => {
+    const accounts: Account[] = [
+      makeAccount({
+        id: "refresh-expired",
+        expiresAt: now + 1,
+        refreshTokenExpiresAt: now - 1,
+      }),
+    ];
+
+    expect(selectAccountsDueForRefresh(accounts, now, threshold)).toEqual([]);
   });
 
   it("skips accounts without an expiresAt", () => {
@@ -80,6 +105,35 @@ describe("selectAccountsDueForRefresh", () => {
   });
 });
 
+describe("selectAccountsWithExpiredRefreshToken", () => {
+  const now = 1_700_000_000_000;
+
+  it("selects accounts whose refreshTokenExpiresAt is in the past", () => {
+    const accounts: Account[] = [
+      makeAccount({ id: "expired", refreshTokenExpiresAt: now - 1 }),
+      makeAccount({ id: "still-valid", refreshTokenExpiresAt: now + 60_000 }),
+      makeAccount({ id: "no-expiry", refreshTokenExpiresAt: null }),
+    ];
+
+    expect(selectAccountsWithExpiredRefreshToken(accounts, now)).toEqual([
+      "expired",
+    ]);
+  });
+
+  it("skips invalidated accounts even when refreshTokenExpiresAt is past", () => {
+    const accounts: Account[] = [
+      makeAccount({
+        id: "expired-invalidated",
+        invalidated: true,
+        invalidatedReason: "refresh_failed",
+        refreshTokenExpiresAt: now - 1,
+      }),
+    ];
+
+    expect(selectAccountsWithExpiredRefreshToken(accounts, now)).toEqual([]);
+  });
+});
+
 describe("createProactiveRefreshService", () => {
   const alarmsCreateMock = vi.fn(async () => undefined);
   const alarmsGetMock = vi.fn<
@@ -88,6 +142,8 @@ describe("createProactiveRefreshService", () => {
   const listAccountsMock = vi.fn<() => Promise<Account[]>>();
   const refreshAccountTokenMock =
     vi.fn<(accountId: string) => Promise<{ ok: true; token: string }>>();
+  const markAccountInvalidatedMock =
+    vi.fn<(accountId: string, reason: "expired") => Promise<void>>();
 
   beforeEach(() => {
     alarmsCreateMock.mockClear();
@@ -96,6 +152,8 @@ describe("createProactiveRefreshService", () => {
     listAccountsMock.mockReset();
     refreshAccountTokenMock.mockReset();
     refreshAccountTokenMock.mockResolvedValue({ ok: true, token: "t" });
+    markAccountInvalidatedMock.mockReset();
+    markAccountInvalidatedMock.mockResolvedValue(undefined);
     vi.stubGlobal("browser", {
       alarms: { create: alarmsCreateMock, get: alarmsGetMock },
     });
@@ -105,6 +163,7 @@ describe("createProactiveRefreshService", () => {
     return createProactiveRefreshService({
       refreshCoordinator: { refreshAccountToken: refreshAccountTokenMock },
       listAccounts: listAccountsMock,
+      markAccountInvalidated: markAccountInvalidatedMock,
       now: () => nowValue,
     });
   }
@@ -157,12 +216,22 @@ describe("createProactiveRefreshService", () => {
   it("handleAlarmFire refreshes every eligible account", async () => {
     const now = 1_700_000_000_000;
     const dueSoon = now + PROACTIVE_REFRESH_THRESHOLD_MS - 60_000;
+    const futureRefresh = now + 60 * 60 * 1_000;
     listAccountsMock.mockResolvedValue([
-      makeAccount({ id: "acc-a", expiresAt: dueSoon }),
-      makeAccount({ id: "acc-b", expiresAt: dueSoon }),
+      makeAccount({
+        id: "acc-a",
+        expiresAt: dueSoon,
+        refreshTokenExpiresAt: futureRefresh,
+      }),
+      makeAccount({
+        id: "acc-b",
+        expiresAt: dueSoon,
+        refreshTokenExpiresAt: futureRefresh,
+      }),
       makeAccount({
         id: "acc-skip",
         expiresAt: now + PROACTIVE_REFRESH_THRESHOLD_MS + 60_000,
+        refreshTokenExpiresAt: futureRefresh,
       }),
     ]);
 
@@ -176,9 +245,18 @@ describe("createProactiveRefreshService", () => {
 
   it("handleAlarmFire continues when one account refresh rejects", async () => {
     const now = 1_700_000_000_000;
+    const futureRefresh = now + 60 * 60 * 1_000;
     listAccountsMock.mockResolvedValue([
-      makeAccount({ id: "acc-a", expiresAt: now + 1 }),
-      makeAccount({ id: "acc-b", expiresAt: now + 1 }),
+      makeAccount({
+        id: "acc-a",
+        expiresAt: now + 1,
+        refreshTokenExpiresAt: futureRefresh,
+      }),
+      makeAccount({
+        id: "acc-b",
+        expiresAt: now + 1,
+        refreshTokenExpiresAt: futureRefresh,
+      }),
     ]);
     refreshAccountTokenMock.mockRejectedValueOnce(new Error("transient"));
     refreshAccountTokenMock.mockResolvedValueOnce({ ok: true, token: "t" });
@@ -189,5 +267,50 @@ describe("createProactiveRefreshService", () => {
       service.handleAlarmFire(PROACTIVE_REFRESH_ALARM_NAME),
     ).resolves.toBeUndefined();
     expect(refreshAccountTokenMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("handleAlarmFire invalidates accounts whose refresh token has expired", async () => {
+    const now = 1_700_000_000_000;
+    listAccountsMock.mockResolvedValue([
+      makeAccount({
+        id: "refresh-expired",
+        expiresAt: now + 60_000,
+        refreshTokenExpiresAt: now - 1,
+      }),
+    ]);
+
+    const service = buildService(now);
+    await service.handleAlarmFire(PROACTIVE_REFRESH_ALARM_NAME);
+
+    expect(markAccountInvalidatedMock).toHaveBeenCalledWith(
+      "refresh-expired",
+      "expired",
+    );
+    expect(refreshAccountTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("handleAlarmFire processes refresh and invalidation concurrently", async () => {
+    const now = 1_700_000_000_000;
+    listAccountsMock.mockResolvedValue([
+      makeAccount({
+        id: "due",
+        expiresAt: now + PROACTIVE_REFRESH_THRESHOLD_MS - 1,
+        refreshTokenExpiresAt: now + 60 * 60 * 1_000,
+      }),
+      makeAccount({
+        id: "refresh-expired",
+        expiresAt: now + 60_000,
+        refreshTokenExpiresAt: now - 1,
+      }),
+    ]);
+
+    const service = buildService(now);
+    await service.handleAlarmFire(PROACTIVE_REFRESH_ALARM_NAME);
+
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("due");
+    expect(markAccountInvalidatedMock).toHaveBeenCalledWith(
+      "refresh-expired",
+      "expired",
+    );
   });
 });

--- a/tests/proactive-refresh.test.ts
+++ b/tests/proactive-refresh.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createProactiveRefreshService,
+  selectAccountsDueForRefresh,
+} from "../src/background/proactive-refresh";
+import {
+  PROACTIVE_REFRESH_ALARM_NAME,
+  PROACTIVE_REFRESH_PERIOD_MINUTES,
+  PROACTIVE_REFRESH_THRESHOLD_MS,
+} from "../src/config/proactive-refresh";
+import type { Account } from "../src/storage/accounts";
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    id: "acc-1",
+    login: "hon454",
+    avatarUrl: null,
+    token: "ghu_old",
+    createdAt: 1,
+    installations: [],
+    installationsRefreshedAt: 1,
+    invalidated: false,
+    invalidatedReason: null,
+    refreshToken: "ghr_old",
+    expiresAt: null,
+    refreshTokenExpiresAt: null,
+    ...overrides,
+  };
+}
+
+describe("selectAccountsDueForRefresh", () => {
+  const now = 1_700_000_000_000;
+  const threshold = PROACTIVE_REFRESH_THRESHOLD_MS;
+
+  it("selects accounts whose expiresAt is within the threshold window", () => {
+    const accounts: Account[] = [
+      makeAccount({ id: "due-soon", expiresAt: now + threshold - 60_000 }),
+      makeAccount({ id: "already-expired", expiresAt: now - 1 }),
+      makeAccount({ id: "plenty-of-time", expiresAt: now + threshold + 60_000 }),
+    ];
+
+    expect(selectAccountsDueForRefresh(accounts, now, threshold)).toEqual([
+      "due-soon",
+      "already-expired",
+    ]);
+  });
+
+  it("skips accounts without an expiresAt", () => {
+    const accounts: Account[] = [
+      makeAccount({ id: "no-expiry", expiresAt: null }),
+    ];
+
+    expect(selectAccountsDueForRefresh(accounts, now, threshold)).toEqual([]);
+  });
+
+  it("skips accounts without a refresh token", () => {
+    const accounts: Account[] = [
+      makeAccount({
+        id: "no-refresh-token",
+        refreshToken: null,
+        expiresAt: now + 1,
+      }),
+    ];
+
+    expect(selectAccountsDueForRefresh(accounts, now, threshold)).toEqual([]);
+  });
+
+  it("skips invalidated accounts", () => {
+    const accounts: Account[] = [
+      makeAccount({
+        id: "invalidated",
+        invalidated: true,
+        invalidatedReason: "refresh_failed",
+        expiresAt: now + 1,
+      }),
+    ];
+
+    expect(selectAccountsDueForRefresh(accounts, now, threshold)).toEqual([]);
+  });
+});
+
+describe("createProactiveRefreshService", () => {
+  const alarmsCreateMock = vi.fn(async () => undefined);
+  const listAccountsMock = vi.fn<() => Promise<Account[]>>();
+  const refreshAccountTokenMock =
+    vi.fn<(accountId: string) => Promise<{ ok: true; token: string }>>();
+
+  beforeEach(() => {
+    alarmsCreateMock.mockClear();
+    listAccountsMock.mockReset();
+    refreshAccountTokenMock.mockReset();
+    refreshAccountTokenMock.mockResolvedValue({ ok: true, token: "t" });
+    vi.stubGlobal("browser", {
+      alarms: { create: alarmsCreateMock },
+    });
+  });
+
+  function buildService(nowValue: number) {
+    return createProactiveRefreshService({
+      refreshCoordinator: { refreshAccountToken: refreshAccountTokenMock },
+      listAccounts: listAccountsMock,
+      now: () => nowValue,
+    });
+  }
+
+  it("scheduleAlarm registers the recurring alarm with the configured period", async () => {
+    const service = buildService(1_700_000_000_000);
+
+    await service.scheduleAlarm();
+
+    expect(alarmsCreateMock).toHaveBeenCalledWith(PROACTIVE_REFRESH_ALARM_NAME, {
+      periodInMinutes: PROACTIVE_REFRESH_PERIOD_MINUTES,
+    });
+  });
+
+  it("handleAlarmFire ignores alarms with a different name", async () => {
+    const service = buildService(1_700_000_000_000);
+
+    await service.handleAlarmFire("something-else");
+
+    expect(listAccountsMock).not.toHaveBeenCalled();
+    expect(refreshAccountTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("handleAlarmFire refreshes every eligible account", async () => {
+    const now = 1_700_000_000_000;
+    const dueSoon = now + PROACTIVE_REFRESH_THRESHOLD_MS - 60_000;
+    listAccountsMock.mockResolvedValue([
+      makeAccount({ id: "acc-a", expiresAt: dueSoon }),
+      makeAccount({ id: "acc-b", expiresAt: dueSoon }),
+      makeAccount({
+        id: "acc-skip",
+        expiresAt: now + PROACTIVE_REFRESH_THRESHOLD_MS + 60_000,
+      }),
+    ]);
+
+    const service = buildService(now);
+    await service.handleAlarmFire(PROACTIVE_REFRESH_ALARM_NAME);
+
+    expect(refreshAccountTokenMock).toHaveBeenCalledTimes(2);
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-a");
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-b");
+  });
+
+  it("handleAlarmFire continues when one account refresh rejects", async () => {
+    const now = 1_700_000_000_000;
+    listAccountsMock.mockResolvedValue([
+      makeAccount({ id: "acc-a", expiresAt: now + 1 }),
+      makeAccount({ id: "acc-b", expiresAt: now + 1 }),
+    ]);
+    refreshAccountTokenMock.mockRejectedValueOnce(new Error("transient"));
+    refreshAccountTokenMock.mockResolvedValueOnce({ ok: true, token: "t" });
+
+    const service = buildService(now);
+
+    await expect(
+      service.handleAlarmFire(PROACTIVE_REFRESH_ALARM_NAME),
+    ).resolves.toBeUndefined();
+    expect(refreshAccountTokenMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/proactive-refresh.test.ts
+++ b/tests/proactive-refresh.test.ts
@@ -287,8 +287,10 @@ describe("createProactiveRefreshService", () => {
 
   it("handleAlarmFire continues when one account refresh rejects", async () => {
     // Defensive coverage: Promise.allSettled insulates us even if a future
-    // change breaks the coordinator contract and lets a rejection escape.
-    // In current production code, refreshAccountToken always resolves.
+    // change lets a rejection escape. refreshAccountToken wraps
+    // refreshAccessToken in try/catch, but storage I/O (getAccountById,
+    // updateAccountTokens, markAccountInvalidated) is outside that guard
+    // and can reject.
     const now = 1_700_000_000_000;
     const futureRefresh = now + 60 * 60 * 1_000;
     listAccountsMock.mockResolvedValue([

--- a/tests/proactive-refresh.test.ts
+++ b/tests/proactive-refresh.test.ts
@@ -104,6 +104,32 @@ describe("selectAccountsDueForRefresh", () => {
 
     expect(selectAccountsDueForRefresh(accounts, now, threshold)).toEqual([]);
   });
+
+  it("includes accounts where expiresAt equals now", () => {
+    const accounts: Account[] = [
+      makeAccount({
+        id: "expires-at-now",
+        expiresAt: now,
+        refreshTokenExpiresAt: now + 7 * 24 * 60 * 60 * 1_000,
+      }),
+    ];
+
+    expect(selectAccountsDueForRefresh(accounts, now, threshold)).toEqual([
+      "expires-at-now",
+    ]);
+  });
+
+  it("skips accounts where expiresAt - now equals the threshold exactly", () => {
+    const accounts: Account[] = [
+      makeAccount({
+        id: "exact-threshold",
+        expiresAt: now + threshold,
+        refreshTokenExpiresAt: now + 7 * 24 * 60 * 60 * 1_000,
+      }),
+    ];
+
+    expect(selectAccountsDueForRefresh(accounts, now, threshold)).toEqual([]);
+  });
 });
 
 describe("selectAccountsWithExpiredRefreshToken", () => {
@@ -132,6 +158,19 @@ describe("selectAccountsWithExpiredRefreshToken", () => {
     ];
 
     expect(selectAccountsWithExpiredRefreshToken(accounts, now)).toEqual([]);
+  });
+
+  it("includes accounts where refreshTokenExpiresAt equals now", () => {
+    const accounts: Account[] = [
+      makeAccount({
+        id: "refresh-at-now",
+        refreshTokenExpiresAt: now,
+      }),
+    ];
+
+    expect(selectAccountsWithExpiredRefreshToken(accounts, now)).toEqual([
+      "refresh-at-now",
+    ]);
   });
 });
 

--- a/tests/proactive-refresh.test.ts
+++ b/tests/proactive-refresh.test.ts
@@ -82,17 +82,22 @@ describe("selectAccountsDueForRefresh", () => {
 
 describe("createProactiveRefreshService", () => {
   const alarmsCreateMock = vi.fn(async () => undefined);
+  const alarmsGetMock = vi.fn<
+    (name: string) => Promise<{ periodInMinutes?: number } | undefined>
+  >();
   const listAccountsMock = vi.fn<() => Promise<Account[]>>();
   const refreshAccountTokenMock =
     vi.fn<(accountId: string) => Promise<{ ok: true; token: string }>>();
 
   beforeEach(() => {
     alarmsCreateMock.mockClear();
+    alarmsGetMock.mockReset();
+    alarmsGetMock.mockResolvedValue(undefined);
     listAccountsMock.mockReset();
     refreshAccountTokenMock.mockReset();
     refreshAccountTokenMock.mockResolvedValue({ ok: true, token: "t" });
     vi.stubGlobal("browser", {
-      alarms: { create: alarmsCreateMock },
+      alarms: { create: alarmsCreateMock, get: alarmsGetMock },
     });
   });
 
@@ -104,7 +109,33 @@ describe("createProactiveRefreshService", () => {
     });
   }
 
-  it("scheduleAlarm registers the recurring alarm with the configured period", async () => {
+  it("scheduleAlarm creates the alarm when no existing alarm is registered", async () => {
+    alarmsGetMock.mockResolvedValue(undefined);
+    const service = buildService(1_700_000_000_000);
+
+    await service.scheduleAlarm();
+
+    expect(alarmsGetMock).toHaveBeenCalledWith(PROACTIVE_REFRESH_ALARM_NAME);
+    expect(alarmsCreateMock).toHaveBeenCalledWith(PROACTIVE_REFRESH_ALARM_NAME, {
+      periodInMinutes: PROACTIVE_REFRESH_PERIOD_MINUTES,
+    });
+  });
+
+  it("scheduleAlarm does not re-create an existing alarm that matches the configured period", async () => {
+    alarmsGetMock.mockResolvedValue({
+      periodInMinutes: PROACTIVE_REFRESH_PERIOD_MINUTES,
+    });
+    const service = buildService(1_700_000_000_000);
+
+    await service.scheduleAlarm();
+
+    expect(alarmsCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("scheduleAlarm recreates the alarm when the existing period differs", async () => {
+    alarmsGetMock.mockResolvedValue({
+      periodInMinutes: PROACTIVE_REFRESH_PERIOD_MINUTES + 5,
+    });
     const service = buildService(1_700_000_000_000);
 
     await service.scheduleAlarm();

--- a/tests/proactive-refresh.test.ts
+++ b/tests/proactive-refresh.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { RefreshOutcome } from "../src/auth/refresh-coordinator";
 import {
   createProactiveRefreshService,
   selectAccountsDueForRefresh,
@@ -141,7 +142,7 @@ describe("createProactiveRefreshService", () => {
   >();
   const listAccountsMock = vi.fn<() => Promise<Account[]>>();
   const refreshAccountTokenMock =
-    vi.fn<(accountId: string) => Promise<{ ok: true; token: string }>>();
+    vi.fn<(accountId: string) => Promise<RefreshOutcome>>();
   const markAccountInvalidatedMock =
     vi.fn<(accountId: string, reason: "expired") => Promise<void>>();
 
@@ -151,7 +152,9 @@ describe("createProactiveRefreshService", () => {
     alarmsGetMock.mockResolvedValue(undefined);
     listAccountsMock.mockReset();
     refreshAccountTokenMock.mockReset();
-    refreshAccountTokenMock.mockResolvedValue({ ok: true, token: "t" });
+    refreshAccountTokenMock.mockResolvedValue(
+      { ok: true, token: "t" } satisfies RefreshOutcome,
+    );
     markAccountInvalidatedMock.mockReset();
     markAccountInvalidatedMock.mockResolvedValue(undefined);
     vi.stubGlobal("browser", {
@@ -244,6 +247,9 @@ describe("createProactiveRefreshService", () => {
   });
 
   it("handleAlarmFire continues when one account refresh rejects", async () => {
+    // Defensive coverage: Promise.allSettled insulates us even if a future
+    // change breaks the coordinator contract and lets a rejection escape.
+    // In current production code, refreshAccountToken always resolves.
     const now = 1_700_000_000_000;
     const futureRefresh = now + 60 * 60 * 1_000;
     listAccountsMock.mockResolvedValue([
@@ -267,6 +273,32 @@ describe("createProactiveRefreshService", () => {
       service.handleAlarmFire(PROACTIVE_REFRESH_ALARM_NAME),
     ).resolves.toBeUndefined();
     expect(refreshAccountTokenMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("handleAlarmFire continues when the coordinator returns a terminal failure for one account", async () => {
+    const now = 1_700_000_000_000;
+    const futureRefresh = now + 60 * 60 * 1_000;
+    listAccountsMock.mockResolvedValue([
+      makeAccount({
+        id: "acc-a",
+        expiresAt: now + 1,
+        refreshTokenExpiresAt: futureRefresh,
+      }),
+      makeAccount({
+        id: "acc-b",
+        expiresAt: now + 1,
+        refreshTokenExpiresAt: futureRefresh,
+      }),
+    ]);
+    refreshAccountTokenMock.mockResolvedValueOnce({ ok: false, terminal: true });
+    refreshAccountTokenMock.mockResolvedValueOnce({ ok: true, token: "t" });
+
+    const service = buildService(now);
+    await service.handleAlarmFire(PROACTIVE_REFRESH_ALARM_NAME);
+
+    expect(refreshAccountTokenMock).toHaveBeenCalledTimes(2);
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-a");
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-b");
   });
 
   it("handleAlarmFire invalidates accounts whose refresh token has expired", async () => {

--- a/tests/proactive-refresh.test.ts
+++ b/tests/proactive-refresh.test.ts
@@ -72,6 +72,18 @@ describe("selectAccountsDueForRefresh", () => {
     expect(selectAccountsDueForRefresh(accounts, now, threshold)).toEqual([]);
   });
 
+  it("skips accounts where refreshTokenExpiresAt equals now", () => {
+    const accounts: Account[] = [
+      makeAccount({
+        id: "refresh-at-now",
+        expiresAt: now + 1,
+        refreshTokenExpiresAt: now,
+      }),
+    ];
+
+    expect(selectAccountsDueForRefresh(accounts, now, threshold)).toEqual([]);
+  });
+
   it("skips accounts without an expiresAt", () => {
     const accounts: Account[] = [
       makeAccount({ id: "no-expiry", expiresAt: null }),

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       48: "/icon/48.png",
       128: "/icon/128.png",
     },
-    permissions: ["storage"],
+    permissions: ["storage", "alarms"],
     host_permissions: ["https://github.com/*", "https://api.github.com/*"],
     action: {
       default_title: "GitHub Pulls Show Reviewers — Open options",


### PR DESCRIPTION
## Summary

- Register a recurring `chrome.alarms` job that refreshes soon-to-expire access tokens before a user-triggered request pays the refresh round-trip.
- Reuse the existing per-account refresh coordinator, so proactive and reactive refreshes share the in-flight dedupe.
- Ship the `alarms` manifest permission and tests for both the selection logic and the background wiring.

## Why

Follow-up to #15. The reactive 401 → refresh → retry path still means the unlucky first row after expiry pays an extra round trip, and access tokens that expire while no GitHub tab is open never refresh until the user browses back to a PR list. Chrome persists alarm registrations across MV3 service-worker activations, so a 15-minute alarm can drive refreshes independently of tab state and close both gaps.

## Changes

- New `src/config/proactive-refresh.ts` exports the alarm name, a 15-minute period, and the 30-minute refresh threshold. Threshold is intentionally > period so no expiry window slips between fires.
- New `src/background/proactive-refresh.ts` exposes a pure `selectAccountsDueForRefresh` helper and a `createProactiveRefreshService` that schedules the alarm and dispatches eligible accounts through the shared coordinator. One account failing does not abort the others (`Promise.allSettled`).
- `entrypoints/background.ts` wires the service, schedules the alarm on boot, and routes `browser.alarms.onAlarm` into the handler. Non-matching alarm names are ignored inside the service.
- `wxt.config.ts` adds the `alarms` permission.
- `tests/background.test.ts` grows mocks for `listAccounts` + `browser.alarms` and covers the new wiring; `tests/proactive-refresh.test.ts` covers the selection rules, alarm scheduling, alarm-name filtering, and failure isolation.

## Impact

- User-facing impact: the first reviewer fetch after a long idle window no longer pays the refresh round-trip for private repos with refresh-token accounts. No UI change.
- API/schema impact: none. Reuses the existing account storage fields (`expiresAt`, `refreshToken`, `invalidated`).
- Performance impact: one additional `browser.alarms` registration per service-worker activation, one `listAccounts` read per 15-minute fire, and up to one refresh network call per eligible account. The coordinator dedupes against concurrent reactive refreshes.
- Operational or rollout impact: requires the `alarms` permission in the manifest. Existing installs get the new permission on extension update; Chrome does not disable the extension for added `alarms`.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

### Test details

- `pnpm test` — 207 tests pass (22 files), including 8 new tests in `tests/proactive-refresh.test.ts` and 3 new tests in `tests/background.test.ts` for alarm wiring.
- `pnpm typecheck` — clean.
- `pnpm build` — chrome-mv3 build succeeds; built `manifest.json` includes `"permissions":["storage","alarms"]`.
- Manual in-browser verification not performed in this PR; the reactive refresh path (#15) still serves as the safety net, and alarm dispatch is covered by unit + integration tests.

## Breaking Changes

- None

## Related Issues

Part of #7