### PR TITLE
fix(access-banner): avoid Configure access for unattributed reviewer failures

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -45,12 +45,14 @@ export default defineContentScript({
               aggregator.reportUncovered();
               return;
             }
-            // Fallback for errors we cannot attribute (schema drift, network
-            // failure, aborted fetch, etc.). We keep the existing behavior and
-            // flag the repo as uncovered so the banner still guides the user
-            // toward App installation — doing nothing here would leave the row
-            // blank with no explanation.
-            aggregator.reportUncovered();
+            // Unattributed failures (schema drift, network error, empty
+            // envelope, etc.) are not App-coverage problems. Showing the
+            // Configure access banner would be misleading guidance, so we
+            // log for diagnosis and leave the banner untouched.
+            console.warn(
+              "[ghpsr] Unclassified reviewer-fetch failure; banner suppressed.",
+              error,
+            );
           },
         });
       }
@@ -92,12 +94,6 @@ function classifyRowFailure(
     (failure) => failure.status === 404 || failure.status === 403,
   );
   if (uncovered) {
-    return { rateLimited: false, uncovered: true };
-  }
-
-  // No signed-in account at all: the row failure is effectively an
-  // access-gate signal, not a server-side coverage problem.
-  if (account == null) {
     return { rateLimited: false, uncovered: true };
   }
 

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -191,12 +191,13 @@ describe("content entrypoint", () => {
       expect(aggregator.reportUncovered).not.toHaveBeenCalled();
     });
 
-    it("falls through to uncovered for non-GitHubApiError errors", async () => {
+    it("does not show any banner for unattributed errors (schema drift, network, etc.)", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
 
-      // e.g., a schema error or a generic network error: we can't classify
-      // but we still want the banner to give the user actionable guidance.
+      // A generic network error: we cannot attribute this to App coverage.
+      // The Configure access banner would be misleading guidance, so we stay
+      // silent and let the developer diagnose via console warnings.
       onRowFailure({
         owner: "cinev",
         repo: "shotloom",
@@ -204,7 +205,64 @@ describe("content entrypoint", () => {
         error: new Error("Network down"),
       });
 
-      expect(aggregator.reportUncovered).toHaveBeenCalledTimes(1);
+      expect(aggregator.reportUncovered).not.toHaveBeenCalled();
+      expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
+    });
+
+    it("does not show any banner for schema envelope failures", async () => {
+      const aggregator = makeAggregator();
+      const { onRowFailure } = await bootContent(aggregator);
+
+      onRowFailure({
+        owner: "cinev",
+        repo: "shotloom",
+        account: { id: "acc-1" },
+        error: {
+          kind: "schema",
+          status: null,
+          message: "Response shape changed",
+        },
+      });
+
+      expect(aggregator.reportUncovered).not.toHaveBeenCalled();
+      expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
+    });
+
+    it("does not show any banner for unknown envelope failures", async () => {
+      const aggregator = makeAggregator();
+      const { onRowFailure } = await bootContent(aggregator);
+
+      onRowFailure({
+        owner: "cinev",
+        repo: "shotloom",
+        account: { id: "acc-1" },
+        error: {
+          kind: "unknown",
+          status: null,
+          message: "Background fetch aborted",
+        },
+      });
+
+      expect(aggregator.reportUncovered).not.toHaveBeenCalled();
+      expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
+    });
+
+    it("does not show any banner for empty endpoint envelope failures", async () => {
+      const aggregator = makeAggregator();
+      const { onRowFailure } = await bootContent(aggregator);
+
+      onRowFailure({
+        owner: "cinev",
+        repo: "shotloom",
+        account: { id: "acc-1" },
+        error: {
+          kind: "github-endpoints",
+          status: null,
+          failures: [],
+        },
+      });
+
+      expect(aggregator.reportUncovered).not.toHaveBeenCalled();
       expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary

- Stop mapping unknown, schema, and empty reviewer-fetch failure envelopes to `reportUncovered()`.
- Keep 403/404 → Configure access and 429 / anonymous-403 → Sign in behavior intact.
- Log unattributed failures via `console.warn` so developers can still diagnose schema or network drift.

## Why

The Configure access banner is a strong instruction to change GitHub App installation access. Surfacing it for schema drift, network failures, or aborted fetches misled users and masked real runtime / DOM / API drift. This aligns row classification with what the banner actually tells the user to do.

## Changes

- `entrypoints/content.ts`: drop the "fall through to uncovered" fallback in `classifyRowFailure` / the `onRowFailure` handler, and warn on unclassified errors instead. Also remove the `account == null && no status` uncovered fallback, since a null-account failure without a diagnostic status is not evidence of missing App coverage.
- `tests/content.test.ts`: flip the existing non-GitHubApiError case to expect no banner, and add coverage for `schema`, `unknown`, and empty-`failures` envelopes.

## Impact

- User-facing impact: unattributed reviewer-fetch failures no longer trigger the Configure access or Sign in banner. The row simply has no reviewer summary, which matches the "least noisy" behavior called out in the issue. Covered (403/404 with an account) and unauthenticated-rate-limit (429, or 403 without an account) cases still surface their existing banner.
- API/schema impact: none.
- Performance impact: none.
- Operational or rollout impact: none; behavior change ships with the next build.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (233 passed, including 4 new / updated cases in `tests/content.test.ts`)

## Breaking Changes

- None

## Related Issues

Resolves #29