### PR TITLE
fix(reviewers): paginate pull request reviews before state mapping

### DIFF
--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -248,17 +248,17 @@ export async function fetchPullReviewerSummary(input: {
     input.pullNumber,
   );
   const pullUrl = `https://api.github.com${pullEndpoint.path}`;
-  const reviewUrl = `https://api.github.com${reviewsEndpoint.path}`;
+  const reviewsFirstPageUrl = `https://api.github.com${reviewsEndpoint.path}?per_page=100`;
 
-  const [pullResponse, reviewsResponse] = await Promise.all([
+  const [pullResponse, reviewsFirstResponse] = await Promise.all([
     fetch(pullUrl, { headers, signal: input.signal }),
-    fetch(reviewUrl, { headers, signal: input.signal }),
+    fetch(reviewsFirstPageUrl, { headers, signal: input.signal }),
   ]);
 
   const failures = (
     await Promise.all([
       createGitHubApiErrorFromResponse(pullResponse, pullEndpoint),
-      createGitHubApiErrorFromResponse(reviewsResponse, reviewsEndpoint),
+      createGitHubApiErrorFromResponse(reviewsFirstResponse, reviewsEndpoint),
     ])
   ).filter((failure): failure is GitHubApiError => failure != null);
 
@@ -270,12 +270,14 @@ export async function fetchPullReviewerSummary(input: {
   if (!pullParsed.success) {
     throw new GitHubApiSchemaError(pullEndpoint, pullParsed.error.issues);
   }
-  const reviewsParsed = reviewsSchema.safeParse(await reviewsResponse.json());
-  if (!reviewsParsed.success) {
-    throw new GitHubApiSchemaError(reviewsEndpoint, reviewsParsed.error.issues);
-  }
+
+  const reviews = await collectReviewsAcrossPages({
+    firstResponse: reviewsFirstResponse,
+    endpoint: reviewsEndpoint,
+    headers,
+    signal: input.signal,
+  });
   const pull = pullParsed.data;
-  const reviews = reviewsParsed.data;
   const latestNonCommentByUser = new Map<
     string,
     {
@@ -546,6 +548,61 @@ async function createGitHubApiError(
     endpoint,
     readRateLimitSnapshot(response),
   );
+}
+
+async function collectReviewsAcrossPages(params: {
+  firstResponse: Response;
+  endpoint: GitHubEndpointDescriptor;
+  headers: Headers;
+  signal?: AbortSignal;
+}): Promise<z.infer<typeof reviewsSchema>> {
+  const collected: z.infer<typeof reviewsSchema> = [];
+
+  let response = params.firstResponse;
+  while (true) {
+    const parsed = reviewsSchema.safeParse(await response.json());
+    if (!parsed.success) {
+      throw new GitHubApiSchemaError(params.endpoint, parsed.error.issues);
+    }
+    collected.push(...parsed.data);
+
+    const nextUrl = parseNextPageUrl(response.headers.get("Link"));
+    if (nextUrl == null) {
+      return collected;
+    }
+
+    response = await fetch(nextUrl, {
+      headers: params.headers,
+      signal: params.signal,
+    });
+
+    const error = await createGitHubApiErrorFromResponse(
+      response,
+      params.endpoint,
+    );
+    if (error != null) {
+      throw new GitHubPullRequestEndpointsError([error]);
+    }
+  }
+}
+
+function parseNextPageUrl(linkHeader: string | null): string | null {
+  if (linkHeader == null) {
+    return null;
+  }
+
+  for (const segment of linkHeader.split(",")) {
+    const match = /<([^>]+)>\s*;\s*rel="([^"]+)"/.exec(segment.trim());
+    if (match == null) {
+      continue;
+    }
+    const rels = match[2].split(/\s+/);
+    if (rels.includes("next")) {
+      return match[1];
+    }
+  }
+
+  return null;
 }
 
 function normalizeReviewState(state: string): ReviewState | null {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -594,6 +594,163 @@ describe("fetchPullReviewerSummary", () => {
     }
   });
 
+  it("follows Link: rel=\"next\" so a later-page review wins over first-page data", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            user: { login: "hon454" },
+            requested_reviewers: [],
+            requested_teams: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "CHANGES_REQUESTED",
+              submitted_at: "2026-04-20T12:00:00Z",
+              user: { login: "frank", avatar_url: null },
+            },
+          ]),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              Link: '<https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/42/reviews?per_page=100&page=2>; rel="next", <https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/42/reviews?per_page=100&page=2>; rel="last"',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "APPROVED",
+              submitted_at: "2026-04-24T12:00:00Z",
+              user: { login: "frank", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+    });
+
+    expect(summary.completedReviews).toEqual([
+      { login: "frank", avatarUrl: null, state: "APPROVED" },
+    ]);
+
+    expect(fetchMock.mock.calls).toHaveLength(3);
+    const firstReviewsUrl = fetchMock.mock.calls[1]?.[0];
+    expect(String(firstReviewsUrl)).toContain("per_page=100");
+    const nextPageUrl = fetchMock.mock.calls[2]?.[0];
+    expect(String(nextPageUrl)).toContain("page=2");
+  });
+
+  it("forwards AbortSignal to every paginated reviews request", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            user: { login: "hon454" },
+            requested_reviewers: [],
+            requested_teams: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            Link: '<https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/42/reviews?per_page=100&page=2>; rel="next"',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+      signal: controller.signal,
+    });
+
+    for (const call of fetchMock.mock.calls) {
+      expect(call[1]?.signal).toBe(controller.signal);
+    }
+  });
+
+  it("reports the reviews endpoint when a later page fails", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            user: { login: "hon454" },
+            requested_reviewers: [],
+            requested_teams: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            Link: '<https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/42/reviews?per_page=100&page=2>; rel="next"',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ message: "API rate limit exceeded" }),
+          {
+            status: 403,
+            headers: {
+              "Content-Type": "application/json",
+              "x-ratelimit-remaining": "0",
+              "x-ratelimit-limit": "60",
+            },
+          },
+        ),
+      );
+
+    try {
+      await fetchPullReviewerSummary({
+        owner: "hon454",
+        repo: "github-pulls-show-reviewers",
+        pullNumber: "42",
+        githubToken: null,
+      });
+      throw new Error("Expected fetchPullReviewerSummary to reject.");
+    } catch (error) {
+      const message = describeGitHubApiError(error, { githubToken: null });
+      expect(message).toContain(
+        "/repos/hon454/github-pulls-show-reviewers/pulls/42/reviews",
+      );
+      expect(message).toContain("unauthenticated rate limit");
+    }
+  });
+
   it("picks the latest non-COMMENTED review when multiple non-comment reviews exist", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(


### PR DESCRIPTION
## Summary

- Follow `Link: rel="next"` on `/repos/.../pulls/{n}/reviews` so reviewer state is derived from the full review history, not only the first page.
- Request `per_page=100` on the first page to reduce paginated round trips.
- Keep the no-token public-repository path and the shared `AbortSignal` semantics across every page.

## Why

The reviewer summary previously read only one reviews page. Pull requests with enough review history could therefore show stale or incomplete reviewer state — a newer APPROVED or DISMISSED on page 2 could be hidden by an older CHANGES_REQUESTED that happened to land on page 1. Reviewer-state correctness is the core product guarantee, so this is a P1 audit fix.

## Changes

- `src/github/api.ts`: extract `collectReviewsAcrossPages` + `parseNextPageUrl`, request the first page with `per_page=100`, and continue through every `Link: rel="next"` response before running the existing review-state mapping. Later-page failures surface through the existing `GitHubPullRequestEndpointsError` path so the `/reviews` endpoint is still named in rate-limit and 4xx diagnostics.
- `tests/api.test.ts`: add three fetch-mocked cases — a later-page APPROVED wins over a first-page CHANGES_REQUESTED; every paginated request forwards the caller's `AbortSignal`; and a 403 on page 2 still reports the reviews endpoint with the unauthenticated rate-limit message.

## Impact

- User-facing impact: Reviewer state on the PR list now reflects the full review history for pull requests with >30 reviews (GitHub's default page size) or >100 reviews when `per_page=100` is honoured.
- API/schema impact: None. Response schema and public exports are unchanged. Paginated requests reuse the same headers, so the GitHub App installation requirements are identical.
- Performance impact: One extra network request per additional reviews page. Most PRs fit on one page at `per_page=100`, so typical cost is unchanged; large-history PRs pay O(pages) sequential round trips. First page still runs in parallel with the pull endpoint.
- Operational or rollout impact: None.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm test` — 233 tests across 23 files pass, including the three new pagination cases in `tests/api.test.ts`.
- `pnpm lint` — clean.
- `pnpm typecheck` — clean.

## Breaking Changes

- None

## Related Issues

Resolves #27