### PR TITLE
ops(ci): require frozen lockfile installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      - run: pnpm install --frozen-lockfile=false
+      - run: pnpm install --frozen-lockfile
       - run: pnpm prepare
       - run: pnpm lint
       - run: pnpm typecheck
@@ -37,7 +37,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      - run: pnpm install --frozen-lockfile=false
+      - run: pnpm install --frozen-lockfile
       - run: pnpm prepare
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm test:e2e:build

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -1,0 +1,27 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(currentDir, "..");
+
+describe("CI workflow", () => {
+  it("uses frozen lockfile installs in every job", async () => {
+    const workflow = await readFile(
+      path.join(projectRoot, ".github/workflows/ci.yml"),
+      "utf8",
+    );
+    const installCommands = workflow
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("- run: pnpm install"));
+
+    expect(installCommands.length).toBeGreaterThan(0);
+    expect(installCommands).toEqual(
+      installCommands.map(() => "- run: pnpm install --frozen-lockfile"),
+    );
+    expect(workflow).not.toContain("--frozen-lockfile=false");
+  });
+});


### PR DESCRIPTION
## Summary

- Enforce frozen pnpm installs in both CI jobs.
- Add a workflow regression test so CI install commands cannot drift back to lockfile-mutating mode unnoticed.

## Why

CI previously used `pnpm install --frozen-lockfile=false`, while release packaging uses `pnpm install --frozen-lockfile`. That allowed dependency metadata drift to pass PR CI and fail later during release packaging.

## Changes

- Updated the CI `lint-and-test` and `e2e` install steps to use `pnpm install --frozen-lockfile`.
- Added Vitest coverage that verifies every CI `pnpm install` step uses the frozen lockfile flag and rejects `--frozen-lockfile=false`.

## Impact

- User-facing impact: None.
- API/schema impact: None.
- Performance impact: None.
- Operational or rollout impact: CI will now fail when the committed lockfile is out of sync with dependency metadata.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

### Test details

- `pnpm install --frozen-lockfile`
- `pnpm vitest run tests/ci-workflow.test.ts` RED before workflow change, then GREEN after workflow change
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`

## Breaking Changes

- None

## Related Issues

Resolves #28

Co-location note: no checklist items apply; this only changes CI install policy and regression coverage.
