### PR TITLE
chore(release): prepare v1.4.0

### DIFF
--- a/docs/chrome-web-store-submission.md
+++ b/docs/chrome-web-store-submission.md
@@ -48,9 +48,10 @@ Single purpose:
 
 Permission justification draft:
 
-- `storage`: stores locally the GitHub App accounts (one user-to-server token per account) so the user can access private repositories. It also stores the review-chip display preferences (`showStateBadge` and `showReviewerName`) under the local `preferences` key.
+- `storage`: stores locally the GitHub App accounts (user-to-server access token, refresh token, and token-expiry timestamps per account) so the user can access private repositories. It also stores the review-chip display preferences (`showStateBadge` and `showReviewerName`) under the local `preferences` key.
+- `alarms`: schedules a recurring 15-minute background task that refreshes GitHub App access tokens ahead of expiry. Without this, every eight-hour token lifetime would force the user to sign in again even while actively using the extension, and reviewer lookups on private repositories would stall until the next sign-in.
 - `https://github.com/*`: reads the current GitHub pull request list page to find repository context and render reviewer chips inline.
-- `https://api.github.com/*`: fetches requested reviewers, requested teams, and review history from GitHub's REST API.
+- `https://api.github.com/*`: fetches requested reviewers, requested teams, and review history from GitHub's REST API. Requests originate from the extension's background service worker; the access token never enters the content-script execution context.
 
 Remote code:
 `No, this extension does not execute remote code.`

--- a/docs/chrome-web-store-submission.md
+++ b/docs/chrome-web-store-submission.md
@@ -101,5 +101,5 @@ Host [privacy-policy.md](./privacy-policy.md) at a stable public URL before subm
 Expected package path after `pnpm zip`:
 
 ```text
-.output/github-pulls-show-reviewers-1.3.0-chrome.zip
+.output/github-pulls-show-reviewers-1.4.0-chrome.zip
 ```

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -7,8 +7,11 @@
   its GitHub App installations (`all` or `selected` with explicit full names).
 - Device flow runs on the options page. Polling stops when the options tab
   closes; restarts are clean.
-- Content-script reviewer fetches resolve the covering account per repo via
-  the cached installations. No user-typed scope patterns.
+- Content scripts detect PR rows and dispatch a `fetchPullReviewerSummary`
+  message to the background service worker. The background resolves the
+  covering account per repo via the cached installations and performs the
+  GitHub REST calls, so access tokens never enter the content-script
+  execution context. No user-typed scope patterns.
 - Row-level failures render an empty reviewer slot. A page-level banner surfaces
   uncovered-org guidance and unauthenticated rate-limit hints.
 
@@ -18,8 +21,10 @@
 2. Find PR rows with centralized GitHub selectors.
 3. Extract the pull request number from the row id or primary pull request link.
 4. Resolve the covering account for `owner/repo` via `resolveAccountForRepo`.
-5. Fetch reviewer data from GitHub only when the cache is cold. Use the
-   matched account's token, or no token if none matches.
+5. Send a `fetchPullReviewerSummary` message to the background service
+   worker when the cache is cold. The background resolves the matched
+   account's token (or no token if none matches), performs the GitHub REST
+   calls, and returns the parsed summary or a typed error.
 6. Render a single `Reviewers` section inline in the PR row metadata area. Each reviewer is an avatar chip. Requested reviewers keep the blue requested ring. Completed reviewers show a ring and badge derived from one `(isRequested, state)` mapping. Review selection prefers the latest non-`COMMENTED` review for a reviewer, falling back to the latest `COMMENTED` review only when no non-comment review exists. A still-requested reviewer with prior `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` evidence shows the refresh badge instead of the prior state badge. Requested teams keep the text chip shape.
 7. On API errors, emit a signal to the banner aggregator; do not render
    row-level error text.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,12 +1,12 @@
 # Privacy Policy
 
-Last updated: 2026-04-23
+Last updated: 2026-04-24
 
 `GitHub Pulls Show Reviewers` is a Chrome extension that shows requested reviewers, requested teams, and completed review state directly inside GitHub pull request list pages.
 
 ## What the extension accesses
 
-The extension runs only on `https://github.com/*` pages that match repository routes and requests reviewer data from `https://api.github.com/*`.
+The extension runs on `https://github.com/*` pull request list pages and requests reviewer data from `https://api.github.com/*` through its background service worker. The background service worker also schedules a recurring `chrome.alarms` job to refresh GitHub App access tokens ahead of their expiry so that private-repository lookups keep working without requiring a fresh sign-in every eight hours.
 
 To provide its reviewer visibility feature, the extension may access:
 
