### PR TITLE
feat(access-banner): name current repo, use Configure access link

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -28,7 +28,7 @@ export default defineContentScript({
       if (!reviewerListBooted) {
         reviewerListBooted = true;
         bootReviewerListPage(ctx, {
-          onRowFailure({ owner, account, error }) {
+          onRowFailure({ account, error }) {
             if (aggregator == null) {
               aggregator = bootAccessBanner(ctx);
             }
@@ -42,15 +42,15 @@ export default defineContentScript({
               return;
             }
             if (signals.uncovered) {
-              aggregator.reportUncoveredOwner(owner);
+              aggregator.reportUncovered();
               return;
             }
             // Fallback for errors we cannot attribute (schema drift, network
             // failure, aborted fetch, etc.). We keep the existing behavior and
-            // flag the owner as uncovered so the banner still guides the user
+            // flag the repo as uncovered so the banner still guides the user
             // toward App installation — doing nothing here would leave the row
             // blank with no explanation.
-            aggregator.reportUncoveredOwner(owner);
+            aggregator.reportUncovered();
           },
         });
       }

--- a/src/features/access-banner/aggregator.ts
+++ b/src/features/access-banner/aggregator.ts
@@ -1,4 +1,4 @@
-export type BannerRepo = { owner: string; name: string };
+export type BannerRepo = { readonly owner: string; readonly name: string };
 
 export type BannerState = {
   uncovered: boolean;
@@ -20,7 +20,10 @@ export function createBannerAggregator(options: {
   repo: BannerRepo;
 }): BannerAggregator {
   const dismissKey = `ghpsr:banner-dismissed:${options.pathname}`;
-  const repo = options.repo;
+  const repo: BannerRepo = {
+    owner: options.repo.owner,
+    name: options.repo.name,
+  };
   let uncovered = false;
   let unauthRateLimited = false;
   let dismissed = readDismissed(dismissKey);
@@ -86,11 +89,9 @@ function readDismissed(key: string): boolean {
   }
 }
 
-export function formatBannerMessage(state: {
-  uncovered: boolean;
-  unauthRateLimited: boolean;
-  repo: BannerRepo;
-}): string {
+export function formatBannerMessage(
+  state: Pick<BannerState, "uncovered" | "unauthRateLimited" | "repo">,
+): string {
   if (state.uncovered) {
     return `Add ${state.repo.owner}/${state.repo.name} to @${state.repo.owner}'s GitHub App installation to see reviewers on this page.`;
   }

--- a/src/features/access-banner/aggregator.ts
+++ b/src/features/access-banner/aggregator.ts
@@ -1,31 +1,37 @@
+export type BannerRepo = { owner: string; name: string };
+
 export type BannerState = {
-  uncoveredOrgs: string[];
+  uncovered: boolean;
   unauthRateLimited: boolean;
   dismissed: boolean;
+  repo: BannerRepo;
 };
 
 export type BannerAggregator = {
   getState(): BannerState;
   subscribe(listener: (state: BannerState) => void): () => void;
-  reportUncoveredOwner(owner: string): void;
+  reportUncovered(): void;
   reportUnauthRateLimit(): void;
   dismiss(): void;
 };
 
 export function createBannerAggregator(options: {
   pathname: string;
+  repo: BannerRepo;
 }): BannerAggregator {
   const dismissKey = `ghpsr:banner-dismissed:${options.pathname}`;
-  const orgs = new Set<string>();
+  const repo = options.repo;
+  let uncovered = false;
   let unauthRateLimited = false;
   let dismissed = readDismissed(dismissKey);
   const listeners = new Set<(state: BannerState) => void>();
 
   function snapshot(): BannerState {
     return {
-      uncoveredOrgs: [...orgs],
+      uncovered,
       unauthRateLimited,
       dismissed,
+      repo,
     };
   }
 
@@ -43,12 +49,11 @@ export function createBannerAggregator(options: {
         listeners.delete(listener);
       };
     },
-    reportUncoveredOwner(owner) {
-      const normalized = owner.toLowerCase();
-      if (orgs.has(normalized)) {
+    reportUncovered() {
+      if (uncovered) {
         return;
       }
-      orgs.add(normalized);
+      uncovered = true;
       emit();
     },
     reportUnauthRateLimit() {
@@ -82,15 +87,12 @@ function readDismissed(key: string): boolean {
 }
 
 export function formatBannerMessage(state: {
-  uncoveredOrgs: string[];
+  uncovered: boolean;
   unauthRateLimited: boolean;
+  repo: BannerRepo;
 }): string {
-  if (state.uncoveredOrgs.length === 1) {
-    return `Add GitHub App access to @${state.uncoveredOrgs[0]} to see reviewers on this page.`;
-  }
-  if (state.uncoveredOrgs.length > 1) {
-    const [first, ...rest] = state.uncoveredOrgs;
-    return `Add GitHub App access to @${first} and ${rest.length} more organization${rest.length === 1 ? "" : "s"}.`;
+  if (state.uncovered) {
+    return `Add ${state.repo.owner}/${state.repo.name} to @${state.repo.owner}'s GitHub App installation to see reviewers on this page.`;
   }
   if (state.unauthRateLimited) {
     return "You hit GitHub's unauthenticated rate limit.";

--- a/src/features/access-banner/dom.ts
+++ b/src/features/access-banner/dom.ts
@@ -18,8 +18,7 @@ export function mountBanner(input: {
 
   function render(state: BannerState): void {
     const visible =
-      !state.dismissed &&
-      (state.uncoveredOrgs.length > 0 || state.unauthRateLimited);
+      !state.dismissed && (state.uncovered || state.unauthRateLimited);
 
     if (!visible) {
       element?.remove();
@@ -50,14 +49,13 @@ export function mountBanner(input: {
     message.textContent = formatBannerMessage(state);
     element.append(message);
 
-    if (state.uncoveredOrgs.length > 0) {
-      const installLink = document.createElement("a");
-      installLink.href = input.installUrl;
-      installLink.target = "_blank";
-      installLink.rel = "noreferrer";
-      installLink.textContent =
-        state.uncoveredOrgs.length === 1 ? "Install" : "Manage access";
-      element.append(installLink);
+    if (state.uncovered) {
+      const configureLink = document.createElement("a");
+      configureLink.href = input.installUrl;
+      configureLink.target = "_blank";
+      configureLink.rel = "noreferrer";
+      configureLink.textContent = "Configure access";
+      element.append(configureLink);
     } else if (state.unauthRateLimited) {
       const signInLink = document.createElement("a");
       signInLink.href = input.optionsPageUrl;

--- a/src/features/access-banner/index.ts
+++ b/src/features/access-banner/index.ts
@@ -19,6 +19,7 @@ export function bootAccessBanner(
   }
   const aggregator = createBannerAggregator({
     pathname: window.location.pathname,
+    repo: { owner: route.owner, name: route.repo },
   });
 
   const optionsPageUrl = browser.runtime.getURL("/options.html");

--- a/src/features/access-banner/index.ts
+++ b/src/features/access-banner/index.ts
@@ -19,6 +19,8 @@ export function bootAccessBanner(
   }
   const aggregator = createBannerAggregator({
     pathname: window.location.pathname,
+    // parsePullListRoute returns { owner, repo }; BannerRepo uses `name` to
+    // avoid the awkward `repo.repo` path when reading the state later.
     repo: { owner: route.owner, name: route.repo },
   });
 

--- a/tests/access-banner.test.ts
+++ b/tests/access-banner.test.ts
@@ -6,7 +6,7 @@ import {
   formatBannerMessage,
 } from "../src/features/access-banner/aggregator";
 
-const TEST_REPO = { owner: "cinev", name: "shotloom" };
+const TEST_REPO = { owner: "cinev", name: "shotloom" } as const;
 
 beforeEach(() => {
   window.sessionStorage.clear();
@@ -102,7 +102,7 @@ describe("formatBannerMessage", () => {
     );
   });
 
-  it("prefers the uncovered message over the rate-limit message", () => {
+  it("uses the uncovered message when both flags are set", () => {
     const text = formatBannerMessage({
       uncovered: true,
       unauthRateLimited: true,

--- a/tests/access-banner.test.ts
+++ b/tests/access-banner.test.ts
@@ -6,6 +6,8 @@ import {
   formatBannerMessage,
 } from "../src/features/access-banner/aggregator";
 
+const TEST_REPO = { owner: "cinev", name: "shotloom" };
+
 beforeEach(() => {
   window.sessionStorage.clear();
 });
@@ -17,75 +19,116 @@ afterEach(() => {
 });
 
 describe("bannerAggregator", () => {
-  it("starts empty", () => {
-    const aggregator = createBannerAggregator({ pathname: "/cinev/shotloom/pulls" });
+  it("starts with uncovered=false and carries the repo", () => {
+    const aggregator = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
     expect(aggregator.getState()).toEqual({
-      uncoveredOrgs: [],
+      uncovered: false,
       unauthRateLimited: false,
       dismissed: false,
+      repo: TEST_REPO,
     });
   });
 
-  it("dedupes org entries case-insensitively", () => {
-    const aggregator = createBannerAggregator({ pathname: "/x/pulls" });
-    aggregator.reportUncoveredOwner("CINEV");
-    aggregator.reportUncoveredOwner("cinev");
-    aggregator.reportUncoveredOwner("cinev");
-    expect(aggregator.getState().uncoveredOrgs).toEqual(["cinev"]);
+  it("flips uncovered to true once reported and is idempotent", () => {
+    const aggregator = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
+    const listener = vi.fn();
+    aggregator.subscribe(listener);
+    listener.mockClear();
+
+    aggregator.reportUncovered();
+    aggregator.reportUncovered();
+    aggregator.reportUncovered();
+
+    expect(aggregator.getState().uncovered).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
   });
 
   it("flags an unauth rate limit", () => {
-    const aggregator = createBannerAggregator({ pathname: "/x/pulls" });
+    const aggregator = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
     aggregator.reportUnauthRateLimit();
     expect(aggregator.getState().unauthRateLimited).toBe(true);
   });
 
   it("persists dismissal by pathname via sessionStorage", () => {
-    const first = createBannerAggregator({ pathname: "/cinev/shotloom/pulls" });
+    const first = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
     first.dismiss();
-    const second = createBannerAggregator({ pathname: "/cinev/shotloom/pulls" });
+    const second = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
     expect(second.getState().dismissed).toBe(true);
-    const other = createBannerAggregator({ pathname: "/other/repo/pulls" });
+    const other = createBannerAggregator({
+      pathname: "/other/repo/pulls",
+      repo: { owner: "other", name: "repo" },
+    });
     expect(other.getState().dismissed).toBe(false);
   });
 
   it("resets dismissal when the pathname changes", () => {
-    const first = createBannerAggregator({ pathname: "/cinev/shotloom/pulls" });
+    const first = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
     first.dismiss();
-    const second = createBannerAggregator({ pathname: "/cinev/landing/pulls" });
+    const second = createBannerAggregator({
+      pathname: "/cinev/landing/pulls",
+      repo: { owner: "cinev", name: "landing" },
+    });
     expect(second.getState().dismissed).toBe(false);
   });
 });
 
 describe("formatBannerMessage", () => {
-  it("formats a single uncovered org", () => {
+  it("names the repo and org when uncovered", () => {
     const text = formatBannerMessage({
-      uncoveredOrgs: ["cinev"],
+      uncovered: true,
       unauthRateLimited: false,
+      repo: TEST_REPO,
     });
     expect(text).toBe(
-      "Add GitHub App access to @cinev to see reviewers on this page.",
+      "Add cinev/shotloom to @cinev's GitHub App installation to see reviewers on this page.",
     );
   });
 
-  it("formats multiple uncovered orgs", () => {
+  it("prefers the uncovered message over the rate-limit message", () => {
     const text = formatBannerMessage({
-      uncoveredOrgs: ["cinev", "acme", "beta"],
-      unauthRateLimited: false,
+      uncovered: true,
+      unauthRateLimited: true,
+      repo: TEST_REPO,
     });
     expect(text).toBe(
-      "Add GitHub App access to @cinev and 2 more organizations.",
+      "Add cinev/shotloom to @cinev's GitHub App installation to see reviewers on this page.",
     );
   });
 
   it("formats an unauth rate limit message when nothing else is reported", () => {
     const text = formatBannerMessage({
-      uncoveredOrgs: [],
+      uncovered: false,
       unauthRateLimited: true,
+      repo: TEST_REPO,
     });
-    expect(text).toBe(
-      "You hit GitHub's unauthenticated rate limit.",
-    );
+    expect(text).toBe("You hit GitHub's unauthenticated rate limit.");
+  });
+
+  it("returns an empty string when there is nothing to surface", () => {
+    const text = formatBannerMessage({
+      uncovered: false,
+      unauthRateLimited: false,
+      repo: TEST_REPO,
+    });
+    expect(text).toBe("");
   });
 });
 
@@ -101,11 +144,16 @@ describe("banner DOM", () => {
       optionsPageUrl: "chrome-extension://ext-id/options.html",
       onDismiss: () => {},
     });
-    banner.update({ uncoveredOrgs: [], unauthRateLimited: false, dismissed: false });
+    banner.update({
+      uncovered: false,
+      unauthRateLimited: false,
+      dismissed: false,
+      repo: TEST_REPO,
+    });
     expect(document.querySelector("[data-ghpsr-banner]")).toBeNull();
   });
 
-  it("inserts the banner when an uncovered org is reported", () => {
+  it("inserts a repo-aware banner with a Configure access link when uncovered", () => {
     document.body.innerHTML = `<main><div class="gh-header"></div></main>`;
     const target = document.querySelector<HTMLElement>(".gh-header")!;
     const banner = mountBanner({
@@ -115,12 +163,43 @@ describe("banner DOM", () => {
       onDismiss: () => {},
     });
     banner.update({
-      uncoveredOrgs: ["cinev"],
+      uncovered: true,
       unauthRateLimited: false,
       dismissed: false,
+      repo: TEST_REPO,
     });
+
     const el = document.querySelector("[data-ghpsr-banner]");
-    expect(el?.textContent).toContain("@cinev");
+    expect(el?.textContent).toContain("cinev/shotloom");
+    expect(el?.textContent).toContain("@cinev's GitHub App installation");
+    const link = el?.querySelector("a");
+    expect(link?.textContent).toBe("Configure access");
+    expect(link?.getAttribute("href")).toBe(
+      "https://github.com/apps/test-app/installations/new",
+    );
+  });
+
+  it("renders a Sign in link for the unauth rate-limit state", () => {
+    document.body.innerHTML = `<main><div class="gh-header"></div></main>`;
+    const target = document.querySelector<HTMLElement>(".gh-header")!;
+    const banner = mountBanner({
+      insertAfter: target,
+      installUrl: "https://github.com/apps/test-app/installations/new",
+      optionsPageUrl: "chrome-extension://ext-id/options.html",
+      onDismiss: () => {},
+    });
+    banner.update({
+      uncovered: false,
+      unauthRateLimited: true,
+      dismissed: false,
+      repo: TEST_REPO,
+    });
+
+    const link = document.querySelector("[data-ghpsr-banner] a");
+    expect(link?.textContent).toBe("Sign in");
+    expect(link?.getAttribute("href")).toBe(
+      "chrome-extension://ext-id/options.html",
+    );
   });
 
   it("removes the banner when dismissed", () => {
@@ -133,14 +212,16 @@ describe("banner DOM", () => {
       onDismiss: () => {},
     });
     banner.update({
-      uncoveredOrgs: ["cinev"],
+      uncovered: true,
       unauthRateLimited: false,
       dismissed: false,
+      repo: TEST_REPO,
     });
     banner.update({
-      uncoveredOrgs: ["cinev"],
+      uncovered: true,
       unauthRateLimited: false,
       dismissed: true,
+      repo: TEST_REPO,
     });
     expect(document.querySelector("[data-ghpsr-banner]")).toBeNull();
   });

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -34,7 +34,7 @@ afterEach(() => {
 });
 
 type Aggregator = {
-  reportUncoveredOwner: ReturnType<typeof vi.fn>;
+  reportUncovered: ReturnType<typeof vi.fn>;
   reportUnauthRateLimit: ReturnType<typeof vi.fn>;
   teardown?: ReturnType<typeof vi.fn>;
 };
@@ -85,7 +85,7 @@ describe("content entrypoint", () => {
 
   it("waits to boot PR-list features until navigation enters a PR list", async () => {
     const aggregator = {
-      reportUncoveredOwner: vi.fn(),
+      reportUncovered: vi.fn(),
       reportUnauthRateLimit: vi.fn(),
       teardown: vi.fn(),
     };
@@ -120,7 +120,7 @@ describe("content entrypoint", () => {
   describe("onRowFailure banner classification", () => {
     function makeAggregator(): Aggregator {
       return {
-        reportUncoveredOwner: vi.fn(),
+        reportUncovered: vi.fn(),
         reportUnauthRateLimit: vi.fn(),
         teardown: vi.fn(),
       };
@@ -145,10 +145,10 @@ describe("content entrypoint", () => {
       });
 
       expect(aggregator.reportUnauthRateLimit).toHaveBeenCalledTimes(1);
-      expect(aggregator.reportUncoveredOwner).not.toHaveBeenCalled();
+      expect(aggregator.reportUncovered).not.toHaveBeenCalled();
     });
 
-    it("treats mixed 404 + 403 with an account as uncovered-owner (no rate limit)", async () => {
+    it("treats mixed 404 + 403 with an account as uncovered (no rate limit)", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
       const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
@@ -166,7 +166,7 @@ describe("content entrypoint", () => {
         error,
       });
 
-      expect(aggregator.reportUncoveredOwner).toHaveBeenCalledWith("cinev");
+      expect(aggregator.reportUncovered).toHaveBeenCalledTimes(1);
       expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
     });
 
@@ -188,10 +188,10 @@ describe("content entrypoint", () => {
       });
 
       expect(aggregator.reportUnauthRateLimit).toHaveBeenCalledTimes(1);
-      expect(aggregator.reportUncoveredOwner).not.toHaveBeenCalled();
+      expect(aggregator.reportUncovered).not.toHaveBeenCalled();
     });
 
-    it("falls through to uncovered-owner for non-GitHubApiError errors", async () => {
+    it("falls through to uncovered for non-GitHubApiError errors", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
 
@@ -204,7 +204,7 @@ describe("content entrypoint", () => {
         error: new Error("Network down"),
       });
 
-      expect(aggregator.reportUncoveredOwner).toHaveBeenCalledWith("cinev");
+      expect(aggregator.reportUncovered).toHaveBeenCalledTimes(1);
       expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
     });
 
@@ -226,7 +226,7 @@ describe("content entrypoint", () => {
         },
       });
 
-      expect(aggregator.reportUncoveredOwner).toHaveBeenCalledWith("cinev");
+      expect(aggregator.reportUncovered).toHaveBeenCalledTimes(1);
       expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary

- Replace the ambiguous `Install` link in the pulls-list access banner with a repo-aware message and a `Configure access` label so testers understand that the current repository needs to be added to the organization's GitHub App installation.
- Collapse the banner aggregator from a multi-owner `Set<string>` to a single `uncovered` boolean with the current `{owner, name}` carried on state, since a pulls-list route always resolves to exactly one repository.

## Why

When a signed-in user lands on a private pulls page whose repository is not covered by the organization's GitHub App installation, the banner used to read `Add GitHub App access to @cinev to see reviewers on this page.` and offer a lone `Install` link. Testers reported that `Install` was ambiguous: nothing in the UI said what needed to be installed, where the click would land, or which repository was the missing one. The existing copy also named the organization but never the repository that was actually uncovered.

This change tells the user exactly what to do — add the current repository to the organization's existing (or to-be-created) GitHub App installation — and uses GitHub's own settings term `Configure` for the link so the label matches the destination surface.

## Changes

- **Banner state and API** (`src/features/access-banner/aggregator.ts`): replace `uncoveredOrgs: string[]` with `uncovered: boolean` and a `repo: BannerRepo` carried on every snapshot. `createBannerAggregator` now takes `repo` at construction and defensively copies it; `BannerRepo` fields are `readonly`. `reportUncoveredOwner(owner)` is replaced with argument-less `reportUncovered()`. `formatBannerMessage` emits `Add {owner}/{name} to @{owner}'s GitHub App installation to see reviewers on this page.` when uncovered; the unauth rate-limit message is unchanged.
- **Banner DOM** (`src/features/access-banner/dom.ts`): the uncovered-state link renders `Configure access` (href unchanged at `https://github.com/apps/{slug}/installations/new`). The `Sign in` link for the unauth rate-limit case is preserved. Dismiss button, styling, and mount-target selection are unchanged.
- **Banner wiring** (`src/features/access-banner/index.ts`): pass `{ owner: route.owner, name: route.repo }` through `parsePullListRoute` into `createBannerAggregator`. Comment in place so future readers see why `BannerRepo.name` corresponds to the route's `repo` field.
- **Content script** (`entrypoints/content.ts`): the row-failure classifier calls `aggregator.reportUncovered()` (no argument) in both the classified-uncovered branch and the unclassifiable-error fallback branch.
- **Tests** (`tests/access-banner.test.ts`, `tests/content.test.ts`): rewrite aggregator, `formatBannerMessage`, and DOM suites for the new shape; assert the `Configure access` link text and the repo-aware message; update `content.test.ts` mock type and expectations. Preserve the `bootAccessBanner` "returns null when production config is missing" regression. The obsolete multi-org phrasing assertions are removed.
- **Local planning notes** (`docs/superpowers/`): spec and plan files live under the repo's gitignored planning directory and are not part of the PR diff.

## Impact

- User-facing impact: private repos in orgs without GitHub App coverage now show a clearer, repo-specific call to action. No behavior change for public repos, covered private repos, or the unauth rate-limit path.
- API/schema impact: internal to the access-banner module. No stored data, storage keys, or message shapes change; the dismissal `sessionStorage` key still uses `ghpsr:banner-dismissed:{pathname}`.
- Performance impact: none. One less `Set<string>` and a small reduction in production-code branches.
- Operational or rollout impact: none. Ships as a copy + state-shape refactor with no migration.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm typecheck` — clean.
- `pnpm test` — 22 files / 223 tests pass (was 222; the new DOM assertion for the `Sign in` link replaced the deleted multi-org copy tests with net +1).
- Manual verification on a live org with an uncovered private repo is not performed in this PR. The DOM test pins the `Configure access` text and the `installUrl` href, and the bannerAggregator test pins `reportUncovered` idempotency and pathname-scoped dismissal.
- e2e suite (`pnpm test:e2e`) was not re-run because this change does not alter selectors, message shapes, or reviewer fetch paths.

## Breaking Changes

- None for users. Internal API shape of `BannerAggregator` changed (`reportUncoveredOwner` removed, `reportUncovered` added) but the only caller is `entrypoints/content.ts`, updated in the same commit.

## Related Issues

No issue: UX polish from tester feedback surfaced in conversation; no pre-existing tracking issue.