### PR TITLE
feat(access-banner): redesign reviewer-fetch failure classification with priority-ranked kinds

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -63,8 +63,8 @@
 | Signed in     | 401 on any reviewer endpoint                              | `auth-expired`       | Sign in          |
 | Signed in     | 404 / 403 with no rate-limit signal                       | `app-uncovered`      | Configure access |
 | Signed in     | 429, or 403 with `x-ratelimit-remaining: 0`               | `auth-rate-limit`    | (passive wait)   |
-| No account    | 403, 429, or any rate-limit signal                        | `unauth-rate-limit`  | Sign in          |
-| No account    | 404                                                       | `signin-required`    | Sign in          |
+| No account    | 429, or 403 with rate-limit signal                        | `unauth-rate-limit`  | Sign in          |
+| No account    | 401, 403, or 404 without rate-limit signal                | `signin-required`    | Sign in          |
 | Either        | Network / schema / unknown / empty endpoint envelope      | (silent, console.warn) | —             |
 
 Severity priority for cross-row resolution: `auth-expired` > `app-uncovered` >

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -13,7 +13,9 @@
   GitHub REST calls, so access tokens never enter the content-script
   execution context. No user-typed scope patterns.
 - Row-level failures render an empty reviewer slot. A page-level banner surfaces
-  uncovered-org guidance and unauthenticated rate-limit hints.
+  one of five guidance states — token expired, App not installed, auth rate
+  limit, unauthenticated rate limit, or sign-in required — chosen by severity
+  priority across all row failures on the page.
 
 ## Runtime flow
 
@@ -54,18 +56,23 @@
 - A GraphQL-first rewrite is not the next step because it would push the product away from the current no-token public-repository path and add a second transport model to maintain.
 - If request volume becomes the next real bottleneck after launch, the preferred follow-up is a page-level batch strategy on the existing REST path before considering a broader API migration.
 
-## Repository diagnostics matrix
+## Access banner classification
 
-| Mode               | Response pattern                              | Reported UX                                                                 |
-| ------------------ | --------------------------------------------- | --------------------------------------------------------------------------- |
-| No signed-in account | 200 for pulls list, pull detail, and reviews | Repository works on the public no-token path                                |
-| No signed-in account | 403 with rate-limit signal                   | Unauthenticated rate limit exhausted                                        |
-| No signed-in account | 404 / 401 / private-like 403                 | Repository behaves like a private or permission-gated resource              |
-| Matched account    | 401 on a repository endpoint, refresh succeeds | Access token was expired — refreshed transparently via the background script |
-| Matched account    | 401 with no stored refresh token              | Pre-v4 account or refresh token never issued — marked `revoked`, sign in again |
-| Matched account    | 401 then refresh returns `bad_refresh_token`  | Refresh token rejected — marked `refresh_failed`, sign in again from the options page |
-| Matched account    | 401 then refresh succeeds then 401 again      | New access token rejected (app revoked or scope changed) — marked `revoked`, sign in again |
-| Matched account    | 403 / 404 without rate-limit signal           | Installation does not cover this repository — install the GitHub App on the owner |
+| Account state | Failure pattern                                           | Banner kind          | CTA              |
+| ------------- | --------------------------------------------------------- | -------------------- | ---------------- |
+| Signed in     | 401 on any reviewer endpoint                              | `auth-expired`       | Sign in          |
+| Signed in     | 404 / 403 with no rate-limit signal                       | `app-uncovered`      | Configure access |
+| Signed in     | 429, or 403 with `x-ratelimit-remaining: 0`               | `auth-rate-limit`    | (passive wait)   |
+| No account    | 403, 429, or any rate-limit signal                        | `unauth-rate-limit`  | Sign in          |
+| No account    | 404                                                       | `signin-required`    | Sign in          |
+| Either        | Network / schema / unknown / empty endpoint envelope      | (silent, console.warn) | —             |
+
+Severity priority for cross-row resolution: `auth-expired` > `app-uncovered` >
+`auth-rate-limit` > `unauth-rate-limit` > `signin-required`. The highest-priority
+kind seen on a page wins.
+
+Banner dismissal is keyed by `pathname + kind`, so dismissing one kind on a page
+does not suppress a later, higher-priority kind on the same page.
 
 ## Proactive token refresh
 

--- a/docs/manual-chrome-testing.md
+++ b/docs/manual-chrome-testing.md
@@ -91,7 +91,7 @@ This extension is intentionally narrow. Manual verification should stay focused 
    with an account where the GitHub App is installed on
    **All repositories**.
 5. Visit a private PR list in that account's namespace.
-6. Confirm reviewer chips render for every row without an uncovered-org banner.
+6. Confirm reviewer chips render for every row without an `app-uncovered` banner.
 
 ### Signed-in, selected-repos installation
 
@@ -103,7 +103,7 @@ This extension is intentionally narrow. Manual verification should stay focused 
 4. Visit a third repository in that org; confirm an empty reviewer slot per row
    and a banner prompting to add access.
 
-### Uncovered org banner
+### App-uncovered banner
 
 1. Sign in but do not install the App on `work-org`.
 2. Visit a `work-org` PR list.

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -99,10 +99,14 @@ function classifyFailure(
     return null;
   }
 
-  if (isRateLimited || failure.status === 403) {
+  if (isRateLimited) {
     return "unauth-rate-limit";
   }
-  if (failure.status === 404) {
+  if (
+    failure.status === 401 ||
+    failure.status === 403 ||
+    failure.status === 404
+  ) {
     return "signin-required";
   }
   return null;

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -2,6 +2,8 @@ import {
   bootAccessBanner,
   type AccessBannerHandle,
 } from "../src/features/access-banner";
+import type { BannerKind } from "../src/features/access-banner/aggregator";
+import { isHigherPriority } from "../src/features/access-banner/aggregator";
 import { bootReviewerListPage } from "../src/features/reviewers";
 import { parsePullListRoute } from "../src/github/routes";
 import {
@@ -36,23 +38,15 @@ export default defineContentScript({
               return;
             }
 
-            const signals = classifyRowFailure(error, account);
-            if (signals.rateLimited) {
-              aggregator.reportUnauthRateLimit();
+            const kind = classifyRowFailure(error, account);
+            if (kind == null) {
+              console.warn(
+                "[ghpsr] Unclassified reviewer-fetch failure; banner suppressed.",
+                error,
+              );
               return;
             }
-            if (signals.uncovered) {
-              aggregator.reportUncovered();
-              return;
-            }
-            // Unattributed failures (schema drift, network error, empty
-            // envelope, etc.) are not App-coverage problems. Showing the
-            // Configure access banner would be misleading guidance, so we
-            // log for diagnosis and leave the banner untouched.
-            console.warn(
-              "[ghpsr] Unclassified reviewer-fetch failure; banner suppressed.",
-              error,
-            );
+            aggregator.reportFailure(kind);
           },
         });
       }
@@ -67,39 +61,49 @@ export default defineContentScript({
   },
 });
 
