### PR TITLE
feat(reviewers): self-heal stale GitHub App installation coverage

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -79,6 +79,14 @@ does not suppress a later, higher-priority kind on the same page.
 - A recurring `chrome.alarms` job (15-minute period, 30-minute refresh threshold) pre-warms access tokens before the reactive 401 path is needed, and invalidates accounts whose refresh token has already expired.
 - Design rationale, alternatives, and the revisit trigger live in [ADR 0005](./adr/0005-proactive-refresh.md).
 
+## Stale GitHub App installation self-healing
+
+- `resolveAccountForRepo` reads the locally cached installations snapshot, so a repo added to an existing installation outside the extension can look uncovered until the next manual `Refresh installations` click.
+- `createSelfHealingAccountResolver` (`src/features/reviewers/account-resolution.ts`) wraps the resolution: when the cached lookup misses, it scans for accounts that own a `selected` installation on the same owner but do not list the repo, then sends a `refreshAccountInstallations` message to the background and re-runs the resolution.
+- The background-side `createInstallationRefreshService` (`src/background/installation-refresh.ts`) holds the token, refreshes via `RefreshCoordinator` on 401, persists through `replaceInstallations`, and dedupes concurrent calls per `accountId`. Tokens never enter the content-script context.
+- Each candidate is refreshed at most once per page session. A successful refresh writes to `account:installations:*`, which the existing `accountsChange` storage listener uses to clear the row cache and re-render covered rows transparently.
+- Genuinely uncovered repos still flow into the `app-uncovered` / `signin-required` banner copy after the refresh attempt completes.
+
 ## Next implementation targets
 
 - Collapse request volume further where practical.

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,4 +1,5 @@
 import { createRefreshCoordinator } from "../src/auth/refresh-coordinator";
+import { createInstallationRefreshService } from "../src/background/installation-refresh";
 import { createProactiveRefreshService } from "../src/background/proactive-refresh";
 import { createReviewerFetchService } from "../src/background/reviewer-fetch";
 import { getGitHubAppConfig } from "../src/config/github-app";
@@ -6,6 +7,9 @@ import {
   isCancelPullReviewerSummaryMessage,
   isFetchPullReviewerSummaryMessage,
 } from "../src/runtime/reviewer-fetch";
