### PR TITLE
v1.4.5: preserve refresh token + clean up release docs

### DIFF
--- a/docs/chrome-web-store-submission.md
+++ b/docs/chrome-web-store-submission.md
@@ -48,7 +48,7 @@ Single purpose:
 
 Permission justification draft:
 
-- `storage`: stores locally the GitHub App accounts (user-to-server access token, refresh token, and token-expiry timestamps per account) so the user can access private repositories. It also stores the review-chip display preferences (`showStateBadge` and `showReviewerName`) under the local `preferences` key.
+- `storage`: stores locally the GitHub App accounts (user-to-server access token, refresh token, and token-expiry timestamps per account) so the user can access private repositories. It also stores the review-chip display preferences (`showStateBadge`, `showReviewerName`, and `openPullsOnly`) under the local `preferences` key.
 - `alarms`: schedules a recurring 15-minute background task that refreshes GitHub App access tokens ahead of expiry. Without this, every eight-hour token lifetime would force the user to sign in again even while actively using the extension, and reviewer lookups on private repositories would stall until the next sign-in.
 - `https://github.com/*`: reads the current GitHub pull request list page to find repository context and render reviewer chips inline.
 - `https://api.github.com/*`: fetches requested reviewers, requested teams, and review history from GitHub's REST API. Requests originate from the extension's background service worker; the access token never enters the content-script execution context.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -53,4 +53,6 @@ To provide its reviewer visibility feature, the extension may access:
 
 ## Contact
 
-If you publish this extension, replace this section with the maintainer's support or privacy contact address before submitting to the Chrome Web Store.
+For privacy questions, support requests, or to report a concern about this
+extension, open an issue on the maintainer's public GitHub Issues tracker:
+<https://github.com/hon454/github-pulls-show-reviewers/issues>.

--- a/src/auth/refresh-coordinator.ts
+++ b/src/auth/refresh-coordinator.ts
@@ -32,11 +32,15 @@ export function createRefreshCoordinator(input: {
         clientId: input.getClientId(),
         refreshToken: account.refreshToken,
       });
