### PR TITLE
chore(release): prepare v1.4.2

### DIFF
--- a/docs/chrome-web-store-submission.md
+++ b/docs/chrome-web-store-submission.md
@@ -108,5 +108,5 @@ Host [privacy-policy.md](./privacy-policy.md) at a stable public URL before subm
 Expected package path after `pnpm zip`:
 
 ```text
-.output/github-pulls-show-reviewers-1.4.1-chrome.zip
+.output/github-pulls-show-reviewers-1.4.2-chrome.zip
 ```

--- a/docs/releases/v1.4.2.md
+++ b/docs/releases/v1.4.2.md
@@ -1,0 +1,28 @@
+## v1.4.2
+
+Patch release for **GitHub Pulls Show Reviewers** focused on reviewer-chip link targeting and automated Chrome Web Store publishing. The reviewer feature scope stays unchanged: requested reviewers, requested teams, and completed review state remain the only surfaced PR-list metadata.
+
+### Highlights
+
+- Reviewer chip links now scope to open pull requests by default. A new `openPullsOnly` display preference (default `true`) appends `is:open` to the search query behind each user and team chip, so following a chip lands on open PRs only. Users who still want closed PRs in reviewer-filtered results can disable **Open pull requests only in reviewer links** on the options page.
+- User chip hrefs follow the same axis as the ring color: still-requested (blue-ring) chips link to `review-requested:<login>`, completed (colored-ring) chips link to `reviewed-by:<login>`. This keeps the link in sync with the badge even when a reviewer is re-requested after a prior review.
+
+### Authentication
+
+- No permission, token-scope, storage-schema, or host-permission changes.
+- Public repositories still work without signing in when GitHub's unauthenticated REST API allows it.
+- Private repositories still use the maintainer-owned GitHub App with `Pull requests: Read` only.
+
+### Quality & Packaging
+
+- `release.yml` now runs `pnpm cws:publish` after creating the GitHub Release on tag-triggered runs. The script calls the Chrome Web Store API v2 `upload` and `publish` endpoints with `publishType: DEFAULT_PUBLISH`, so approved updates publish automatically after review.
+- `scripts/publish-cws.sh` validates upload and publish state against the real `ItemState` enum (`PENDING_REVIEW`, `STAGED`, `PUBLISHED`, `PUBLISHED_TO_TESTERS`), treats empty or `NOT_FOUND` states as fatal, and surfaces `itemError` / `publish_error_detail` in failure messages. Parameterized tests cover each state and required-env combination.
+- Existing v1 display-preference records without `openPullsOnly` migrate transparently via a zod default — no reviewer cache invalidation is triggered when the preference toggles.
+
+### Scope Notes
+
+- Reviewer visibility on GitHub pull request list pages remains the only product goal.
+- Chrome Web Store publish automation is a release-infrastructure change; it does not expand the extension's runtime behavior.
+- Checks, mergeability, labels, assignees, and general PR dashboard features remain out of scope.
+
+**Full Changelog**: https://github.com/hon454/github-pulls-show-reviewers/compare/v1.4.1...v1.4.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-pulls-show-reviewers",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "type": "module",
   "description": "Chrome extension focused on showing reviewers directly in GitHub pull request lists.",


### PR DESCRIPTION
## Summary

- Bump `package.json` to `1.4.2` and align the Chrome Web Store submission packet's expected zip filename.
- Publish `docs/releases/v1.4.2.md` for `release.yml` to attach as the GitHub Release body on tag push.

## Why

The v1.4.2 cycle carries two merged changes that should ship together: reviewer chip link scoping to open PRs by default ([#25](https://github.com/hon454/github-pulls-show-reviewers/pull/25)) and automated Chrome Web Store publishing ([#24](https://github.com/hon454/github-pulls-show-reviewers/pull/24)). Both landed on `main` after `v1.4.1` was tagged. Their co-located docs (README, implementation notes, privacy policy, chrome-web-store.md, chrome-web-store-submission.md) were already updated in their respective PRs, so the only remaining work to cut the tag is the version bump, the expected-zip-path sync, and the structured release note that `release.yml` consumes. This PR performs only that reconciliation so `v1.4.2` can be tagged against `main`.

## Changes

- **Version bump** (`package.json`): `1.4.1` → `1.4.2`. WXT derives the manifest version from this field, so no manifest edit is needed.
- **Chrome Web Store submission packet** (`docs/chrome-web-store-submission.md`): bump the expected zip path from `1.4.1` to `1.4.2`.
- **Release notes** (`docs/releases/v1.4.2.md`, new): summary, Highlights, Authentication, Quality & Packaging, Scope Notes, and compare link. Highlights call out the `openPullsOnly` display preference default and the state-based reviewer chip href rule; Quality & Packaging covers the `pnpm cws:publish` step added to `release.yml` and the real `ItemState` enum validation in `scripts/publish-cws.sh`.

## Impact

- User-facing impact: none from this PR directly; behavior changes shipped in #24 and #25.
- API/schema impact: none. The new `openPullsOnly` preference migrates transparently via a zod default.
- Performance impact: none.
- Operational or rollout impact: tagging `v1.4.2` triggers `release.yml`, which now packages `.output/github-pulls-show-reviewers-1.4.2-chrome.zip`, attaches `docs/releases/v1.4.2.md` as the release body, and invokes `pnpm cws:publish` to submit the zip to Chrome Web Store with `publishType: DEFAULT_PUBLISH`.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

### Test details

- `pnpm verify:release` — green locally (lint, typecheck, 244 vitest tests across 23 files, 6 Playwright e2e specs).
- Manual Chrome verification was not run because this PR is docs/config only; the shipped runtime behavior was already verified in [#25](https://github.com/hon454/github-pulls-show-reviewers/pull/25).

## Breaking Changes

- None.

## Related Issues

No issue: routine patch release prep.

<!-- Co-location checklist: #7 applies — added docs/releases/v1.4.2.md. All other runtime-facing doc updates already landed in #24 and #25. -->