+import {
+  isRefreshAccountInstallationsMessage,
+} from "../src/runtime/installation-refresh";
 import {
   listAccounts,
   markAccountInvalidated,
@@ -16,6 +20,9 @@ export default defineBackground(() => {
     getClientId: () => getGitHubAppConfig().clientId,
   });
   const reviewerFetchService = createReviewerFetchService({
+    refreshCoordinator: coordinator,
+  });
+  const installationRefreshService = createInstallationRefreshService({
     refreshCoordinator: coordinator,
   });
   const proactiveRefreshService = createProactiveRefreshService({
@@ -116,6 +123,21 @@ export default defineBackground(() => {
       if (isCancelPullReviewerSummaryMessage(message)) {
         reviewerFetchService.cancelRequest(message.requestId);
         return undefined;
+      }
+      if (isRefreshAccountInstallationsMessage(message)) {
+        installationRefreshService
+          .refreshAccountInstallations(message.accountId)
+          .then(
+            (outcome) => sendResponse(outcome),
+            (error) => {
+              console.error(
+                "[GitHub Pulls Show Reviewers] refreshAccountInstallations failed.",
+                error,
+              );
+              sendResponse(undefined);
+            },
+          );
+        return true;
       }
       return undefined;
     },

--- a/src/background/installation-refresh.ts
+++ b/src/background/installation-refresh.ts
@@ -1,0 +1,103 @@
+import type { RefreshCoordinator } from "../auth/refresh-coordinator";
+import { extractGitHubApiStatus } from "../github/api";
+import {
+  fetchInstallationRepositories,
+  fetchUserInstallations,
+} from "../github/auth";
+import {
+  getAccountById,
+  markAccountInvalidated,
+  replaceInstallations,
+  type Account,
+  type Installation,
+} from "../storage/accounts";
+
+export type InstallationRefreshOutcome =
+  | { ok: true }
+  | { ok: false; reason: "no-account" | "invalidated" | "failed" };
+
+export type InstallationRefreshService = {
+  refreshAccountInstallations(accountId: string): Promise<InstallationRefreshOutcome>;
+};
+
+export function createInstallationRefreshService(input: {
+  refreshCoordinator: RefreshCoordinator;
+}): InstallationRefreshService {
+  const { refreshCoordinator } = input;
+  const inFlight = new Map<string, Promise<InstallationRefreshOutcome>>();
+
+  async function loadInstallationsWithToken(token: string): Promise<Installation[]> {
+    const apiInstallations = await fetchUserInstallations({ token });
+    return Promise.all(
+      apiInstallations.map(async (installation): Promise<Installation> => ({
+        id: installation.id,
+        account: installation.account,
+        repositorySelection: installation.repositorySelection,
+        repoFullNames:
+          installation.repositorySelection === "selected"
+            ? await fetchInstallationRepositories({
+                token,
+                installationId: installation.id,
+              })
+            : null,
+      })),
+    );
+  }
+
+  async function run(accountId: string): Promise<InstallationRefreshOutcome> {
+    const account = await getAccountById(accountId);
+    if (account == null) {
+      return { ok: false, reason: "no-account" };
+    }
+    if (account.invalidated) {
+      return { ok: false, reason: "invalidated" };
+    }
+
+    try {
+      const installations = await loadInstallationsWithToken(account.token);
+      await replaceInstallations(account.id, installations);
+      return { ok: true };
+    } catch (error) {
+      if (extractGitHubApiStatus(error) !== 401) {
+        return { ok: false, reason: "failed" };
+      }
+
+      if (account.refreshToken == null) {
+        await markAccountInvalidated(account.id, "revoked");
+        return { ok: false, reason: "failed" };
+      }
+
+      const refreshOutcome = await refreshCoordinator.refreshAccountToken(account.id);
+      if (!refreshOutcome.ok) {
+        return { ok: false, reason: "failed" };
+      }
+
+      const refreshed: Account | null = await getAccountById(account.id);
+      const tokenForRetry = refreshed?.token ?? refreshOutcome.token;
+      try {
+        const installations = await loadInstallationsWithToken(tokenForRetry);
+        await replaceInstallations(account.id, installations);
+        return { ok: true };
+      } catch (retryError) {
+        if (extractGitHubApiStatus(retryError) === 401) {
+          await markAccountInvalidated(account.id, "revoked");
+        }
+        return { ok: false, reason: "failed" };
+      }
+    }
+  }
+
+  return {
+    refreshAccountInstallations(accountId: string): Promise<InstallationRefreshOutcome> {
+      const existing = inFlight.get(accountId);
+      if (existing) {
+        return existing;
+      }
+      const promise = run(accountId).finally(() => {
+        inFlight.delete(accountId);
+      });
+      inFlight.set(accountId, promise);
+      return promise;
+    },
+  };
+}

--- a/src/features/reviewers/account-resolution.ts
+++ b/src/features/reviewers/account-resolution.ts
@@ -1,0 +1,97 @@
+import {
+  listAccounts,
+  resolveAccountForRepo,
+  type Account,
+} from "../../storage/accounts";
+
+export type SelfHealingAccountResolver = {
+  resolveAccount(owner: string, repo: string): Promise<Account | null>;
+};
+
+export type RequestInstallationsRefresh = (accountId: string) => Promise<boolean>;
+
+export function createSelfHealingAccountResolver(input: {
+  requestRefresh: RequestInstallationsRefresh;
+}): SelfHealingAccountResolver {
+  const { requestRefresh } = input;
+  // Page-session memo: refresh each candidate at most once. We persist the
+  // attempt outcome in the Set whether it succeeded or failed so that a
+  // failing refresh does not get retried for every row that hits the same
+  // owner.
+  const attemptedRefreshes = new Set<string>();
+  const inFlightRefreshes = new Map<string, Promise<boolean>>();
+
+  function dedupedRefresh(accountId: string): Promise<boolean> {
+    const existing = inFlightRefreshes.get(accountId);
+    if (existing) {
+      return existing;
+    }
+    const promise = requestRefresh(accountId)
+      .catch(() => false)
+      .finally(() => {
+        attemptedRefreshes.add(accountId);
+        inFlightRefreshes.delete(accountId);
+      });
+    inFlightRefreshes.set(accountId, promise);
+    return promise;
+  }
+
+  async function findStaleCandidates(
+    owner: string,
+    repo: string,
+  ): Promise<string[]> {
+    const accounts = await listAccounts();
+    const normalizedOwner = owner.toLowerCase();
+    const normalizedFullName = `${normalizedOwner}/${repo.toLowerCase()}`;
+    const candidates: string[] = [];
+
+    for (const account of accounts) {
+      if (account.invalidated) {
+        continue;
+      }
+      const ownerInstallations = account.installations.filter(
+        (installation) =>
+          installation.account.login.toLowerCase() === normalizedOwner,
+      );
+      if (ownerInstallations.length === 0) {
+        continue;
+      }
+      // If any installation already covers the repo, resolveAccountForRepo
+      // should have returned this account. Treat it as not-stale and skip.
+      const alreadyCovers = ownerInstallations.some((installation) => {
+        if (installation.repositorySelection === "all") {
+          return true;
+        }
+        const fullNames = installation.repoFullNames ?? [];
+        return fullNames.some((name) => name.toLowerCase() === normalizedFullName);
+      });
+      if (alreadyCovers) {
+        continue;
+      }
+      candidates.push(account.id);
+    }
+
+    return candidates;
+  }
+
+  return {
+    async resolveAccount(owner: string, repo: string): Promise<Account | null> {
+      const initial = await resolveAccountForRepo(owner, repo);
+      if (initial != null) {
+        return initial;
+      }
+
+      const candidates = await findStaleCandidates(owner, repo);
+      const refreshable = candidates.filter(
+        (accountId) => !attemptedRefreshes.has(accountId),
+      );
+      if (refreshable.length === 0) {
+        return null;
+      }
+
+      await Promise.all(refreshable.map((accountId) => dedupedRefresh(accountId)));
+
+      return await resolveAccountForRepo(owner, repo);
+    },
+  };
+}

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -9,11 +9,12 @@ import {
 import type { PullReviewerSummary } from "../../github/api";
 import { parsePullListRoute } from "../../github/routes";
 import { githubSelectors } from "../../github/selectors";
+import type { RefreshAccountInstallationsResponse } from "../../runtime/installation-refresh";
 import {
   ReviewerFetchRuntimeError,
   type FetchPullReviewerSummaryResponse,
 } from "../../runtime/reviewer-fetch";
-import { resolveAccountForRepo, type Account } from "../../storage/accounts";
+import { type Account } from "../../storage/accounts";
 import {
   DEFAULT_PREFERENCES,
   getPreferences,
@@ -22,6 +23,7 @@ import {
   type Preferences,
 } from "../../storage/preferences";
 
+import { createSelfHealingAccountResolver } from "./account-resolution";
 import {
   clearRenderedReviewerState,
   ensureReviewerMount,
@@ -56,6 +58,9 @@ export function bootReviewerListPage(
   };
   const inflightRequests = new Map<string, InflightRequest>();
   let cachedPreferences: Promise<Preferences> | null = null;
+  const accountResolver = createSelfHealingAccountResolver({
+    requestRefresh: requestInstallationsRefresh,
+  });
 
   function abortInflightRequests(): void {
     for (const request of inflightRequests.values()) {
@@ -132,7 +137,7 @@ export function bootReviewerListPage(
     const controller = new AbortController();
     let request: InflightRequest | null = null;
     const promise = (async () => {
-      const account = await resolveAccountForRepo(route.owner, route.repo);
+      const account = await accountResolver.resolveAccount(route.owner, route.repo);
 
       try {
         const summary = await fetchWithRefresh({
@@ -361,4 +366,16 @@ function createAbortError(): Error {
   const error = new Error("The operation was aborted.");
   error.name = "AbortError";
   return error;
+}
+
+async function requestInstallationsRefresh(accountId: string): Promise<boolean> {
+  try {
+    const response = (await browser.runtime.sendMessage({
+      type: "refreshAccountInstallations",
+      accountId,
+    })) as RefreshAccountInstallationsResponse;
+    return response?.ok === true;
+  } catch {
+    return false;
+  }
 }

--- a/src/runtime/installation-refresh.ts
+++ b/src/runtime/installation-refresh.ts
@@ -1,0 +1,22 @@
+import type { InstallationRefreshOutcome } from "../background/installation-refresh";
+
+export type RefreshAccountInstallationsMessage = {
+  type: "refreshAccountInstallations";
+  accountId: string;
+};
+
+export type RefreshAccountInstallationsResponse =
+  | InstallationRefreshOutcome
+  | undefined;
+
+export function isRefreshAccountInstallationsMessage(
+  value: unknown,
+): value is RefreshAccountInstallationsMessage {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    (value as { type?: unknown }).type === "refreshAccountInstallations" &&
+    typeof (value as { accountId?: unknown }).accountId === "string" &&
+    ((value as { accountId: string }).accountId.trim().length > 0)
+  );
+}

--- a/tests/account-resolution.test.ts
+++ b/tests/account-resolution.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createSelfHealingAccountResolver } from "../src/features/reviewers/account-resolution";
+import type { Account } from "../src/storage/accounts";
+
+const resolveAccountForRepoMock = vi.hoisted(() => vi.fn());
+const listAccountsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/storage/accounts", () => ({
+  resolveAccountForRepo: resolveAccountForRepoMock,
+  listAccounts: listAccountsMock,
+}));
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    id: "acc-1",
+    login: "reviewer",
+    avatarUrl: null,
+    token: "ghu_x",
+    createdAt: 1,
+    installations: [],
+    installationsRefreshedAt: 1,
+    invalidated: false,
+    invalidatedReason: null,
+    refreshToken: "ghr_x",
+    expiresAt: null,
+    refreshTokenExpiresAt: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resolveAccountForRepoMock.mockReset();
+  listAccountsMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createSelfHealingAccountResolver", () => {
+  it("returns the cached-resolution result without refreshing when an account already covers the repo", async () => {
+    const account = makeAccount();
+    resolveAccountForRepoMock.mockResolvedValueOnce(account);
+    const requestRefresh = vi.fn();
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    const result = await resolver.resolveAccount("acme", "widgets");
+
+    expect(result).toBe(account);
+    expect(listAccountsMock).not.toHaveBeenCalled();
+    expect(requestRefresh).not.toHaveBeenCalled();
+  });
+
+  it("returns null without refreshing when no account has any installation on the owner", async () => {
+    resolveAccountForRepoMock.mockResolvedValueOnce(null);
+    listAccountsMock.mockResolvedValueOnce([
+      makeAccount({
+        id: "acc-other",
+        installations: [
+          {
+            id: 1,
+            account: { login: "different-org", type: "Organization", avatarUrl: null },
+            repositorySelection: "all",
+            repoFullNames: null,
+          },
+        ],
+      }),
+    ]);
+    const requestRefresh = vi.fn();
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    const result = await resolver.resolveAccount("acme", "widgets");
+
+    expect(result).toBeNull();
+    expect(requestRefresh).not.toHaveBeenCalled();
+  });
+
+  it("triggers a refresh for an account with a stale 'selected' installation on the owner and re-resolves", async () => {
+    const accountAfter = makeAccount({
+      id: "acc-stale",
+      installations: [
+        {
+          id: 7,
+          account: { login: "acme", type: "Organization", avatarUrl: null },
+          repositorySelection: "selected",
+          repoFullNames: ["acme/widgets"],
+        },
+      ],
+    });
+    const accountBefore = makeAccount({
+      id: "acc-stale",
+      installations: [
+        {
+          id: 7,
+          account: { login: "acme", type: "Organization", avatarUrl: null },
+          repositorySelection: "selected",
+          repoFullNames: ["acme/legacy"],
+        },
+      ],
+    });
+    resolveAccountForRepoMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(accountAfter);
+    listAccountsMock.mockResolvedValueOnce([accountBefore]);
+    const requestRefresh = vi.fn().mockResolvedValue(true);
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    const result = await resolver.resolveAccount("acme", "widgets");
+
+    expect(requestRefresh).toHaveBeenCalledTimes(1);
+    expect(requestRefresh).toHaveBeenCalledWith("acc-stale");
+    expect(result).toBe(accountAfter);
+    expect(resolveAccountForRepoMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a 'selected' installation with a missing repoFullNames list as a stale candidate", async () => {
+    resolveAccountForRepoMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    listAccountsMock.mockResolvedValueOnce([
+      makeAccount({
+        id: "acc-empty",
+        installations: [
+          {
+            id: 4,
+            account: { login: "acme", type: "Organization", avatarUrl: null },
+            repositorySelection: "selected",
+            repoFullNames: null,
+          },
+        ],
+      }),
+    ]);
+    const requestRefresh = vi.fn().mockResolvedValue(true);
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    await resolver.resolveAccount("acme", "widgets");
+
+    expect(requestRefresh).toHaveBeenCalledWith("acc-empty");
+  });
+
+  it("skips invalidated accounts when picking refresh candidates", async () => {
+    resolveAccountForRepoMock.mockResolvedValueOnce(null);
+    listAccountsMock.mockResolvedValueOnce([
+      makeAccount({
+        id: "acc-dead",
+        invalidated: true,
+        installations: [
+          {
+            id: 1,
+            account: { login: "acme", type: "Organization", avatarUrl: null },
+            repositorySelection: "selected",
+            repoFullNames: [],
+          },
+        ],
+      }),
+    ]);
+    const requestRefresh = vi.fn().mockResolvedValue(true);
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    const result = await resolver.resolveAccount("acme", "widgets");
+
+    expect(requestRefresh).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it("refreshes each candidate account at most once per page session, even across many calls", async () => {
+    resolveAccountForRepoMock.mockResolvedValue(null);
+    listAccountsMock.mockResolvedValue([
+      makeAccount({
+        id: "acc-stale",
+        installations: [
+          {
+            id: 7,
+            account: { login: "acme", type: "Organization", avatarUrl: null },
+            repositorySelection: "selected",
+            repoFullNames: [],
+          },
+        ],
+      }),
+    ]);
+    const requestRefresh = vi.fn().mockResolvedValue(true);
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    await resolver.resolveAccount("acme", "widgets");
+    await resolver.resolveAccount("acme", "gadgets");
+    await resolver.resolveAccount("acme", "trinkets");
+
+    expect(requestRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes concurrent calls into a single in-flight refresh per account", async () => {
+    resolveAccountForRepoMock.mockResolvedValue(null);
+    listAccountsMock.mockResolvedValue([
+      makeAccount({
+        id: "acc-stale",
+        installations: [
+          {
+            id: 7,
+            account: { login: "acme", type: "Organization", avatarUrl: null },
+            repositorySelection: "selected",
+            repoFullNames: [],
+          },
+        ],
+      }),
+    ]);
+    let resolveRefresh: (value: boolean) => void = () => {};
+    const requestRefresh = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    const a = resolver.resolveAccount("acme", "widgets");
+    const b = resolver.resolveAccount("acme", "gadgets");
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    resolveRefresh(true);
+    await Promise.all([a, b]);
+
+    expect(requestRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches the owner case-insensitively when finding refresh candidates", async () => {
+    resolveAccountForRepoMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    listAccountsMock.mockResolvedValueOnce([
+      makeAccount({
+        id: "acc-mixed",
+        installations: [
+          {
+            id: 11,
+            account: { login: "AcMe", type: "Organization", avatarUrl: null },
+            repositorySelection: "selected",
+            repoFullNames: [],
+          },
+        ],
+      }),
+    ]);
+    const requestRefresh = vi.fn().mockResolvedValue(true);
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    await resolver.resolveAccount("acme", "widgets");
+
+    expect(requestRefresh).toHaveBeenCalledWith("acc-mixed");
+  });
+
+  it("does not call requestRefresh when the only matching installation already covers the repo (defensive guard)", async () => {
+    // resolveAccountForRepo would have returned the account here, so this is
+    // belt-and-suspenders: if listAccounts shows a matching repo for an
+    // installation, we should not flag that account as stale.
+    resolveAccountForRepoMock.mockResolvedValueOnce(null);
+    listAccountsMock.mockResolvedValueOnce([
+      makeAccount({
+        id: "acc-fresh",
+        installations: [
+          {
+            id: 5,
+            account: { login: "acme", type: "Organization", avatarUrl: null },
+            repositorySelection: "selected",
+            repoFullNames: ["acme/widgets"],
+          },
+        ],
+      }),
+    ]);
+    const requestRefresh = vi.fn();
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    await resolver.resolveAccount("acme", "widgets");
+
+    expect(requestRefresh).not.toHaveBeenCalled();
+  });
+
+  it("does not retry resolveAccountForRepo when no candidates were refreshed", async () => {
+    resolveAccountForRepoMock.mockResolvedValueOnce(null);
+    listAccountsMock.mockResolvedValueOnce([]);
+    const requestRefresh = vi.fn();
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    const result = await resolver.resolveAccount("acme", "widgets");
+
+    expect(result).toBeNull();
+    expect(resolveAccountForRepoMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still re-resolves and returns null when a refresh succeeds but does not heal coverage", async () => {
+    resolveAccountForRepoMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    listAccountsMock.mockResolvedValueOnce([
+      makeAccount({
+        id: "acc-stale",
+        installations: [
+          {
+            id: 7,
+            account: { login: "acme", type: "Organization", avatarUrl: null },
+            repositorySelection: "selected",
+            repoFullNames: [],
+          },
+        ],
+      }),
+    ]);
+    const requestRefresh = vi.fn().mockResolvedValue(true);
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    const result = await resolver.resolveAccount("acme", "widgets");
+
+    expect(result).toBeNull();
+    expect(resolveAccountForRepoMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -14,6 +14,8 @@ const {
   listAccountsMock,
   markAccountInvalidatedMock,
   createRefreshCoordinatorMock,
+  refreshAccountInstallationsMock,
+  createInstallationRefreshServiceMock,
   getGitHubAppConfigMock,
 } = vi.hoisted(() => ({
   refreshAccountTokenMock: vi.fn(),
@@ -22,14 +24,23 @@ const {
   listAccountsMock: vi.fn<() => Promise<unknown[]>>(),
   markAccountInvalidatedMock: vi.fn(),
   createRefreshCoordinatorMock: vi.fn(),
+  refreshAccountInstallationsMock: vi.fn(),
+  createInstallationRefreshServiceMock: vi.fn(),
   getGitHubAppConfigMock: vi.fn(() => ({ clientId: "test-client-id" })),
 }));
 createRefreshCoordinatorMock.mockImplementation(() => ({
   refreshAccountToken: refreshAccountTokenMock,
 }));
+createInstallationRefreshServiceMock.mockImplementation(() => ({
+  refreshAccountInstallations: refreshAccountInstallationsMock,
+}));
 
 vi.mock("../src/auth/refresh-coordinator", () => ({
   createRefreshCoordinator: createRefreshCoordinatorMock,
+}));
+
+vi.mock("../src/background/installation-refresh", () => ({
+  createInstallationRefreshService: createInstallationRefreshServiceMock,
 }));
 
 vi.mock("../src/config/github-app", () => ({
@@ -95,7 +106,9 @@ beforeEach(() => {
   listAccountsMock.mockReset().mockResolvedValue([]);
   markAccountInvalidatedMock.mockReset();
   refreshAccountTokenMock.mockResolvedValue({ ok: true, token: "new-token" });
+  refreshAccountInstallationsMock.mockReset().mockResolvedValue({ ok: true });
   createRefreshCoordinatorMock.mockClear();
+  createInstallationRefreshServiceMock.mockClear();
   getGitHubAppConfigMock.mockClear();
   alarmsCreateMock.mockClear();
   capturedMessageListener = null;
@@ -588,6 +601,70 @@ describe("background runtime.onMessage handler", () => {
       throw new Error("expected background fetch signal");
     }
     expect(signal.aborted).toBe(true);
+  });
+});
+
+describe("background refreshAccountInstallations dispatch", () => {
+  it("dispatches valid refresh-installations messages from this extension", async () => {
+    const listener = await bootBackground();
+
+    const response = await callListener(
+      listener,
+      { type: "refreshAccountInstallations", accountId: "acc-1" },
+      { id: SELF_RUNTIME_ID },
+    );
+
+    expect(refreshAccountInstallationsMock).toHaveBeenCalledTimes(1);
+    expect(refreshAccountInstallationsMock).toHaveBeenCalledWith("acc-1");
+    expect(response).toEqual({ ok: true });
+  });
+
+  it("returns the failure outcome from the installation-refresh service", async () => {
+    refreshAccountInstallationsMock.mockResolvedValueOnce({
+      ok: false,
+      reason: "failed",
+    });
+    const listener = await bootBackground();
+
+    const response = await callListener(
+      listener,
+      { type: "refreshAccountInstallations", accountId: "acc-1" },
+      { id: SELF_RUNTIME_ID },
+    );
+
+    expect(response).toEqual({ ok: false, reason: "failed" });
+  });
+
+  it("rejects refresh-installations messages from a foreign extension id", async () => {
+    const listener = await bootBackground();
+
+    const response = await callListener(
+      listener,
+      { type: "refreshAccountInstallations", accountId: "acc-1" },
+      { id: "other-extension-id" },
+    );
+
+    expect(response).toBeUndefined();
+    expect(refreshAccountInstallationsMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores malformed refresh-installations messages", async () => {
+    const listener = await bootBackground();
+
+    const missingAccountId = await callListener(
+      listener,
+      { type: "refreshAccountInstallations" },
+      { id: SELF_RUNTIME_ID },
+    );
+    const emptyAccountId = await callListener(
+      listener,
+      { type: "refreshAccountInstallations", accountId: "" },
+      { id: SELF_RUNTIME_ID },
+    );
+
+    expect(missingAccountId).toBeUndefined();
+    expect(emptyAccountId).toBeUndefined();
+    expect(refreshAccountInstallationsMock).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/installation-refresh.test.ts
+++ b/tests/installation-refresh.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as authModule from "../src/github/auth";
+import { createInstallationRefreshService } from "../src/background/installation-refresh";
+import type { Account, Installation } from "../src/storage/accounts";
+
+type AuthModule = typeof authModule;
+
+const getAccountByIdMock = vi.hoisted(() => vi.fn());
+const replaceInstallationsMock = vi.hoisted(() => vi.fn());
+const markAccountInvalidatedMock = vi.hoisted(() => vi.fn());
+const refreshAccountTokenMock = vi.hoisted(() => vi.fn());
+const fetchUserInstallationsMock = vi.hoisted(() => vi.fn());
+const fetchInstallationRepositoriesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/storage/accounts", () => ({
+  getAccountById: getAccountByIdMock,
+  replaceInstallations: replaceInstallationsMock,
+  markAccountInvalidated: markAccountInvalidatedMock,
+}));
+
+vi.mock("../src/github/auth", async () => {
+  const actual = await vi.importActual<AuthModule>("../src/github/auth");
+  return {
+    ...actual,
+    fetchUserInstallations: fetchUserInstallationsMock,
+    fetchInstallationRepositories: fetchInstallationRepositoriesMock,
+  };
+});
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    id: "acc-1",
+    login: "octocat",
+    avatarUrl: null,
+    token: "ghu_old",
+    createdAt: 1,
+    installations: [],
+    installationsRefreshedAt: 1,
+    invalidated: false,
+    invalidatedReason: null,
+    refreshToken: "ghr_old",
+    expiresAt: null,
+    refreshTokenExpiresAt: null,
+    ...overrides,
+  };
+}
+
+function makeApiInstallation(overrides: {
+  id: number;
+  login: string;
+  repositorySelection: "all" | "selected";
+}): {
+  id: number;
+  account: { login: string; type: "User" | "Organization"; avatarUrl: string | null };
+  repositorySelection: "all" | "selected";
+} {
+  return {
+    id: overrides.id,
+    account: {
+      login: overrides.login,
+      type: "Organization",
+      avatarUrl: null,
+    },
+    repositorySelection: overrides.repositorySelection,
+  };
+}
+
+const refreshCoordinatorMock = {
+  refreshAccountToken: refreshAccountTokenMock,
+};
+
+beforeEach(() => {
+  getAccountByIdMock.mockReset();
+  replaceInstallationsMock.mockReset().mockResolvedValue(undefined);
+  markAccountInvalidatedMock.mockReset().mockResolvedValue(undefined);
+  refreshAccountTokenMock.mockReset();
+  fetchUserInstallationsMock.mockReset();
+  fetchInstallationRepositoriesMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createInstallationRefreshService", () => {
+  it("fetches installations + selected-repo lists with the account token and persists them", async () => {
+    getAccountByIdMock.mockResolvedValue(makeAccount({ token: "ghu_live" }));
+    fetchUserInstallationsMock.mockResolvedValue([
+      makeApiInstallation({ id: 1, login: "acme", repositorySelection: "selected" }),
+      makeApiInstallation({ id: 2, login: "octocat", repositorySelection: "all" }),
+    ]);
+    fetchInstallationRepositoriesMock.mockResolvedValue(["acme/widgets", "acme/legacy"]);
+
+    const service = createInstallationRefreshService({
+      refreshCoordinator: refreshCoordinatorMock,
+    });
+    const outcome = await service.refreshAccountInstallations("acc-1");
+
+    expect(outcome).toEqual({ ok: true });
+    expect(fetchUserInstallationsMock).toHaveBeenCalledWith({ token: "ghu_live" });
+    expect(fetchInstallationRepositoriesMock).toHaveBeenCalledTimes(1);
+    expect(fetchInstallationRepositoriesMock).toHaveBeenCalledWith({
+      token: "ghu_live",
+      installationId: 1,
+    });
+
+    expect(replaceInstallationsMock).toHaveBeenCalledTimes(1);
+    const [accountId, installations] = replaceInstallationsMock.mock.calls[0] as [
+      string,
+      Installation[],
+    ];
+    expect(accountId).toBe("acc-1");
+    expect(installations).toEqual([
+      {
+        id: 1,
+        account: { login: "acme", type: "Organization", avatarUrl: null },
+        repositorySelection: "selected",
+        repoFullNames: ["acme/widgets", "acme/legacy"],
+      },
+      {
+        id: 2,
+        account: { login: "octocat", type: "Organization", avatarUrl: null },
+        repositorySelection: "all",
+        repoFullNames: null,
+      },
+    ]);
+  });
+
+  it("returns ok:false reason=no-account when the account has been removed", async () => {
+    getAccountByIdMock.mockResolvedValue(null);
+
+    const service = createInstallationRefreshService({
+      refreshCoordinator: refreshCoordinatorMock,
+    });
+    const outcome = await service.refreshAccountInstallations("missing");
+
+    expect(outcome).toEqual({ ok: false, reason: "no-account" });
+    expect(fetchUserInstallationsMock).not.toHaveBeenCalled();
+    expect(replaceInstallationsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns ok:false reason=invalidated for an invalidated account without trying to fetch", async () => {
+    getAccountByIdMock.mockResolvedValue(
+      makeAccount({ invalidated: true, invalidatedReason: "revoked" }),
+    );
+
+    const service = createInstallationRefreshService({
+      refreshCoordinator: refreshCoordinatorMock,
+    });
+    const outcome = await service.refreshAccountInstallations("acc-1");
+
+    expect(outcome).toEqual({ ok: false, reason: "invalidated" });
+    expect(fetchUserInstallationsMock).not.toHaveBeenCalled();
+    expect(replaceInstallationsMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the access token on a 401 and retries the fetch with the new token", async () => {
+    getAccountByIdMock
+      .mockResolvedValueOnce(makeAccount({ token: "ghu_old" }))
+      .mockResolvedValueOnce(makeAccount({ token: "ghu_new" }));
+    fetchUserInstallationsMock
+      .mockRejectedValueOnce(Object.assign(new Error("401"), { status: 401 }))
+      .mockResolvedValueOnce([
+        makeApiInstallation({ id: 7, login: "acme", repositorySelection: "all" }),
+      ]);
+    refreshAccountTokenMock.mockResolvedValue({ ok: true, token: "ghu_new" });
+
+    const service = createInstallationRefreshService({
+      refreshCoordinator: refreshCoordinatorMock,
+    });
+    const outcome = await service.refreshAccountInstallations("acc-1");
+
+    expect(outcome).toEqual({ ok: true });
+    expect(fetchUserInstallationsMock).toHaveBeenCalledTimes(2);
+    expect(fetchUserInstallationsMock.mock.calls[0][0]).toEqual({ token: "ghu_old" });
+    expect(fetchUserInstallationsMock.mock.calls[1][0]).toEqual({ token: "ghu_new" });
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-1");
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+    expect(replaceInstallationsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates the account when the retry after token refresh still fails with 401", async () => {
+    getAccountByIdMock.mockResolvedValue(makeAccount({ token: "ghu_old" }));
+    fetchUserInstallationsMock.mockRejectedValue(
+      Object.assign(new Error("401"), { status: 401 }),
+    );
+    refreshAccountTokenMock.mockResolvedValue({ ok: true, token: "ghu_new" });
+
+    const service = createInstallationRefreshService({
+      refreshCoordinator: refreshCoordinatorMock,
+    });
+    const outcome = await service.refreshAccountInstallations("acc-1");
+
+    expect(outcome).toEqual({ ok: false, reason: "failed" });
+    expect(markAccountInvalidatedMock).toHaveBeenCalledWith("acc-1", "revoked");
+    expect(replaceInstallationsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns ok:false reason=failed without invalidation when token refresh is transiently unavailable", async () => {
+    getAccountByIdMock.mockResolvedValue(makeAccount({ token: "ghu_old" }));
+    fetchUserInstallationsMock.mockRejectedValue(
+      Object.assign(new Error("401"), { status: 401 }),
+    );
+    refreshAccountTokenMock.mockResolvedValue({ ok: false, terminal: false });
+
+    const service = createInstallationRefreshService({
+      refreshCoordinator: refreshCoordinatorMock,
+    });
+    const outcome = await service.refreshAccountInstallations("acc-1");
+
+    expect(outcome).toEqual({ ok: false, reason: "failed" });
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+    expect(replaceInstallationsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns ok:false reason=failed when the account has no refresh token and the initial fetch is unauthorized", async () => {
+    getAccountByIdMock.mockResolvedValue(
+      makeAccount({ refreshToken: null, token: "ghu_dead" }),
+    );
+    fetchUserInstallationsMock.mockRejectedValue(
+      Object.assign(new Error("401"), { status: 401 }),
+    );
+
+    const service = createInstallationRefreshService({
+      refreshCoordinator: refreshCoordinatorMock,
+    });
+    const outcome = await service.refreshAccountInstallations("acc-1");
+
+    expect(outcome).toEqual({ ok: false, reason: "failed" });
+    expect(refreshAccountTokenMock).not.toHaveBeenCalled();
+    expect(markAccountInvalidatedMock).toHaveBeenCalledWith("acc-1", "revoked");
+  });
+
+  it("returns ok:false reason=failed and does not persist when the API throws a non-401 error", async () => {
+    getAccountByIdMock.mockResolvedValue(makeAccount());
+    fetchUserInstallationsMock.mockRejectedValue(new Error("network down"));
+
+    const service = createInstallationRefreshService({
+      refreshCoordinator: refreshCoordinatorMock,
+    });
+    const outcome = await service.refreshAccountInstallations("acc-1");
+
+    expect(outcome).toEqual({ ok: false, reason: "failed" });
+    expect(refreshAccountTokenMock).not.toHaveBeenCalled();
+    expect(replaceInstallationsMock).not.toHaveBeenCalled();
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+  });
+
+  it("dedupes concurrent refresh calls for the same account into a single API run", async () => {
+    getAccountByIdMock.mockResolvedValue(makeAccount());
+    let resolveFetch: (value: ReturnType<typeof makeApiInstallation>[]) => void = () => {};
+    fetchUserInstallationsMock.mockImplementation(
+      () =>
+        new Promise<ReturnType<typeof makeApiInstallation>[]>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    const service = createInstallationRefreshService({
+      refreshCoordinator: refreshCoordinatorMock,
+    });
+    const a = service.refreshAccountInstallations("acc-1");
+    const b = service.refreshAccountInstallations("acc-1");
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    resolveFetch([
+      makeApiInstallation({ id: 9, login: "acme", repositorySelection: "all" }),
+    ]);
+
+    const [outcomeA, outcomeB] = await Promise.all([a, b]);
+
+    expect(outcomeA).toEqual({ ok: true });
+    expect(outcomeB).toEqual({ ok: true });
+    expect(getAccountByIdMock).toHaveBeenCalledTimes(1);
+    expect(fetchUserInstallationsMock).toHaveBeenCalledTimes(1);
+    expect(replaceInstallationsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts a fresh refresh for the same account after the previous one settles", async () => {
+    getAccountByIdMock.mockResolvedValue(makeAccount());
+    fetchUserInstallationsMock.mockResolvedValue([]);
+
+    const service = createInstallationRefreshService({
+      refreshCoordinator: refreshCoordinatorMock,
+    });
+    await service.refreshAccountInstallations("acc-1");
+    await service.refreshAccountInstallations("acc-1");
+
+    expect(fetchUserInstallationsMock).toHaveBeenCalledTimes(2);
+    expect(replaceInstallationsMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -6,11 +6,13 @@ import type { PullReviewerSummary } from "../src/github/api";
 import type * as PreferencesModule from "../src/storage/preferences";
 
 const resolveAccountForRepoMock = vi.fn();
+const listAccountsMock = vi.fn();
 const getPreferencesMock = vi.fn();
 const runtimeSendMessageMock = vi.fn();
 
 vi.mock("../src/storage/accounts", () => ({
   resolveAccountForRepo: resolveAccountForRepoMock,
+  listAccounts: listAccountsMock,
 }));
 
 vi.mock("../src/storage/preferences", async () => {
@@ -64,6 +66,7 @@ function getRegisteredListener(
 beforeEach(() => {
   vi.resetModules();
   resolveAccountForRepoMock.mockReset();
+  listAccountsMock.mockReset().mockResolvedValue([]);
   getPreferencesMock.mockReset();
   runtimeSendMessageMock.mockReset();
   getPreferencesMock.mockResolvedValue({


### PR DESCRIPTION
## Summary

- Wraps the per-row account resolution with a self-healing path: when `resolveAccountForRepo` misses, the resolver scans for accounts that own a `selected` installation on the same owner but do not list the repo, sends a new `refreshAccountInstallations` background message, and re-resolves.
- Adds `createInstallationRefreshService` (background) that holds the token, refreshes installations + selected-repo lists, retries via `RefreshCoordinator` on a 401, persists through `replaceInstallations`, and dedupes concurrent calls per `accountId`. Tokens never enter the content-script context.
- Each candidate account is refreshed at most once per page session and concurrent in-flight refreshes share a single promise. A successful refresh writes to `account:installations:*`, which the existing `accountsChange` storage listener picks up to clear the row cache and re-render.

Closes #41

## Test plan

- [x] `pnpm test` (290 vitest tests, including new `installation-refresh` and `account-resolution` suites and refreshed `background.test.ts` wiring)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Reviewer manually adds a repo to an existing GitHub App installation outside the extension and confirms the row resolves into reviewer chips on next page open without an explicit `Refresh installations` click