+      // GitHub may omit refresh_token / refresh_token_expires_in on a successful
+      // refresh when no rotation occurred. Treat null as "no rotation" and
+      // preserve the existing stored values rather than clearing them.
       await updateAccountTokens(accountId, {
         token: result.accessToken,
-        refreshToken: result.refreshToken,
+        refreshToken: result.refreshToken ?? account.refreshToken,
         expiresAt: result.expiresAt,
-        refreshTokenExpiresAt: result.refreshTokenExpiresAt,
+        refreshTokenExpiresAt:
+          result.refreshTokenExpiresAt ?? account.refreshTokenExpiresAt,
       });
       return { ok: true, token: result.accessToken };
     } catch (error) {

--- a/tests/auth.refresh.test.ts
+++ b/tests/auth.refresh.test.ts
@@ -56,6 +56,29 @@ describe("refreshAccessToken", () => {
     expect(body).toContain("refresh_token=ghr_old");
   });
 
+  it("returns null refresh fields when the success response omits refresh_token rotation", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        access_token: "ghu_newaccess",
+        expires_in: 28800,
+        scope: "",
+        token_type: "bearer",
+      }),
+    );
+
+    const result = await refreshAccessToken({
+      clientId: "Iv1.test",
+      refreshToken: "ghr_old",
+    });
+
+    expect(result).toEqual({
+      accessToken: "ghu_newaccess",
+      refreshToken: null,
+      expiresAt: Date.UTC(2026, 3, 23, 0, 0, 0) + 28_800_000,
+      refreshTokenExpiresAt: null,
+    });
+  });
+
   it("throws RefreshTokenError(terminal) for bad_refresh_token", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       jsonResponse(fixture("refresh-token-bad.json")),

--- a/tests/refresh-coordinator.test.ts
+++ b/tests/refresh-coordinator.test.ts
@@ -82,6 +82,59 @@ describe("createRefreshCoordinator", () => {
     expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
   });
 
+  it("preserves the existing refresh token when the refresh response omits refresh_token", async () => {
+    getAccountByIdMock.mockResolvedValue(
+      makeAccount({
+        refreshToken: "ghr_old",
+        refreshTokenExpiresAt: 9_999_999,
+      }),
+    );
+    const fresh: RefreshTokenResult = {
+      accessToken: "ghu_new",
+      refreshToken: null,
+      expiresAt: 1234,
+      refreshTokenExpiresAt: null,
+    };
+    refreshAccessTokenMock.mockResolvedValue(fresh);
+
+    const coordinator = createRefreshCoordinator({ getClientId: () => "Iv1.test" });
+    const outcome = await coordinator.refreshAccountToken("acc-1");
+
+    expect(outcome).toEqual({ ok: true, token: "ghu_new" });
+    expect(updateAccountTokensMock).toHaveBeenCalledWith("acc-1", {
+      token: "ghu_new",
+      refreshToken: "ghr_old",
+      expiresAt: 1234,
+      refreshTokenExpiresAt: 9_999_999,
+    });
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+  });
+
+  it("rotates the refresh token when the response includes a new one", async () => {
+    getAccountByIdMock.mockResolvedValue(
+      makeAccount({
+        refreshToken: "ghr_old",
+        refreshTokenExpiresAt: 1_000,
+      }),
+    );
+    refreshAccessTokenMock.mockResolvedValue({
+      accessToken: "ghu_new",
+      refreshToken: "ghr_rotated",
+      expiresAt: 2222,
+      refreshTokenExpiresAt: 5_000,
+    });
+
+    const coordinator = createRefreshCoordinator({ getClientId: () => "Iv1.test" });
+    await coordinator.refreshAccountToken("acc-1");
+
+    expect(updateAccountTokensMock).toHaveBeenCalledWith("acc-1", {
+      token: "ghu_new",
+      refreshToken: "ghr_rotated",
+      expiresAt: 2222,
+      refreshTokenExpiresAt: 5_000,
+    });
+  });
+
   it("dedupes concurrent calls for the same account into a single refresh", async () => {
     getAccountByIdMock.mockResolvedValue(makeAccount());
     let resolveRefresh: (value: RefreshTokenResult) => void = () => {};


### PR DESCRIPTION
## Summary

- Preserve the account's existing refresh token / expiry when a successful refresh response omits rotation fields (#42).
- List `openPullsOnly` alongside the other preferences in the Chrome Web Store storage justification (#46).
- Replace the privacy policy contact placeholder with the public GitHub Issues tracker (#47).

## Why

These are the three issues on the v1.4.5 milestone ("Auth safety and release documentation cleanup"). Together they fix a P1 auth-reliability bug and finish the release-readiness checklist for the Chrome Web Store submission packet.

## Changes

- `src/auth/refresh-coordinator.ts`: when `refreshAccessToken` returns `null` for `refreshToken` / `refreshTokenExpiresAt`, treat that as "no rotation" and reuse the account's previously stored values rather than overwriting storage with `null`.
- `tests/refresh-coordinator.test.ts`, `tests/auth.refresh.test.ts`: add coverage for both rotated and non-rotated success envelopes; coverage for terminal/transient errors is unchanged.
- `docs/chrome-web-store-submission.md`: add `openPullsOnly` to the `storage` permission justification.
- `docs/privacy-policy.md`: replace the placeholder contact section with the public Issues tracker URL.

## Impact

- User-facing impact: existing accounts with non-rotating refresh responses no longer silently lose their refresh tokens. Privacy policy now lists a real contact channel.
- API/schema impact: none. `RefreshTokenResult` shape and `updateAccountTokens` signature are unchanged.
- Performance impact: none.
- Operational or rollout impact: unblocks Chrome Web Store submission.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint`, `pnpm typecheck`, `pnpm test` all pass locally (265 tests).
- New unit tests:
  - `refresh-coordinator.test.ts`: preserves the existing refresh token when the refresh response omits `refresh_token`; rotates the refresh token when the response includes a new one.
  - `auth.refresh.test.ts`: returns `null` refresh fields when the success response omits `refresh_token` rotation.

## Breaking Changes

- None

## Related Issues

Resolves #42, #46, #47