### PR TITLE
fix(background): keep onMessage channel open with sendResponse

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -62,7 +62,11 @@ export default defineBackground(() => {
   });
 
   browser.runtime.onMessage.addListener(
-    (message: unknown, sender: { id?: string } | undefined) => {
+    (
+      message: unknown,
+      sender: { id?: string } | undefined,
+      sendResponse: (response?: unknown) => void,
+    ) => {
       // Reject messages from other extensions or extension pages. Only
       // components of this extension (content scripts, options page) are
       // allowed to trigger a token refresh — otherwise a third party could
@@ -71,18 +75,43 @@ export default defineBackground(() => {
       if (sender?.id !== browser.runtime.id) {
         return undefined;
       }
+      // Chrome MV3 does not reliably await a Promise returned from an
+      // `onMessage` listener. Returning `true` keeps the message channel
+      // open and `sendResponse` delivers the async result to the caller.
       if (
         message != null &&
         typeof message === "object" &&
         (message as { type?: unknown }).type === "refreshAccessToken" &&
         typeof (message as { accountId?: unknown }).accountId === "string"
       ) {
-        return coordinator.refreshAccountToken(
-          (message as { accountId: string }).accountId,
-        );
+        coordinator
+          .refreshAccountToken(
+            (message as { accountId: string }).accountId,
+          )
+          .then(
+            (outcome) => sendResponse(outcome),
+            (error) => {
+              console.error(
+                "[GitHub Pulls Show Reviewers] refreshAccountToken failed.",
+                error,
+              );
+              sendResponse(undefined);
+            },
+          );
+        return true;
       }
       if (isFetchPullReviewerSummaryMessage(message)) {
-        return reviewerFetchService.handleFetchMessage(message);
+        reviewerFetchService.handleFetchMessage(message).then(
+          (response) => sendResponse(response),
+          (error) => {
+            console.error(
+              "[GitHub Pulls Show Reviewers] Reviewer fetch handler crashed.",
+              error,
+            );
+            sendResponse(undefined);
+          },
+        );
+        return true;
       }
       if (isCancelPullReviewerSummaryMessage(message)) {
         reviewerFetchService.cancelRequest(message.requestId);

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -56,7 +56,7 @@ type MessageSender = { id?: string };
 type MessageListener = (
   message: unknown,
   sender: MessageSender | undefined,
-  sendResponse: () => void,
+  sendResponse: (value?: unknown) => void,
 ) => unknown;
 
 const SELF_RUNTIME_ID = "self-extension-id";
@@ -65,6 +65,23 @@ let capturedMessageListener: MessageListener | null;
 
 function flushMicrotasks() {
   return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// Drives the listener through Chrome's `return true` + `sendResponse`
+// contract. The returned Promise resolves to whatever the listener routes
+// back to the caller — either the async `sendResponse` value or the sync
+// return for messages the listener does not handle.
+function callListener(
+  listener: MessageListener,
+  message: unknown,
+  sender: MessageSender | undefined,
+): Promise<unknown> {
+  return new Promise((resolve) => {
+    const keepOpen = listener(message, sender, resolve);
+    if (keepOpen !== true) {
+      resolve(keepOpen);
+    }
+  });
 }
 
 let capturedAlarmListener: ((alarm: { name: string }) => void) | null;
@@ -128,52 +145,62 @@ describe("background runtime.onMessage handler", () => {
   it("dispatches valid refresh messages that originate from this extension", async () => {
     const listener = await bootBackground();
 
-    const result = listener(
+    const response = await callListener(
+      listener,
+      { type: "refreshAccessToken", accountId: "acc-1" },
+      { id: SELF_RUNTIME_ID },
+    );
+
+    expect(refreshAccountTokenMock).toHaveBeenCalledTimes(1);
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-1");
+    expect(response).toEqual({ ok: true, token: "new-token" });
+  });
+
+  it("keeps the message channel open for async dispatch", async () => {
+    const listener = await bootBackground();
+
+    const sync = listener(
       { type: "refreshAccessToken", accountId: "acc-1" },
       { id: SELF_RUNTIME_ID },
       () => {},
     );
 
-    expect(refreshAccountTokenMock).toHaveBeenCalledTimes(1);
-    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-1");
-    await expect(result as Promise<unknown>).resolves.toEqual({
-      ok: true,
-      token: "new-token",
-    });
+    expect(sync).toBe(true);
   });
 
   it("rejects valid refresh messages from a different extension id", async () => {
     const listener = await bootBackground();
 
-    const result = listener(
+    const response = await callListener(
+      listener,
       { type: "refreshAccessToken", accountId: "acc-1" },
       { id: "some-other-extension-id" },
-      () => {},
     );
 
-    expect(result).toBeUndefined();
+    expect(response).toBeUndefined();
     expect(refreshAccountTokenMock).not.toHaveBeenCalled();
   });
 
   it("rejects malformed envelopes even when sent from this extension", async () => {
     const listener = await bootBackground();
 
-    const missingAccountId = listener(
+    const missingAccountId = await callListener(
+      listener,
       { type: "refreshAccessToken" },
       { id: SELF_RUNTIME_ID },
-      () => {},
     );
-    const wrongType = listener(
+    const wrongType = await callListener(
+      listener,
       { type: "somethingElse", accountId: "acc-1" },
       { id: SELF_RUNTIME_ID },
-      () => {},
     );
-    const notAnObject = listener(
+    const notAnObject = await callListener(
+      listener,
       "refreshAccessToken",
       { id: SELF_RUNTIME_ID },
-      () => {},
     );
-    const emptyReviewerFetch = listener(
+    const emptyReviewerFetch = await callListener(
+      listener,
       {
         type: "fetchPullReviewerSummary",
         requestId: "req-1",
@@ -183,7 +210,6 @@ describe("background runtime.onMessage handler", () => {
         accountId: null,
       },
       { id: SELF_RUNTIME_ID },
-      () => {},
     );
 
     expect(missingAccountId).toBeUndefined();
@@ -208,7 +234,8 @@ describe("background runtime.onMessage handler", () => {
     });
     fetchPullReviewerSummaryMock.mockResolvedValue(summary);
 
-    const result = listener(
+    const response = await callListener(
+      listener,
       {
         type: "fetchPullReviewerSummary",
         requestId: "req-1",
@@ -218,13 +245,9 @@ describe("background runtime.onMessage handler", () => {
         accountId: "acc-1",
       },
       { id: SELF_RUNTIME_ID },
-      () => {},
     );
 
-    await expect(result as Promise<unknown>).resolves.toEqual({
-      ok: true,
-      summary,
-    });
+    expect(response).toEqual({ ok: true, summary });
     expect(fetchPullReviewerSummaryMock).toHaveBeenCalledWith({
       owner: "cinev",
       repo: "shotloom",
@@ -257,7 +280,8 @@ describe("background runtime.onMessage handler", () => {
       .mockRejectedValueOnce({ status: 401 })
       .mockResolvedValueOnce(summary);
 
-    const result = listener(
+    const response = await callListener(
+      listener,
       {
         type: "fetchPullReviewerSummary",
         requestId: "req-1",
@@ -267,13 +291,9 @@ describe("background runtime.onMessage handler", () => {
         accountId: "acc-1",
       },
       { id: SELF_RUNTIME_ID },
-      () => {},
     );
 
-    await expect(result as Promise<unknown>).resolves.toEqual({
-      ok: true,
-      summary,
-    });
+    expect(response).toEqual({ ok: true, summary });
     expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-1");
     expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(2);
     expect(fetchPullReviewerSummaryMock.mock.calls[1][0]).toMatchObject({
@@ -292,7 +312,8 @@ describe("background runtime.onMessage handler", () => {
     refreshAccountTokenMock.mockResolvedValueOnce({ ok: false, terminal: false });
     fetchPullReviewerSummaryMock.mockRejectedValueOnce({ status: 401 });
 
-    const result = listener(
+    const response = await callListener(
+      listener,
       {
         type: "fetchPullReviewerSummary",
         requestId: "req-1",
@@ -302,10 +323,9 @@ describe("background runtime.onMessage handler", () => {
         accountId: "acc-1",
       },
       { id: SELF_RUNTIME_ID },
-      () => {},
     );
 
-    await expect(result as Promise<unknown>).resolves.toMatchObject({
+    expect(response).toMatchObject({
       ok: false,
       error: { kind: "unknown", status: 401 },
     });
@@ -322,7 +342,8 @@ describe("background runtime.onMessage handler", () => {
     });
     fetchPullReviewerSummaryMock.mockRejectedValueOnce({ status: 401 });
 
-    const result = listener(
+    const response = await callListener(
+      listener,
       {
         type: "fetchPullReviewerSummary",
         requestId: "req-1",
@@ -332,10 +353,9 @@ describe("background runtime.onMessage handler", () => {
         accountId: "acc-1",
       },
       { id: SELF_RUNTIME_ID },
-      () => {},
     );
 
-    await expect(result as Promise<unknown>).resolves.toMatchObject({
+    expect(response).toMatchObject({
       ok: false,
       error: { kind: "unknown", status: 401 },
     });
@@ -360,7 +380,8 @@ describe("background runtime.onMessage handler", () => {
       .mockRejectedValueOnce({ status: 401 })
       .mockRejectedValueOnce({ status: 401 });
 
-    const result = listener(
+    const response = await callListener(
+      listener,
       {
         type: "fetchPullReviewerSummary",
         requestId: "req-1",
@@ -370,10 +391,9 @@ describe("background runtime.onMessage handler", () => {
         accountId: "acc-1",
       },
       { id: SELF_RUNTIME_ID },
-      () => {},
     );
 
-    await expect(result as Promise<unknown>).resolves.toMatchObject({
+    expect(response).toMatchObject({
       ok: false,
       error: { kind: "unknown", status: 401 },
     });
@@ -418,13 +438,13 @@ describe("background runtime.onMessage handler", () => {
     }
     expect(signal.aborted).toBe(false);
 
-    const cancelResult = listener(
+    const cancelResult = await callListener(
+      listener,
       {
         type: "cancelPullReviewerSummary",
         requestId: "req-cancel",
       },
       { id: SELF_RUNTIME_ID },
-      () => {},
     );
 
     expect(cancelResult).toBeUndefined();
@@ -538,13 +558,13 @@ describe("background runtime.onMessage handler", () => {
       },
     );
 
-    const cancelResult = listener(
+    const cancelResult = await callListener(
+      listener,
       {
         type: "cancelPullReviewerSummary",
         requestId: "req-pre-cancel",
       },
       { id: SELF_RUNTIME_ID },
-      () => {},
     );
     expect(cancelResult).toBeUndefined();
 


### PR DESCRIPTION
## Summary

- Restore reviewer-row rendering on GitHub PR list pages by switching the background `onMessage` listener from a bare Promise return to the documented Chrome MV3 `return true` + `sendResponse` contract.
- Update the background-test helper to drive the listener the way Chrome drives it, and add a guard that the async dispatch paths keep the channel open.

## Why

PR #15 moved the reviewer fetch into the service worker and made the background `onMessage` listener return the fetch Promise directly. Chrome MV3 does not reliably await that Promise: the message channel closes synchronously, the content script receives `undefined`, and `unwrapReviewerFetchResponse(undefined)` throws. The row's `.ghpsr-root` is created but left empty, so the reviewer row is blank for every PR.

v1.4.0 release prep (#19) landed without catching this because only `pnpm typecheck` runs in CI — `pnpm test`, `pnpm test:e2e`, and `pnpm lint` only run in the release workflow on a tag push. The e2e suite fails locally against `main` with the same symptom the production extension would show, which would block the v1.4.0 release workflow.

Unit tests passed because they invoke the listener directly and await its return value; only the real Chrome dispatch path exposes the bug.

## Changes

- `entrypoints/background.ts`: the `runtime.onMessage` listener now accepts `sendResponse`, calls `sendResponse(result)` from the `.then` / `.catch` of the async branches, and returns `true` to hold the channel open. Terminal errors from the handler are logged and `sendResponse(undefined)` is delivered so the content script's `unwrapReviewerFetchResponse` still throws the existing runtime error.
- `tests/background.test.ts`: add a `callListener` helper that drives the listener through Chrome's contract and resolves the returned Promise via `sendResponse`. Rewrite the existing assertions to consume the helper. Add a dedicated case asserting the listener returns `true` for async dispatch paths so future regressions fail here rather than in the e2e suite.

## Impact

- User-facing impact: Restores the reviewer row on GitHub PR list pages. Without this fix, v1.4.0 would ship with blank `.ghpsr-root` mounts on every PR.
- API/schema impact: None. Message shapes are unchanged.
- Performance impact: None. Identical code path; only the response transport contract changes.
- Operational or rollout impact: Needed before the `v1.4.0` tag is pushed; otherwise the release workflow's `pnpm verify:release` step will fail in e2e.

## Testing

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

### Test details

- `pnpm lint` — clean.
- `pnpm typecheck` — clean.
- `pnpm test` — 221/221 (was 220; +1 for the new async-channel assertion).
- `pnpm test:e2e` — 6/6. Before this fix, 4 of the 6 default specs failed with `.ghpsr-root` empty after a 5-second wait.
- Local debug run with `context.route` on `api.github.com/**` confirmed the route handlers were already hit (SW fetch worked end-to-end); the gap was only the message response arriving as `undefined` at the content script.

## Breaking Changes

- None. Message envelope, response shape, and error-routing semantics are identical.

## Related Issues

No issue: latent v1.4.0 blocker discovered during release prep. Ship with the release so the `v1.4.0` tag's release workflow passes `pnpm verify:release`.