### PR TITLE
fix(api): narrow isRateLimitError details fallback to documented messages

### DIFF
--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -778,11 +778,17 @@ function readHeaderNumber(headers: Headers, name: string): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
+// Matches GitHub's documented rate-limit error messages only:
+// - primary:   "API rate limit exceeded for …"
+// - secondary: "You have exceeded a secondary rate limit …"
+// Word boundaries prevent false positives like "no rate limit applied".
+const RATE_LIMIT_MESSAGE_PATTERN = /\b(?:api|secondary) rate limit\b/i;
+
 export function isRateLimitError(error: GitHubApiError): boolean {
   return (
     error.status === 429 ||
     error.rateLimit?.remaining === 0 ||
-    error.details?.toLowerCase().includes("rate limit") === true
+    (error.details != null && RATE_LIMIT_MESSAGE_PATTERN.test(error.details))
   );
 }
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -7,6 +7,7 @@ import {
   GitHubApiSchemaError,
   fetchPullReviewerSummary,
   describeGitHubApiError,
+  isRateLimitError,
   parseRepositoryReference,
   validateGitHubRepositoryAccess,
 } from "../src/github/api";
@@ -96,6 +97,57 @@ describe("describeGitHubApiError", () => {
       owner: "hon454",
       repo: "github-pulls-show-reviewers",
     });
+  });
+});
+
+describe("isRateLimitError", () => {
+  it("returns true for HTTP 429", () => {
+    expect(isRateLimitError(new GitHubApiError(429))).toBe(true);
+  });
+
+  it("returns true when rateLimit.remaining is exhausted", () => {
+    const error = new GitHubApiError(403, undefined, undefined, {
+      limit: 60,
+      remaining: 0,
+      resource: "core",
+      resetAt: null,
+    });
+    expect(isRateLimitError(error)).toBe(true);
+  });
+
+  it('matches GitHub primary rate-limit message ("API rate limit exceeded …")', () => {
+    expect(
+      isRateLimitError(
+        new GitHubApiError(403, "API rate limit exceeded for 1.2.3.4"),
+      ),
+    ).toBe(true);
+  });
+
+  it('matches GitHub secondary rate-limit message ("… secondary rate limit …")', () => {
+    expect(
+      isRateLimitError(
+        new GitHubApiError(
+          403,
+          "You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match unrelated details that incidentally contain "rate limit"', () => {
+    expect(
+      isRateLimitError(
+        new GitHubApiError(403, "This endpoint has no rate limit applied"),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when no rate-limit signal is present", () => {
+    expect(
+      isRateLimitError(
+        new GitHubApiError(403, "Resource not accessible by integration"),
+      ),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace the loose `details.toLowerCase().includes("rate limit")` fallback in `isRateLimitError` with a regex pinned to GitHub's documented primary (`API rate limit exceeded …`) and secondary (`… secondary rate limit …`) phrasing, anchored with `\b` word boundaries.
- Add unit coverage in `tests/api.test.ts` for `isRateLimitError`: HTTP 429, exhausted `rateLimit.remaining`, primary and secondary message matches, a false-positive regression case (`"This endpoint has no rate limit applied"`), and a no-signal control case.

## Why

Codex's review of #37 flagged that the substring fallback would falsely classify any error whose `details` incidentally contained the phrase "rate limit" — exactly the kind of misclassification that #37's banner-kind taxonomy was meant to eliminate at the surface layer. Tracked in #38.

This change does not introduce the function (PR #37 already exported it for envelope reuse); it only tightens the message-based clause and locks the behavior in with tests.

## Stacking

- **Base:** `claude/condescending-bell-d41354` (#37)
- Once #37 merges, GitHub will automatically retarget this PR's base to `main`.

## Testing

- [x] Unit tests
- [ ] Integration tests (e2e Playwright)
- [ ] Manual testing

### Test details

- `pnpm test` → 262/262 pass (was 256 on the base branch; +6 new `isRateLimitError` cases)
- `pnpm typecheck` → clean
- `pnpm lint` → clean

## Breaking Changes

None. Internal helper signature is unchanged.

## Related Issues

Closes #38

Related: #37, #36