@@ -20,8 +20,8 @@ To provide its reviewer visibility feature, the extension may access:
 ## How data is used
 
 - GitHub page context is used locally to determine which repository and pull requests are visible on the current page.
-- Reviewer metadata is requested from GitHub's API and rendered inline on the GitHub pull request list page.
-- The GitHub App credentials are used only to authenticate requests to GitHub for private repository access and to refresh expired access tokens.
+- Reviewer metadata is requested from GitHub's API and rendered inline on the GitHub pull request list page. The API request itself runs in the extension's background service worker so that the access token never enters the content-script execution context.
+- The GitHub App credentials are used only to authenticate requests to GitHub for private repository access and to refresh expired access tokens. Refreshes run both reactively on a `401` response and proactively on a recurring 15-minute background schedule via the `alarms` permission, so tokens stay valid even while no GitHub tab is open.
 
 ## Storage and retention
 

--- a/docs/releases/v1.4.0.md
+++ b/docs/releases/v1.4.0.md
@@ -1,0 +1,45 @@
+## v1.4.0
+
+Minor release for **GitHub Pulls Show Reviewers** focused on authentication reliability and reviewer-fetch architecture. Access tokens now refresh proactively in the background service worker via `chrome.alarms`, and the reviewer fetch itself moved into the background so access tokens never enter the page execution context. The content-script scope narrowed to PR list pages, and a long tail of review-flow, error-classification, and release-infra polish landed together.
+
+### Highlights
+
+- Proactive access-token refresh via `chrome.alarms` ([ADR 0005](../adr/0005-proactive-refresh.md)) and terminal-vs-transient classification of non-2xx OAuth responses ([ADR 0004](../adr/0004-github-app-token-refresh.md)).
+- Reviewer fetches run in the background service worker; content scripts message and render only.
+- Content script loads only on `/owner/repo/pulls*`; the background validates message sender origin; in-flight reviewer fetches abort on route and account changes.
+
+### Permissions
+
+- Adds `alarms`, narrowly scoped to the proactive token-refresh scheduler (15-minute period, 30-minute expiry threshold). Chrome Web Store treats this as a new permission and may require re-review.
+- No new host permissions.
+
+### Authentication
+
+- `refreshAccessToken` parses the response body regardless of status. OAuth error envelopes on 4xx responses reuse the existing `TERMINAL_REFRESH_ERRORS` set; HTTP 400/401 without a parseable body falls back to terminal; 5xx, 429, and network errors stay transient.
+- Proactive refresh runs on a 15-minute schedule with a 30-minute expiry threshold. Accounts whose refresh token has already expired short-circuit to `markAccountInvalidated(..., "expired")` instead of paying a guaranteed-to-fail refresh round-trip.
+- The options-page "Check matched account" diagnostic uses the same retry-with-refresh path as the runtime, so a stale access token no longer reports a false negative.
+- [ADR 0003](../adr/0003-github-app-device-flow.md) carries an amendment pointer to [ADR 0004](../adr/0004-github-app-token-refresh.md); ADR 0004 documents the refresh contract; [ADR 0005](../adr/0005-proactive-refresh.md) documents the proactive-refresh scheduler.
+
+### Reviewer flow
+
+- Reviewer fetch moved into `src/background/reviewer-fetch.ts`. The content script dispatches a typed message and never handles the access token directly.
+- Per-request `AbortController`s cancel outstanding fetches on route changes, storage changes, and account invalidations, so late resolves cannot poison the cache or render into stale mounts.
+- "Sign in again" now replaces the existing invalidated account in place instead of appending a duplicate card for the same GitHub login.
+- Banner classification aggregates all endpoint failures in a `GitHubPullRequestEndpointsError` so mixed 429 / 404 cases route to the correct banner message.
+- `safeParse` guards the reviewer fetch so schema drift from GitHub surfaces as a dedicated error class; cache-hit re-renders no longer flash "Loading reviewers…" over painted chips; the reviewer cache is bounded at 500 entries with LRU eviction.
+
+### Quality & Packaging
+
+- `pnpm test:e2e` and `pnpm cws:assets` run under separate Playwright projects so release verification no longer mutates tracked screenshot assets.
+- New `scripts/run-with-github-app-env.sh` injects GitHub Actions `vars` via `gh variable list`; `pnpm build:release` and `pnpm zip:release` wrap `pnpm build` and `pnpm zip` with that loader so local release builds match the CI environment without a hand-edited `.env.local`.
+- Release workflow pins `pnpm install --frozen-lockfile` for reproducibility.
+- Storage helpers (`markAccountInvalidated`, `updateAccountTokens`, `replaceInstallations`) emit a `console.warn` when a write is skipped because the stored record is missing or malformed, making silent corruptions visible in service-worker DevTools.
+- Chrome Web Store listing copy and privacy policy updated to reflect the new `alarms` permission, the background-worker fetch path, and the proactive refresh schedule.
+
+### Scope Notes
+
+- Reviewer visibility on GitHub pull request list pages remains the only product goal.
+- Proactive token-refresh scheduling is motivated by existing authentication reliability; it does not expand the extension's behavior beyond what [ADR 0003](../adr/0003-github-app-device-flow.md) and [ADR 0004](../adr/0004-github-app-token-refresh.md) already committed to.
+- Checks, mergeability, labels, assignees, and general PR dashboard features remain out of scope.
+
+**Full Changelog**: https://github.com/hon454/github-pulls-show-reviewers/compare/v1.3.0...v1.4.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-pulls-show-reviewers",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "description": "Chrome extension focused on showing reviewers directly in GitHub pull request lists.",


