### PR TITLE
ops(ci): run lint, unit tests, and e2e on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,11 @@ on:
       - main
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
-  verify:
+  lint-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -18,4 +21,24 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile=false
       - run: pnpm prepare
+      - run: pnpm lint
       - run: pnpm typecheck
+      - run: pnpm test
+
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      WXT_GITHUB_APP_CLIENT_ID: TESTING_CLIENT_ID
+      WXT_GITHUB_APP_SLUG: test-app
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile=false
+      - run: pnpm prepare
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm test:e2e:build
+      - run: pnpm test:e2e:run

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ pnpm verify:release
 6. Run `pnpm cws:assets` only when screenshots or store-facing visuals need to be regenerated.
 7. Run `pnpm zip` only after the checks above are green and you are ready to inspect or submit the packaged artifact.
 
-Release automation installs Playwright Chromium and re-runs `pnpm verify:release` before `pnpm zip`, but the regular PR CI is intentionally lighter. Do not treat a green PR check alone as release sign-off.
+PR CI runs the same `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm test:e2e` signals in parallel jobs. Release automation still runs `pnpm verify:release` as a single gate before `pnpm zip` on tag push, which is the authoritative release sign-off.
 
 ## Repository Map
 


### PR DESCRIPTION
## Summary

- Extend `.github/workflows/ci.yml` to run `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm test:e2e` on PRs and pushes to `main`, split into parallel `lint-and-test` and `e2e` jobs so slow e2e does not block the fast-path signals.
- Sync the README "Pre-release Test Workflow" note so it no longer claims PR CI is "intentionally lighter" than release.

## Why

CI used to run only `pnpm typecheck`. The remaining `verify:release` signals (`pnpm lint`, `pnpm test`, `pnpm test:e2e`) ran only from `release.yml` on `v*` tag push. Every non-tag change therefore shipped to `main` with zero lint/unit/e2e signal.

That gap let the MV3 `runtime.onMessage` background-channel regression introduced in #15 sit on `main` through #15 → #18 → #19 (v1.4.0 prep) with a blank reviewer row on every GitHub PR list row. The regression was only surfaced during manual release prep when `pnpm test:e2e` was run by hand, and fixed in #20. The fix is planned to ship in v1.4.1.

## Changes

- `.github/workflows/ci.yml`:
  - Split the single `verify` job into `lint-and-test` (lint, typecheck, unit) and `e2e` (Playwright install + `test:e2e:build` + `test:e2e:run`). Both run in parallel.
  - Mirror `release.yml`'s `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` env and action versions (`actions/checkout@v6`, `pnpm/action-setup@v6`, `actions/setup-node@v6` with Node 22 + pnpm cache).
  - Keep `pnpm install --frozen-lockfile=false` (intentionally different from release, which uses `--frozen-lockfile`).
  - The `e2e` job sets `WXT_GITHUB_APP_CLIENT_ID=TESTING_CLIENT_ID` / `WXT_GITHUB_APP_SLUG=test-app` to match the existing `test:e2e:build` script; no real secrets are needed.
- `README.md`: replace the "PR CI is intentionally lighter" paragraph with a note that PR CI runs the same signals in parallel and release is still the authoritative sign-off.

`release.yml` is intentionally untouched.

## Impact

- User-facing impact: None.
- API/schema impact: None.
- Performance impact: PRs will now spend ~30s on `e2e` in parallel. The `lint-and-test` job completes in under a minute and is not blocked by `e2e`.
- Operational or rollout impact: `main` merges now gate on the same signals as release, closing the regression-visibility gap from #20's postmortem. Planned to ship with v1.4.1.

## Testing

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

### Test details

- `pnpm lint` — clean.
- `pnpm typecheck` — clean.
- `pnpm test` — 221 tests across 22 files pass.
- `pnpm test:e2e` — 6/6 pass on current `main` with #20 applied.
- Regression-catch proof: reverted `entrypoints/background.ts` locally to the pre-#20 state and re-ran `pnpm test:e2e`. 4/6 scenarios fail with blank reviewer rows — exactly the regression that survived #15 → #19. Restored the file before committing; `git diff` confirms only `.github/workflows/ci.yml` and `README.md` are modified.
- Not verified: the new jobs running on GitHub Actions. They will only execute once this PR's first commit lands on the branch and Actions picks them up.

## Breaking Changes

- None.

## Related Issues

Resolves #21