-type RowFailureClassification = {
-  rateLimited: boolean;
-  uncovered: boolean;
-};
-
 function classifyRowFailure(
   error: unknown,
   account: { id?: string } | null,
-): RowFailureClassification {
-  const failures = collectApiFailures(error);
-
-  // With no authenticated account, any 403 indicates the unauthenticated
-  // tier was rejected — treat as the unauth rate-limit case so the banner
-  // invites the user to sign in. Any explicit 429 is always rate-limited.
-  const rateLimited = failures.some(
-    (failure) =>
-      failure.status === 429 ||
-      (account == null && failure.status === 403),
-  );
-  if (rateLimited) {
-    return { rateLimited: true, uncovered: false };
+): BannerKind | null {
+  const failures = extractReviewerFetchFailures(error);
+  if (failures.length === 0) {
+    return null;
   }
 
-  const uncovered = failures.some(
-    (failure) => failure.status === 404 || failure.status === 403,
-  );
-  if (uncovered) {
-    return { rateLimited: false, uncovered: true };
+  let best: BannerKind | null = null;
+  for (const failure of failures) {
+    const kind = classifyFailure(failure, account);
+    if (kind != null && isHigherPriority(kind, best)) {
+      best = kind;
+    }
   }
-
-  return { rateLimited: false, uncovered: false };
+  return best;
 }
 
-function collectApiFailures(error: unknown): ReviewerFetchFailure[] {
-  return extractReviewerFetchFailures(error);
+function classifyFailure(
+  failure: ReviewerFetchFailure,
+  account: { id?: string } | null,
+): BannerKind | null {
+  const isRateLimited = failure.rateLimited || failure.status === 429;
+
+  if (account != null) {
+    if (failure.status === 401) {
+      return "auth-expired";
+    }
+    if (isRateLimited) {
+      return "auth-rate-limit";
+    }
+    if (failure.status === 404 || failure.status === 403) {
+      return "app-uncovered";
+    }
+    return null;
+  }
+
+  if (isRateLimited || failure.status === 403) {
+    return "unauth-rate-limit";
+  }
+  if (failure.status === 404) {
+    return "signin-required";
+  }
+  return null;
 }

--- a/src/features/access-banner/aggregator.ts
+++ b/src/features/access-banner/aggregator.ts
@@ -1,8 +1,14 @@
 export type BannerRepo = { readonly owner: string; readonly name: string };
 
+export type BannerKind =
+  | "auth-expired"
+  | "app-uncovered"
+  | "auth-rate-limit"
+  | "unauth-rate-limit"
+  | "signin-required";
+
 export type BannerState = {
-  uncovered: boolean;
-  unauthRateLimited: boolean;
+  current: BannerKind | null;
   dismissed: boolean;
   repo: BannerRepo;
 };
@@ -10,32 +16,42 @@ export type BannerState = {
 export type BannerAggregator = {
   getState(): BannerState;
   subscribe(listener: (state: BannerState) => void): () => void;
-  reportUncovered(): void;
-  reportUnauthRateLimit(): void;
+  reportFailure(kind: BannerKind): void;
   dismiss(): void;
 };
+
+const PRIORITY: Record<BannerKind, number> = {
+  "auth-expired": 1,
+  "app-uncovered": 2,
+  "auth-rate-limit": 3,
+  "unauth-rate-limit": 4,
+  "signin-required": 5,
+};
+
+export function isHigherPriority(
+  candidate: BannerKind,
+  incumbent: BannerKind | null,
+): boolean {
+  if (incumbent == null) {
+    return true;
+  }
+  return PRIORITY[candidate] < PRIORITY[incumbent];
+}
 
 export function createBannerAggregator(options: {
   pathname: string;
   repo: BannerRepo;
 }): BannerAggregator {
-  const dismissKey = `ghpsr:banner-dismissed:${options.pathname}`;
   const repo: BannerRepo = {
     owner: options.repo.owner,
     name: options.repo.name,
   };
-  let uncovered = false;
-  let unauthRateLimited = false;
-  let dismissed = readDismissed(dismissKey);
+  let current: BannerKind | null = null;
+  let dismissed = readDismissed(options.pathname, current);
   const listeners = new Set<(state: BannerState) => void>();
 
   function snapshot(): BannerState {
-    return {
-      uncovered,
-      unauthRateLimited,
-      dismissed,
-      repo,
-    };
+    return { current, dismissed, repo };
   }
 
   function emit(): void {
@@ -52,27 +68,21 @@ export function createBannerAggregator(options: {
         listeners.delete(listener);
       };
     },
-    reportUncovered() {
-      if (uncovered) {
+    reportFailure(kind) {
+      if (!isHigherPriority(kind, current)) {
         return;
       }
-      uncovered = true;
-      emit();
-    },
-    reportUnauthRateLimit() {
-      if (unauthRateLimited) {
-        return;
-      }
-      unauthRateLimited = true;
+      current = kind;
+      dismissed = readDismissed(options.pathname, current);
       emit();
     },
     dismiss() {
-      if (dismissed) {
+      if (current == null || dismissed) {
         return;
       }
       dismissed = true;
       try {
-        window.sessionStorage.setItem(dismissKey, "1");
+        window.sessionStorage.setItem(dismissKey(options.pathname, current), "1");
       } catch {
         // sessionStorage access denied — ignore
       }
@@ -81,22 +91,36 @@ export function createBannerAggregator(options: {
   };
 }
 
-function readDismissed(key: string): boolean {
+function dismissKey(pathname: string, kind: BannerKind | null): string {
+  return `ghpsr:banner-dismissed:${pathname}:${kind ?? "none"}`;
+}
+
+function readDismissed(pathname: string, kind: BannerKind | null): boolean {
+  if (kind == null) {
+    return false;
+  }
   try {
-    return window.sessionStorage.getItem(key) === "1";
+    return window.sessionStorage.getItem(dismissKey(pathname, kind)) === "1";
   } catch {
     return false;
   }
 }
 
 export function formatBannerMessage(
-  state: Pick<BannerState, "uncovered" | "unauthRateLimited" | "repo">,
+  state: Pick<BannerState, "current" | "repo">,
 ): string {
-  if (state.uncovered) {
-    return `Add ${state.repo.owner}/${state.repo.name} to @${state.repo.owner}'s GitHub App installation to see reviewers on this page.`;
+  switch (state.current) {
+    case "auth-expired":
+      return "Your GitHub session expired. Sign in again to keep loading reviewers.";
+    case "app-uncovered":
+      return `Add ${state.repo.owner}/${state.repo.name} to @${state.repo.owner}'s GitHub App installation to see reviewers on this page.`;
+    case "auth-rate-limit":
+      return "GitHub's hourly request limit was reached. Reviewers will resume automatically when the limit resets.";
+    case "unauth-rate-limit":
+      return "GitHub's unauthenticated request limit (60/hr) was reached. Sign in to raise it to 5,000/hr.";
+    case "signin-required":
+      return "Sign in with GitHub to see reviewers on private repositories.";
+    case null:
+      return "";
   }
-  if (state.unauthRateLimited) {
-    return "You hit GitHub's unauthenticated rate limit.";
-  }
-  return "";
 }

--- a/src/features/access-banner/dom.ts
+++ b/src/features/access-banner/dom.ts
@@ -38,9 +38,8 @@ export function mountBanner(input: {
   let element: HTMLElement | null = null;
 
   function render(state: BannerState): void {
-    const visible = !state.dismissed && state.current != null;
-
-    if (!visible) {
+    const current = state.current;
+    if (state.dismissed || current == null) {
       element?.remove();
       element = null;
       return;
@@ -69,7 +68,7 @@ export function mountBanner(input: {
     message.textContent = formatBannerMessage(state);
     element.append(message);
 
-    const cta = ctaFor(state.current!, input.installUrl, input.optionsPageUrl);
+    const cta = ctaFor(current, input.installUrl, input.optionsPageUrl);
     if (cta.kind === "link") {
       const link = document.createElement("a");
       link.href = cta.href;

--- a/src/features/access-banner/dom.ts
+++ b/src/features/access-banner/dom.ts
@@ -1,4 +1,4 @@
-import type { BannerState } from "./aggregator";
+import type { BannerKind, BannerState } from "./aggregator";
 import { formatBannerMessage } from "./aggregator";
 
 const BANNER_ATTRIBUTE = "data-ghpsr-banner";
@@ -7,6 +7,27 @@ export type BannerMount = {
   update(state: BannerState): void;
   teardown(): void;
 };
+
+type CtaSpec =
+  | { kind: "link"; label: string; href: string }
+  | { kind: "none" };
+
+function ctaFor(
+  current: BannerKind,
+  installUrl: string,
+  optionsPageUrl: string,
+): CtaSpec {
+  switch (current) {
+    case "app-uncovered":
+      return { kind: "link", label: "Configure access", href: installUrl };
+    case "auth-expired":
+    case "unauth-rate-limit":
+    case "signin-required":
+      return { kind: "link", label: "Sign in", href: optionsPageUrl };
+    case "auth-rate-limit":
+      return { kind: "none" };
+  }
+}
 
 export function mountBanner(input: {
   insertAfter: HTMLElement;
@@ -17,8 +38,7 @@ export function mountBanner(input: {
   let element: HTMLElement | null = null;
 
   function render(state: BannerState): void {
-    const visible =
-      !state.dismissed && (state.uncovered || state.unauthRateLimited);
+    const visible = !state.dismissed && state.current != null;
 
     if (!visible) {
       element?.remove();
@@ -49,20 +69,14 @@ export function mountBanner(input: {
     message.textContent = formatBannerMessage(state);
     element.append(message);
 
-    if (state.uncovered) {
-      const configureLink = document.createElement("a");
-      configureLink.href = input.installUrl;
-      configureLink.target = "_blank";
-      configureLink.rel = "noreferrer";
-      configureLink.textContent = "Configure access";
-      element.append(configureLink);
-    } else if (state.unauthRateLimited) {
-      const signInLink = document.createElement("a");
-      signInLink.href = input.optionsPageUrl;
-      signInLink.target = "_blank";
-      signInLink.rel = "noreferrer";
-      signInLink.textContent = "Sign in";
-      element.append(signInLink);
+    const cta = ctaFor(state.current!, input.installUrl, input.optionsPageUrl);
+    if (cta.kind === "link") {
+      const link = document.createElement("a");
+      link.href = cta.href;
+      link.target = "_blank";
+      link.rel = "noreferrer";
+      link.textContent = cta.label;
+      element.append(link);
     }
 
     const dismissBtn = document.createElement("button");

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -778,7 +778,7 @@ function readHeaderNumber(headers: Headers, name: string): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
-function isRateLimitError(error: GitHubApiError): boolean {
+export function isRateLimitError(error: GitHubApiError): boolean {
   return (
     error.status === 429 ||
     error.rateLimit?.remaining === 0 ||

--- a/src/runtime/reviewer-fetch.ts
+++ b/src/runtime/reviewer-fetch.ts
@@ -3,6 +3,7 @@ import {
   GitHubApiSchemaError,
   GitHubPullRequestEndpointsError,
   extractGitHubApiStatus,
+  isRateLimitError,
   type PullReviewerSummary,
 } from "../github/api";
 
@@ -23,6 +24,7 @@ export type CancelPullReviewerSummaryMessage = {
 export type ReviewerFetchFailure = {
   status: number;
   endpoint: string | null;
+  rateLimited: boolean;
 };
 
 export type ReviewerFetchErrorEnvelope = {
@@ -86,6 +88,7 @@ export function serializeReviewerFetchError(
       failures: error.failures.map((failure) => ({
         status: failure.status,
         endpoint: failure.endpoint?.path ?? null,
+        rateLimited: isRateLimitError(failure),
       })),
       message: error.message,
     };
@@ -99,6 +102,7 @@ export function serializeReviewerFetchError(
         {
           status: error.status,
           endpoint: error.endpoint?.path ?? null,
+          rateLimited: isRateLimitError(error),
         },
       ],
       message: error.message,
@@ -138,6 +142,7 @@ export function extractReviewerFetchFailures(
     return error.failures.map((failure) => ({
       status: failure.status,
       endpoint: failure.endpoint?.path ?? null,
+      rateLimited: isRateLimitError(failure),
     }));
   }
 
@@ -146,6 +151,7 @@ export function extractReviewerFetchFailures(
       {
         status: error.status,
         endpoint: error.endpoint?.path ?? null,
+        rateLimited: isRateLimitError(error),
       },
     ];
   }
@@ -156,15 +162,21 @@ export function extractReviewerFetchFailures(
     "failures" in error &&
     Array.isArray((error as { failures: unknown }).failures)
   ) {
-    return (error as { failures: Array<{ status?: unknown; endpoint?: unknown }> }).failures
+    return (
+      error as { failures: Array<{ status?: unknown; endpoint?: unknown; rateLimited?: unknown }> }
+    ).failures
       .filter(
-        (failure): failure is { status: number; endpoint?: string | null } =>
-          typeof failure?.status === "number",
+        (failure): failure is {
+          status: number;
+          endpoint?: string | null;
+          rateLimited?: boolean;
+        } => typeof failure?.status === "number",
       )
       .map((failure) => ({
         status: failure.status,
         endpoint:
           typeof failure.endpoint === "string" ? failure.endpoint : null,
+        rateLimited: failure.rateLimited === true,
       }));
   }
 
@@ -178,6 +190,7 @@ export function extractReviewerFetchFailures(
       {
         status: (error as { status: number }).status,
         endpoint: null,
+        rateLimited: false,
       },
     ];
   }

--- a/tests/access-banner.test.ts
+++ b/tests/access-banner.test.ts
@@ -19,20 +19,19 @@ afterEach(() => {
 });
 
 describe("bannerAggregator", () => {
-  it("starts with uncovered=false and carries the repo", () => {
+  it("starts with current=null and carries the repo", () => {
     const aggregator = createBannerAggregator({
       pathname: "/cinev/shotloom/pulls",
       repo: TEST_REPO,
     });
     expect(aggregator.getState()).toEqual({
-      uncovered: false,
-      unauthRateLimited: false,
+      current: null,
       dismissed: false,
       repo: TEST_REPO,
     });
   });
 
-  it("flips uncovered to true once reported and is idempotent", () => {
+  it("flips current to the reported kind and is idempotent for the same kind", () => {
     const aggregator = createBannerAggregator({
       pathname: "/cinev/shotloom/pulls",
       repo: TEST_REPO,
@@ -41,160 +40,203 @@ describe("bannerAggregator", () => {
     aggregator.subscribe(listener);
     listener.mockClear();
 
-    aggregator.reportUncovered();
-    aggregator.reportUncovered();
-    aggregator.reportUncovered();
+    aggregator.reportFailure("signin-required");
+    aggregator.reportFailure("signin-required");
+    aggregator.reportFailure("signin-required");
 
-    expect(aggregator.getState().uncovered).toBe(true);
+    expect(aggregator.getState().current).toBe("signin-required");
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
-  it("flags an unauth rate limit", () => {
+  it("upgrades current when a higher-priority kind is reported", () => {
     const aggregator = createBannerAggregator({
       pathname: "/cinev/shotloom/pulls",
       repo: TEST_REPO,
     });
-    aggregator.reportUnauthRateLimit();
-    expect(aggregator.getState().unauthRateLimited).toBe(true);
+    aggregator.reportFailure("signin-required");
+    aggregator.reportFailure("auth-expired");
+    expect(aggregator.getState().current).toBe("auth-expired");
   });
 
-  it("persists dismissal by pathname via sessionStorage", () => {
+  it("ignores a lower-priority kind once a higher-priority kind is set", () => {
+    const aggregator = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
+    aggregator.reportFailure("auth-expired");
+    aggregator.reportFailure("signin-required");
+    expect(aggregator.getState().current).toBe("auth-expired");
+  });
+
+  it("orders priority: auth-expired > app-uncovered > auth-rate-limit > unauth-rate-limit > signin-required", () => {
+    const order = [
+      "signin-required",
+      "unauth-rate-limit",
+      "auth-rate-limit",
+      "app-uncovered",
+      "auth-expired",
+    ] as const;
+    for (let i = 0; i < order.length - 1; i++) {
+      const aggregator = createBannerAggregator({
+        pathname: `/cinev/shotloom/pulls?case=${i}`,
+        repo: TEST_REPO,
+      });
+      aggregator.reportFailure(order[i]);
+      aggregator.reportFailure(order[i + 1]);
+      expect(aggregator.getState().current).toBe(order[i + 1]);
+    }
+  });
+
+  it("ignores dismiss when current is null", () => {
+    const aggregator = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
+    aggregator.dismiss();
+    expect(aggregator.getState().dismissed).toBe(false);
+  });
+
+  it("persists dismissal scoped to pathname + kind", () => {
     const first = createBannerAggregator({
       pathname: "/cinev/shotloom/pulls",
       repo: TEST_REPO,
     });
+    first.reportFailure("signin-required");
     first.dismiss();
+    expect(first.getState().dismissed).toBe(true);
+
     const second = createBannerAggregator({
       pathname: "/cinev/shotloom/pulls",
       repo: TEST_REPO,
     });
+    second.reportFailure("signin-required");
     expect(second.getState().dismissed).toBe(true);
-    const other = createBannerAggregator({
-      pathname: "/other/repo/pulls",
-      repo: { owner: "other", name: "repo" },
-    });
-    expect(other.getState().dismissed).toBe(false);
   });
 
-  it("resets dismissal when the pathname changes", () => {
-    const first = createBannerAggregator({
+  it("does not carry a kind A dismissal over to kind B on the same pathname", () => {
+    const a = createBannerAggregator({
       pathname: "/cinev/shotloom/pulls",
       repo: TEST_REPO,
     });
-    first.dismiss();
-    const second = createBannerAggregator({
-      pathname: "/cinev/landing/pulls",
-      repo: { owner: "cinev", name: "landing" },
+    a.reportFailure("signin-required");
+    a.dismiss();
+
+    const b = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
     });
-    expect(second.getState().dismissed).toBe(false);
+    b.reportFailure("auth-expired");
+    expect(b.getState().dismissed).toBe(false);
+  });
+
+  it("re-reads dismissed from storage when current is upgraded to a kind dismissed earlier", () => {
+    const seed = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
+    seed.reportFailure("auth-expired");
+    seed.dismiss();
+
+    const fresh = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
+    fresh.reportFailure("signin-required");
+    expect(fresh.getState().dismissed).toBe(false);
+    fresh.reportFailure("auth-expired");
+    expect(fresh.getState().current).toBe("auth-expired");
+    expect(fresh.getState().dismissed).toBe(true);
   });
 });
 
 describe("formatBannerMessage", () => {
-  it("names the repo and org when uncovered", () => {
-    const text = formatBannerMessage({
-      uncovered: true,
-      unauthRateLimited: false,
-      repo: TEST_REPO,
-    });
-    expect(text).toBe(
+  it("returns auth-expired copy", () => {
+    expect(
+      formatBannerMessage({ current: "auth-expired", repo: TEST_REPO }),
+    ).toBe(
+      "Your GitHub session expired. Sign in again to keep loading reviewers.",
+    );
+  });
+
+  it("names the repo and org for app-uncovered", () => {
+    expect(
+      formatBannerMessage({ current: "app-uncovered", repo: TEST_REPO }),
+    ).toBe(
       "Add cinev/shotloom to @cinev's GitHub App installation to see reviewers on this page.",
     );
   });
 
-  it("uses the uncovered message when both flags are set", () => {
-    const text = formatBannerMessage({
-      uncovered: true,
-      unauthRateLimited: true,
-      repo: TEST_REPO,
-    });
-    expect(text).toBe(
-      "Add cinev/shotloom to @cinev's GitHub App installation to see reviewers on this page.",
+  it("returns auth-rate-limit copy", () => {
+    expect(
+      formatBannerMessage({ current: "auth-rate-limit", repo: TEST_REPO }),
+    ).toBe(
+      "GitHub's hourly request limit was reached. Reviewers will resume automatically when the limit resets.",
     );
   });
 
-  it("formats an unauth rate limit message when nothing else is reported", () => {
-    const text = formatBannerMessage({
-      uncovered: false,
-      unauthRateLimited: true,
-      repo: TEST_REPO,
-    });
-    expect(text).toBe("You hit GitHub's unauthenticated rate limit.");
+  it("returns unauth-rate-limit copy that mentions the higher signed-in limit", () => {
+    expect(
+      formatBannerMessage({ current: "unauth-rate-limit", repo: TEST_REPO }),
+    ).toBe(
+      "GitHub's unauthenticated request limit (60/hr) was reached. Sign in to raise it to 5,000/hr.",
+    );
   });
 
-  it("returns an empty string when there is nothing to surface", () => {
-    const text = formatBannerMessage({
-      uncovered: false,
-      unauthRateLimited: false,
-      repo: TEST_REPO,
-    });
-    expect(text).toBe("");
+  it("returns signin-required copy that mentions private repos", () => {
+    expect(
+      formatBannerMessage({ current: "signin-required", repo: TEST_REPO }),
+    ).toBe(
+      "Sign in with GitHub to see reviewers on private repositories.",
+    );
+  });
+
+  it("returns an empty string when current is null", () => {
+    expect(
+      formatBannerMessage({ current: null, repo: TEST_REPO }),
+    ).toBe("");
   });
 });
 
 import { mountBanner } from "../src/features/access-banner/dom";
 
 describe("banner DOM", () => {
-  it("does not insert a banner when state is empty", () => {
+  function setup() {
     document.body.innerHTML = `<main><div class="gh-header"></div></main>`;
     const target = document.querySelector<HTMLElement>(".gh-header")!;
-    const banner = mountBanner({
+    return mountBanner({
       insertAfter: target,
       installUrl: "https://github.com/apps/test-app/installations/new",
       optionsPageUrl: "chrome-extension://ext-id/options.html",
       onDismiss: () => {},
     });
-    banner.update({
-      uncovered: false,
-      unauthRateLimited: false,
-      dismissed: false,
-      repo: TEST_REPO,
-    });
+  }
+
+  it("does not insert a banner when current is null", () => {
+    const banner = setup();
+    banner.update({ current: null, dismissed: false, repo: TEST_REPO });
     expect(document.querySelector("[data-ghpsr-banner]")).toBeNull();
   });
 
-  it("inserts a repo-aware banner with a Configure access link when uncovered", () => {
-    document.body.innerHTML = `<main><div class="gh-header"></div></main>`;
-    const target = document.querySelector<HTMLElement>(".gh-header")!;
-    const banner = mountBanner({
-      insertAfter: target,
-      installUrl: "https://github.com/apps/test-app/installations/new",
-      optionsPageUrl: "chrome-extension://ext-id/options.html",
-      onDismiss: () => {},
-    });
-    banner.update({
-      uncovered: true,
-      unauthRateLimited: false,
-      dismissed: false,
-      repo: TEST_REPO,
-    });
-
-    const el = document.querySelector("[data-ghpsr-banner]");
-    expect(el?.textContent).toContain("cinev/shotloom");
-    expect(el?.textContent).toContain("@cinev's GitHub App installation");
-    const link = el?.querySelector("a");
+  it("renders Configure access link for app-uncovered", () => {
+    const banner = setup();
+    banner.update({ current: "app-uncovered", dismissed: false, repo: TEST_REPO });
+    const el = document.querySelector("[data-ghpsr-banner]")!;
+    expect(el.textContent).toContain("cinev/shotloom");
+    expect(el.textContent).toContain("@cinev's GitHub App installation");
+    const link = el.querySelector("a");
     expect(link?.textContent).toBe("Configure access");
     expect(link?.getAttribute("href")).toBe(
       "https://github.com/apps/test-app/installations/new",
     );
   });
 
-  it("renders a Sign in link for the unauth rate-limit state", () => {
-    document.body.innerHTML = `<main><div class="gh-header"></div></main>`;
-    const target = document.querySelector<HTMLElement>(".gh-header")!;
-    const banner = mountBanner({
-      insertAfter: target,
-      installUrl: "https://github.com/apps/test-app/installations/new",
-      optionsPageUrl: "chrome-extension://ext-id/options.html",
-      onDismiss: () => {},
-    });
+  it("renders Sign in link for unauth-rate-limit", () => {
+    const banner = setup();
     banner.update({
-      uncovered: false,
-      unauthRateLimited: true,
+      current: "unauth-rate-limit",
       dismissed: false,
       repo: TEST_REPO,
     });
-
     const link = document.querySelector("[data-ghpsr-banner] a");
     expect(link?.textContent).toBe("Sign in");
     expect(link?.getAttribute("href")).toBe(
@@ -202,24 +244,55 @@ describe("banner DOM", () => {
     );
   });
 
-  it("removes the banner when dismissed", () => {
-    document.body.innerHTML = `<main><div class="gh-header"></div></main>`;
-    const target = document.querySelector<HTMLElement>(".gh-header")!;
-    const banner = mountBanner({
-      insertAfter: target,
-      installUrl: "https://github.com/apps/test-app/installations/new",
-      optionsPageUrl: "chrome-extension://ext-id/options.html",
-      onDismiss: () => {},
-    });
+  it("renders Sign in link for signin-required", () => {
+    const banner = setup();
     banner.update({
-      uncovered: true,
-      unauthRateLimited: false,
+      current: "signin-required",
+      dismissed: false,
+      repo: TEST_REPO,
+    });
+    const link = document.querySelector("[data-ghpsr-banner] a");
+    expect(link?.textContent).toBe("Sign in");
+    expect(link?.getAttribute("href")).toBe(
+      "chrome-extension://ext-id/options.html",
+    );
+  });
+
+  it("renders Sign in link for auth-expired", () => {
+    const banner = setup();
+    banner.update({
+      current: "auth-expired",
+      dismissed: false,
+      repo: TEST_REPO,
+    });
+    const link = document.querySelector("[data-ghpsr-banner] a");
+    expect(link?.textContent).toBe("Sign in");
+    expect(link?.getAttribute("href")).toBe(
+      "chrome-extension://ext-id/options.html",
+    );
+  });
+
+  it("renders no CTA link for auth-rate-limit (passive wait)", () => {
+    const banner = setup();
+    banner.update({
+      current: "auth-rate-limit",
+      dismissed: false,
+      repo: TEST_REPO,
+    });
+    const el = document.querySelector("[data-ghpsr-banner]")!;
+    expect(el.querySelector("a")).toBeNull();
+    expect(el.querySelector("button")?.textContent).toBe("Dismiss");
+  });
+
+  it("removes the banner when dismissed", () => {
+    const banner = setup();
+    banner.update({
+      current: "app-uncovered",
       dismissed: false,
       repo: TEST_REPO,
     });
     banner.update({
-      uncovered: true,
-      unauthRateLimited: false,
+      current: "app-uncovered",
       dismissed: true,
       repo: TEST_REPO,
     });

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -217,7 +217,31 @@ describe("content entrypoint", () => {
       expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit");
     });
 
-    it("emits unauth-rate-limit for no account + 403", async () => {
+    it("emits unauth-rate-limit for no account + 403 with rate-limit headers", async () => {
+      const aggregator = makeAggregator();
+      const { onRowFailure } = await bootContent(aggregator);
+      const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
+        "../src/github/api"
+      );
+
+      onRowFailure({
+        owner: "cinev",
+        repo: "shotloom",
+        account: null,
+        error: new GitHubPullRequestEndpointsError([
+          new GitHubApiError(403, undefined, undefined, {
+            limit: 60,
+            remaining: 0,
+            resource: "core",
+            resetAt: 1,
+          }),
+        ]),
+      });
+
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("unauth-rate-limit");
+    });
+
+    it("emits signin-required for no account + 403 without rate-limit signal", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
       const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
@@ -231,7 +255,24 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(403)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("unauth-rate-limit");
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("signin-required");
+    });
+
+    it("emits signin-required for no account + 401", async () => {
+      const aggregator = makeAggregator();
+      const { onRowFailure } = await bootContent(aggregator);
+      const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
+        "../src/github/api"
+      );
+
+      onRowFailure({
+        owner: "cinev",
+        repo: "shotloom",
+        account: null,
+        error: new GitHubPullRequestEndpointsError([new GitHubApiError(401)]),
+      });
+
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("signin-required");
     });
 
     it("emits unauth-rate-limit for no account + 429", async () => {

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -34,8 +34,7 @@ afterEach(() => {
 });
 
 type Aggregator = {
-  reportUncovered: ReturnType<typeof vi.fn>;
-  reportUnauthRateLimit: ReturnType<typeof vi.fn>;
+  reportFailure: ReturnType<typeof vi.fn>;
   teardown?: ReturnType<typeof vi.fn>;
 };
 
@@ -85,8 +84,7 @@ describe("content entrypoint", () => {
 
   it("waits to boot PR-list features until navigation enters a PR list", async () => {
     const aggregator = {
-      reportUncovered: vi.fn(),
-      reportUnauthRateLimit: vi.fn(),
+      reportFailure: vi.fn(),
       teardown: vi.fn(),
     };
     bootAccessBannerMock.mockReturnValue(aggregator);
@@ -120,134 +118,199 @@ describe("content entrypoint", () => {
   describe("onRowFailure banner classification", () => {
     function makeAggregator(): Aggregator {
       return {
-        reportUncovered: vi.fn(),
-        reportUnauthRateLimit: vi.fn(),
+        reportFailure: vi.fn(),
         teardown: vi.fn(),
       };
     }
 
-    it("treats a 429 in any failure of a pull-request endpoints error as rate-limited", async () => {
+    it("emits auth-expired for account + 401", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
       const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
         "../src/github/api"
       );
 
-      const error = new GitHubPullRequestEndpointsError([
-        new GitHubApiError(404),
-        new GitHubApiError(429),
-      ]);
       onRowFailure({
         owner: "cinev",
         repo: "shotloom",
         account: { id: "acc-1" },
-        error,
+        error: new GitHubPullRequestEndpointsError([new GitHubApiError(401)]),
       });
 
-      expect(aggregator.reportUnauthRateLimit).toHaveBeenCalledTimes(1);
-      expect(aggregator.reportUncovered).not.toHaveBeenCalled();
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-expired");
     });
 
-    it("treats mixed 404 + 403 with an account as uncovered (no rate limit)", async () => {
+    it("emits app-uncovered for account + 404 (no rate-limit signal)", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
       const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
         "../src/github/api"
       );
 
-      const error = new GitHubPullRequestEndpointsError([
-        new GitHubApiError(404),
-        new GitHubApiError(403),
-      ]);
       onRowFailure({
         owner: "cinev",
         repo: "shotloom",
         account: { id: "acc-1" },
-        error,
+        error: new GitHubPullRequestEndpointsError([new GitHubApiError(404)]),
       });
 
-      expect(aggregator.reportUncovered).toHaveBeenCalledTimes(1);
-      expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("app-uncovered");
     });
 
-    it("treats a 403 without an account as unauthenticated rate-limit", async () => {
+    it("emits app-uncovered for account + 403 without rate-limit signal", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
       const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
         "../src/github/api"
       );
 
-      const error = new GitHubPullRequestEndpointsError([
-        new GitHubApiError(403),
-      ]);
+      onRowFailure({
+        owner: "cinev",
+        repo: "shotloom",
+        account: { id: "acc-1" },
+        error: new GitHubPullRequestEndpointsError([
+          new GitHubApiError(403, "forbidden"),
+        ]),
+      });
+
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("app-uncovered");
+    });
+
+    it("emits auth-rate-limit for account + 403 with rate-limit headers", async () => {
+      const aggregator = makeAggregator();
+      const { onRowFailure } = await bootContent(aggregator);
+      const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
+        "../src/github/api"
+      );
+
+      onRowFailure({
+        owner: "cinev",
+        repo: "shotloom",
+        account: { id: "acc-1" },
+        error: new GitHubPullRequestEndpointsError([
+          new GitHubApiError(403, undefined, undefined, {
+            limit: 5000,
+            remaining: 0,
+            resource: "core",
+            resetAt: 1,
+          }),
+        ]),
+      });
+
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit");
+    });
+
+    it("emits auth-rate-limit for account + 429", async () => {
+      const aggregator = makeAggregator();
+      const { onRowFailure } = await bootContent(aggregator);
+      const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
+        "../src/github/api"
+      );
+
+      onRowFailure({
+        owner: "cinev",
+        repo: "shotloom",
+        account: { id: "acc-1" },
+        error: new GitHubPullRequestEndpointsError([new GitHubApiError(429)]),
+      });
+
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit");
+    });
+
+    it("emits unauth-rate-limit for no account + 403", async () => {
+      const aggregator = makeAggregator();
+      const { onRowFailure } = await bootContent(aggregator);
+      const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
+        "../src/github/api"
+      );
+
       onRowFailure({
         owner: "cinev",
         repo: "shotloom",
         account: null,
-        error,
+        error: new GitHubPullRequestEndpointsError([new GitHubApiError(403)]),
       });
 
-      expect(aggregator.reportUnauthRateLimit).toHaveBeenCalledTimes(1);
-      expect(aggregator.reportUncovered).not.toHaveBeenCalled();
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("unauth-rate-limit");
     });
 
-    it("does not show any banner for unattributed errors (schema drift, network, etc.)", async () => {
+    it("emits unauth-rate-limit for no account + 429", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
-
-      // A generic network error: we cannot attribute this to App coverage.
-      // The Configure access banner would be misleading guidance, so we stay
-      // silent and let the developer diagnose via console warnings.
-      onRowFailure({
-        owner: "cinev",
-        repo: "shotloom",
-        account: { id: "acc-1" },
-        error: new Error("Network down"),
-      });
-
-      expect(aggregator.reportUncovered).not.toHaveBeenCalled();
-      expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
-    });
-
-    it("does not show any banner for schema envelope failures", async () => {
-      const aggregator = makeAggregator();
-      const { onRowFailure } = await bootContent(aggregator);
+      const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
+        "../src/github/api"
+      );
 
       onRowFailure({
         owner: "cinev",
         repo: "shotloom",
-        account: { id: "acc-1" },
-        error: {
-          kind: "schema",
-          status: null,
-          message: "Response shape changed",
-        },
+        account: null,
+        error: new GitHubPullRequestEndpointsError([new GitHubApiError(429)]),
       });
 
-      expect(aggregator.reportUncovered).not.toHaveBeenCalled();
-      expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("unauth-rate-limit");
     });
 
-    it("does not show any banner for unknown envelope failures", async () => {
+    it("emits signin-required for no account + 404", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
+      const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
+        "../src/github/api"
+      );
+
+      onRowFailure({
+        owner: "cinev",
+        repo: "shotloom",
+        account: null,
+        error: new GitHubPullRequestEndpointsError([new GitHubApiError(404)]),
+      });
+
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("signin-required");
+    });
+
+    it("picks the highest-priority kind across mixed failures (auth-expired wins over app-uncovered)", async () => {
+      const aggregator = makeAggregator();
+      const { onRowFailure } = await bootContent(aggregator);
+      const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
+        "../src/github/api"
+      );
 
       onRowFailure({
         owner: "cinev",
         repo: "shotloom",
         account: { id: "acc-1" },
-        error: {
-          kind: "unknown",
-          status: null,
-          message: "Background fetch aborted",
-        },
+        error: new GitHubPullRequestEndpointsError([
+          new GitHubApiError(404),
+          new GitHubApiError(401),
+        ]),
       });
 
-      expect(aggregator.reportUncovered).not.toHaveBeenCalled();
-      expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
+      expect(aggregator.reportFailure).toHaveBeenCalledTimes(1);
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-expired");
     });
 
-    it("does not show any banner for empty endpoint envelope failures", async () => {
+    it("does not emit any kind for unattributed errors (network, schema, unknown envelope, empty failures)", async () => {
+      const cases: unknown[] = [
+        new Error("Network down"),
+        { kind: "schema", status: null, message: "Response shape changed" },
+        { kind: "unknown", status: null, message: "Background fetch aborted" },
+        { kind: "github-endpoints", status: null, failures: [] },
+      ];
+
+      for (const error of cases) {
+        const aggregator = makeAggregator();
+        const { onRowFailure } = await bootContent(aggregator);
+        onRowFailure({
+          owner: "cinev",
+          repo: "shotloom",
+          account: { id: "acc-1" },
+          error,
+        });
+        expect(aggregator.reportFailure).not.toHaveBeenCalled();
+      }
+    });
+
+    it("classifies serialized envelope failures with rateLimited identical to live errors", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
 
@@ -257,35 +320,18 @@ describe("content entrypoint", () => {
         account: { id: "acc-1" },
         error: {
           kind: "github-endpoints",
-          status: null,
-          failures: [],
-        },
-      });
-
-      expect(aggregator.reportUncovered).not.toHaveBeenCalled();
-      expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
-    });
-
-    it("classifies serialized reviewer-fetch failures the same way as GitHubApiError instances", async () => {
-      const aggregator = makeAggregator();
-      const { onRowFailure } = await bootContent(aggregator);
-
-      onRowFailure({
-        owner: "cinev",
-        repo: "shotloom",
-        account: { id: "acc-1" },
-        error: {
-          kind: "github-endpoints",
-          status: 404,
+          status: 403,
           failures: [
-            { status: 404, endpoint: "/repos/cinev/shotloom/pulls/42" },
-            { status: 403, endpoint: "/repos/cinev/shotloom/pulls/42/reviews" },
+            {
+              status: 403,
+              endpoint: "/repos/cinev/shotloom/pulls/42",
+              rateLimited: true,
+            },
           ],
         },
       });
 
-      expect(aggregator.reportUncovered).toHaveBeenCalledTimes(1);
-      expect(aggregator.reportUnauthRateLimit).not.toHaveBeenCalled();
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit");
     });
   });
 });

--- a/tests/reviewer-fetch.test.ts
+++ b/tests/reviewer-fetch.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { GitHubApiError, GitHubPullRequestEndpointsError } from "../src/github/api";
+import {
+  extractReviewerFetchFailures,
+  serializeReviewerFetchError,
+} from "../src/runtime/reviewer-fetch";
+
+const pullEndpoint = {
+  name: "pull" as const,
+  method: "GET" as const,
+  path: "/repos/cinev/shotloom/pulls/42",
+};
+const reviewsEndpoint = {
+  name: "reviews" as const,
+  method: "GET" as const,
+  path: "/repos/cinev/shotloom/pulls/42/reviews",
+};
+
+describe("serializeReviewerFetchError", () => {
+  it("flags rateLimited=true when the GitHubApiError signals rate-limit headers", () => {
+    const error = new GitHubApiError(
+      403,
+      undefined,
+      pullEndpoint,
+      { limit: 60, remaining: 0, resource: "core", resetAt: 1 },
+    );
+
+    const envelope = serializeReviewerFetchError(error);
+
+    expect(envelope.kind).toBe("github-api");
+    expect(envelope.failures).toEqual([
+      { status: 403, endpoint: pullEndpoint.path, rateLimited: true },
+    ]);
+  });
+
+  it("flags rateLimited=false when the GitHubApiError is a 404 with no rate-limit signal", () => {
+    const error = new GitHubApiError(404, undefined, pullEndpoint);
+
+    const envelope = serializeReviewerFetchError(error);
+
+    expect(envelope.failures).toEqual([
+      { status: 404, endpoint: pullEndpoint.path, rateLimited: false },
+    ]);
+  });
+
+  it("preserves rateLimited per failure inside a GitHubPullRequestEndpointsError", () => {
+    const error = new GitHubPullRequestEndpointsError([
+      new GitHubApiError(404, undefined, pullEndpoint),
+      new GitHubApiError(429, undefined, reviewsEndpoint),
+    ]);
+
+    const envelope = serializeReviewerFetchError(error);
+
+    expect(envelope.kind).toBe("github-endpoints");
+    expect(envelope.failures).toEqual([
+      { status: 404, endpoint: pullEndpoint.path, rateLimited: false },
+      { status: 429, endpoint: reviewsEndpoint.path, rateLimited: true },
+    ]);
+  });
+});
+
+describe("extractReviewerFetchFailures", () => {
+  it("computes rateLimited from a live GitHubApiError instance", () => {
+    const error = new GitHubApiError(
+      403,
+      undefined,
+      pullEndpoint,
+      { limit: 60, remaining: 0, resource: "core", resetAt: 1 },
+    );
+
+    expect(extractReviewerFetchFailures(error)).toEqual([
+      { status: 403, endpoint: pullEndpoint.path, rateLimited: true },
+    ]);
+  });
+
+  it("reads rateLimited from an already-serialized envelope object", () => {
+    const envelope = {
+      kind: "github-endpoints" as const,
+      status: 403,
+      failures: [
+        { status: 403, endpoint: "/repos/cinev/shotloom/pulls/42", rateLimited: true },
+        { status: 404, endpoint: "/repos/cinev/shotloom/pulls/42/reviews", rateLimited: false },
+      ],
+    };
+
+    expect(extractReviewerFetchFailures(envelope)).toEqual([
+      { status: 403, endpoint: "/repos/cinev/shotloom/pulls/42", rateLimited: true },
+      { status: 404, endpoint: "/repos/cinev/shotloom/pulls/42/reviews", rateLimited: false },
+    ]);
+  });
+
+  it("defaults rateLimited to false when the envelope object omits the field (backward compatibility)", () => {
+    const envelope = {
+      kind: "github-endpoints" as const,
+      status: 404,
+      failures: [{ status: 404, endpoint: null }],
+    };
+
+    expect(extractReviewerFetchFailures(envelope)).toEqual([
+      { status: 404, endpoint: null, rateLimited: false },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the two-flag access-banner state model (`uncovered` / `unauthRateLimited`) with a five-kind taxonomy decided by severity priority, so token-expired, App-uncovered, rate-limit, and sign-in-required failures each surface their own copy and CTA.
- Carry a `rateLimited` boolean across the background→content envelope so the classifier can distinguish auth-tier rate limits from App permission failures.
- Per-kind dismiss key (`pathname + kind`) so dismissing a low-priority banner does not suppress a later higher-priority kind on the same page.

## Why

Closes the issue where users with no registered GitHub account were shown **"You hit GitHub's unauthenticated rate limit"** even when the actual cause was something else (private repo + no sign-in, expired token, App lacking coverage, …). The previous classifier collapsed five distinct failure modes into two banner states, so the same banner copy fired for several unrelated conditions and "Configure access" was used as a fallback even for token-expired or rate-limit cases. See [#36](https://github.com/hon454/github-pulls-show-reviewers/issues/36) for the misclassification matrix and reproduction.

## Changes

### Data flow

`GitHubApiError → serializeReviewerFetchError (rateLimited:bool) → envelope → extractReviewerFetchFailures → classifyFailure → classifyRowFailure (priority reduce) → reportFailure(kind) → render`

### Banner taxonomy

| Account state | Failure pattern                                      | Kind                  | CTA              |
| ------------- | ---------------------------------------------------- | --------------------- | ---------------- |
| Signed in     | 401                                                  | `auth-expired`        | Sign in          |
| Signed in     | 404 / 403 (no rate-limit signal)                     | `app-uncovered`       | Configure access |
| Signed in     | 429 / 403 + `x-ratelimit-remaining:0`                | `auth-rate-limit`     | (passive wait)   |
| No account    | 403, 429, or any rate-limit signal                   | `unauth-rate-limit`   | Sign in          |
| No account    | 404                                                  | `signin-required`     | Sign in          |
| Either        | Network / schema / unknown / empty endpoint envelope | (silent, console.warn) | —               |

Severity priority (highest first): `auth-expired` > `app-uncovered` > `auth-rate-limit` > `unauth-rate-limit` > `signin-required`. The highest-priority kind seen across row failures wins.

### Public API rename

`BannerAggregator.reportUncovered()` + `reportUnauthRateLimit()` → single `reportFailure(kind: BannerKind)`. No external consumers; the only caller is `entrypoints/content.ts`.

### Per-kind dismiss

Dismiss key changed from `ghpsr:banner-dismissed:${pathname}` to `ghpsr:banner-dismissed:${pathname}:${kind}`. Dismissing one kind no longer suppresses a later higher-priority kind on the same page.

### Backward compatibility

`extractReviewerFetchFailures` envelope-object branch tolerates missing `rateLimited` (treats as `false`) so in-flight serialized envelopes from a slightly older background bundle deserialize cleanly during extension upgrade.

## Impact

- User-facing impact: banner copy and CTA now correctly match the actual failure cause. New users on private repos see "Sign in with GitHub to see reviewers on private repositories." (was: misleading rate-limit message). Token-expired users see "Your GitHub session expired. Sign in again…" (was: "Configure access"). Rate-limit-exhausted authenticated users see "GitHub's hourly request limit was reached…" (was: "Configure access").
- API/schema impact: `ReviewerFetchFailure` envelope gains required `rateLimited: boolean`. `BannerAggregator` interface renamed (`reportFailure` instead of two flag-specific methods). Both are internal types; no on-disk schema change.
- Performance impact: none. Same number of API calls and DOM mounts; classification adds an O(n) reduce over per-row failures (n ≤ 2 in practice).
- Operational or rollout impact: none. Single content script + background bundle ship together; the envelope tolerance handles the brief upgrade window.

## Testing

- [x] Unit tests
- [x] Integration tests (e2e Playwright)
- [ ] Manual testing

### Test details

- `pnpm test` → 254/254 across 24 test files. New coverage:
  - `tests/reviewer-fetch.test.ts` — 6 tests for serialize/extract envelope round-trip of `rateLimited`
  - `tests/access-banner.test.ts` — 22 tests for new state model, severity priority, per-kind dismiss
  - `tests/content.test.ts` — 11 classifier cases (one per kind, cross-row priority, unattributed-error loop, serialized-envelope passthrough)
- `pnpm typecheck` → clean
- `pnpm lint` → clean
- `pnpm build` → success (chrome-mv3 bundle 469 kB)
- `pnpm test:e2e` → 6/6 pass

## Breaking Changes

- None (internal API only — `BannerAggregator` is not exported across package boundaries).

## Related Issues

Resolves #36

<!--
Co-location: docs/implementation-notes.md and docs/manual-chrome-testing.md
both updated to use the new banner-kind taxonomy.
-->