### PR DESCRIPTION
## Summary

- Bump `package.json` to `1.4.0` and align the submission packet's expected zip filename.
- Publish `docs/releases/v1.4.0.md` for the release workflow to pick up as the release body.
- Disclose the new `alarms` permission and the background-worker fetch path in the privacy policy and in the Chrome Web Store submission packet.
- Sync implementation notes with the reviewer-fetch move that landed in #15.

## Why

The v1.4.0 cycle added a new `alarms` permission ([#18](https://github.com/hon454/github-pulls-show-reviewers/pull/18)) and moved authenticated GitHub fetches into the background service worker ([#15](https://github.com/hon454/github-pulls-show-reviewers/pull/15)). Neither change carried its co-located documentation update, so the privacy policy, the Chrome Web Store submission packet, and the implementation notes were out of sync with shipped behavior. Cutting a tag without reconciling them would publish a listing Chrome Web Store review can flag and leave future readers looking for the fetch logic under the content script. This PR closes those gaps and performs the version bump so `v1.4.0` can be tagged against main.

## Changes

- **Privacy policy** (`docs/privacy-policy.md`): describe the `chrome.alarms` scheduler and note that reviewer fetches now run in the background. Bump `Last updated` to 2026-04-24.
- **Chrome Web Store submission packet** (`docs/chrome-web-store-submission.md`): add an `alarms` entry to the permission-justification draft, expand the `storage` entry to list refresh tokens + expiry timestamps, tighten the `api.github.com` entry to point at the background origin. Also bump the expected zip filename from `1.3.0` to `1.4.0`.
- **Implementation notes** (`docs/implementation-notes.md`): reword the Current MVP bullet and Runtime Flow step 5 so they reflect the background-worker fetch path.
- **Release notes** (`docs/releases/v1.4.0.md`, new): summary, Highlights, Permissions, Authentication, Reviewer flow, Quality & Packaging, Scope Notes, and compare link. The Permissions section calls out that Chrome Web Store may treat `alarms` as a re-review trigger.
- **Version bump** (`package.json`): `1.3.0` → `1.4.0`. WXT derives the manifest version from this, so no manifest edit is needed.

## Impact

- User-facing impact: none from this PR itself; the behavior changes in `v1.4.0` all shipped in earlier PRs. Chrome Web Store reviewers will see accurate permission disclosures.
- API/schema impact: none.
- Performance impact: none.
- Operational or rollout impact: tag `v1.4.0` triggers `release.yml`, which packages `.output/github-pulls-show-reviewers-1.4.0-chrome.zip` and publishes `docs/releases/v1.4.0.md` as the release body.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint` — clean.
- `pnpm typecheck` — clean.
- `pnpm test` — 22 files / 220 tests passed.
- Manual verification per the release checklist in `docs/chrome-web-store.md` is pending and will run before tagging — including `pnpm build:release`, loading the zip in Chrome, a live PR list smoke, a private-repository device-flow + refresh + re-auth walkthrough, and `chrome.alarms.getAll()` inspection in the service-worker devtools to confirm the proactive-refresh alarm registers.

## Breaking Changes

- None. The `alarms` permission is additive; the Chrome Web Store will likely treat it as a re-review trigger, but no user action or migration is required.

## Related Issues

Resolves #7, #9