### PR TITLE
feat(access-banner): enrich rate-limit copy with limit + reset details

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -78,8 +78,9 @@ For rate-limit kinds (`auth-rate-limit`, `unauth-rate-limit`), the GitHub
 response's `x-ratelimit-limit / -remaining / -reset / -resource` headers ride
 with the failure envelope (`ReviewerFetchFailure.rateLimit`) into the
 aggregator, so the banner can report `(used/limit)` and a relative reset
-time. Callers fall back to the static copy whenever the snapshot is missing
-or partial. The snapshot is in-memory only — it is never persisted.
+time. Callers fall back segment-by-segment: missing limit/remaining omits the
+usage clause, and a missing reset timestamp keeps the static reset copy. The
+snapshot is in-memory only — it is never persisted.
 
 ## Proactive token refresh
 

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -74,6 +74,13 @@ kind seen on a page wins.
 Banner dismissal is keyed by `pathname + kind`, so dismissing one kind on a page
 does not suppress a later, higher-priority kind on the same page.
 
+For rate-limit kinds (`auth-rate-limit`, `unauth-rate-limit`), the GitHub
+response's `x-ratelimit-limit / -remaining / -reset / -resource` headers ride
+with the failure envelope (`ReviewerFetchFailure.rateLimit`) into the
+aggregator, so the banner can report `(used/limit)` and a relative reset
+time. Callers fall back to the static copy whenever the snapshot is missing
+or partial. The snapshot is in-memory only — it is never persisted.
+
 ## Proactive token refresh
 
 - A recurring `chrome.alarms` job (15-minute period, 30-minute refresh threshold) pre-warms access tokens before the reactive 401 path is needed, and invalidates accounts whose refresh token has already expired.

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -82,16 +82,30 @@ function classifyRowFailure(
   for (const failure of failures) {
     const kind = classifyFailure(failure, account);
     if (kind == null) continue;
-    if (best != null && !isHigherPriority(kind, best.kind)) continue;
+    if (best != null && !isHigherPriority(kind, best.kind)) {
+      if (
+        kind === best.kind &&
+        isRateLimitKind(kind) &&
+        best.info?.rateLimit == null &&
+        failure.rateLimit != null
+      ) {
+        best = { kind, info: { rateLimit: failure.rateLimit } };
+      }
+      continue;
+    }
     best = {
       kind,
       info:
-        kind === "auth-rate-limit" || kind === "unauth-rate-limit"
+        isRateLimitKind(kind)
           ? { rateLimit: failure.rateLimit }
           : undefined,
     };
   }
   return best;
+}
+
+function isRateLimitKind(kind: BannerKind): boolean {
+  return kind === "auth-rate-limit" || kind === "unauth-rate-limit";
 }
 
 function classifyFailure(

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -2,7 +2,10 @@ import {
   bootAccessBanner,
   type AccessBannerHandle,
 } from "../src/features/access-banner";
-import type { BannerKind } from "../src/features/access-banner/aggregator";
+import type {
+  BannerFailureInfo,
+  BannerKind,
+} from "../src/features/access-banner/aggregator";
 import { isHigherPriority } from "../src/features/access-banner/aggregator";
 import { bootReviewerListPage } from "../src/features/reviewers";
 import { parsePullListRoute } from "../src/github/routes";
@@ -38,15 +41,15 @@ export default defineContentScript({
               return;
             }
 
-            const kind = classifyRowFailure(error, account);
-            if (kind == null) {
+            const classified = classifyRowFailure(error, account);
+            if (classified == null) {
               console.warn(
                 "[ghpsr] Unclassified reviewer-fetch failure; banner suppressed.",
                 error,
               );
               return;
             }
-            aggregator.reportFailure(kind);
+            aggregator.reportFailure(classified.kind, classified.info);
           },
         });
       }
@@ -61,21 +64,32 @@ export default defineContentScript({
   },
 });
 
+type ClassifiedRowFailure = {
+  kind: BannerKind;
+  info?: BannerFailureInfo;
+};
+
 function classifyRowFailure(
   error: unknown,
   account: { id?: string } | null,
-): BannerKind | null {
+): ClassifiedRowFailure | null {
   const failures = extractReviewerFetchFailures(error);
   if (failures.length === 0) {
     return null;
   }
 
-  let best: BannerKind | null = null;
+  let best: ClassifiedRowFailure | null = null;
   for (const failure of failures) {
     const kind = classifyFailure(failure, account);
-    if (kind != null && isHigherPriority(kind, best)) {
-      best = kind;
-    }
+    if (kind == null) continue;
+    if (best != null && !isHigherPriority(kind, best.kind)) continue;
+    best = {
+      kind,
+      info:
+        kind === "auth-rate-limit" || kind === "unauth-rate-limit"
+          ? { rateLimit: failure.rateLimit }
+          : undefined,
+    };
   }
   return best;
 }

--- a/src/features/access-banner/aggregator.ts
+++ b/src/features/access-banner/aggregator.ts
@@ -7,16 +7,28 @@ export type BannerKind =
   | "unauth-rate-limit"
   | "signin-required";
 
+export type BannerRateLimitSnapshot = {
+  limit: number | null;
+  remaining: number | null;
+  resource: string | null;
+  resetAt: number | null;
+};
+
+export type BannerFailureInfo = {
+  rateLimit?: BannerRateLimitSnapshot;
+};
+
 export type BannerState = {
   current: BannerKind | null;
   dismissed: boolean;
   repo: BannerRepo;
+  rateLimit?: BannerRateLimitSnapshot;
 };
 
 export type BannerAggregator = {
   getState(): BannerState;
   subscribe(listener: (state: BannerState) => void): () => void;
-  reportFailure(kind: BannerKind): void;
+  reportFailure(kind: BannerKind, info?: BannerFailureInfo): void;
   dismiss(): void;
 };
 
@@ -47,11 +59,14 @@ export function createBannerAggregator(options: {
     name: options.repo.name,
   };
   let current: BannerKind | null = null;
+  let rateLimit: BannerRateLimitSnapshot | undefined;
   let dismissed = readDismissed(options.pathname, current);
   const listeners = new Set<(state: BannerState) => void>();
 
   function snapshot(): BannerState {
-    return { current, dismissed, repo };
+    return rateLimit == null
+      ? { current, dismissed, repo }
+      : { current, dismissed, repo, rateLimit };
   }
 
   function emit(): void {
@@ -68,11 +83,25 @@ export function createBannerAggregator(options: {
         listeners.delete(listener);
       };
     },
-    reportFailure(kind) {
+    reportFailure(kind, info) {
+      if (kind === current) {
+        // Same kind already active: keep the first non-empty rate-limit
+        // snapshot we received and avoid emitting a no-op.
+        if (rateLimit == null && info?.rateLimit != null) {
+          rateLimit = info.rateLimit;
+          emit();
+        }
+        return;
+      }
       if (!isHigherPriority(kind, current)) {
         return;
       }
       current = kind;
+      // Only carry rate-limit info on rate-limit kinds; clear it for others.
+      rateLimit =
+        kind === "auth-rate-limit" || kind === "unauth-rate-limit"
+          ? info?.rateLimit
+          : undefined;
       dismissed = readDismissed(options.pathname, current);
       emit();
     },
@@ -107,20 +136,73 @@ function readDismissed(pathname: string, kind: BannerKind | null): boolean {
 }
 
 export function formatBannerMessage(
-  state: Pick<BannerState, "current" | "repo">,
+  state: Pick<BannerState, "current" | "repo" | "rateLimit">,
+  options?: { now?: () => number },
 ): string {
   switch (state.current) {
     case "auth-expired":
       return "Your GitHub session expired. Sign in again to keep loading reviewers.";
     case "app-uncovered":
       return `Add ${state.repo.owner}/${state.repo.name} to @${state.repo.owner}'s GitHub App installation to see reviewers on this page.`;
-    case "auth-rate-limit":
-      return "GitHub's hourly request limit was reached. Reviewers will resume automatically when the limit resets.";
-    case "unauth-rate-limit":
-      return "GitHub's unauthenticated request limit (60/hr) was reached. Sign in to raise it to 5,000/hr.";
+    case "auth-rate-limit": {
+      const usage = formatUsageClause(state.rateLimit);
+      const reset = formatResetClause(state.rateLimit, options?.now);
+      const usageSegment = usage ? ` ${usage}` : "";
+      const resetSegment = reset
+        ? ` Reviewers will resume ${reset}.`
+        : " Reviewers will resume automatically when the limit resets.";
+      return `GitHub's hourly request limit was reached.${usageSegment}${resetSegment}`;
+    }
+    case "unauth-rate-limit": {
+      const usage = formatUsageClause(state.rateLimit);
+      const reset = formatResetClause(state.rateLimit, options?.now);
+      const usageSegment = usage
+        ? ` ${usage}`
+        : " (60/hr unauthenticated cap)";
+      const resetSegment = reset ? ` Resets ${reset}.` : "";
+      return `GitHub's unauthenticated request limit was reached.${usageSegment} Sign in to raise it to 5,000/hr.${resetSegment}`;
+    }
     case "signin-required":
       return "Sign in with GitHub to see reviewers on private repositories.";
     case null:
       return "";
   }
+}
+
+function formatUsageClause(
+  rateLimit: BannerRateLimitSnapshot | undefined,
+): string {
+  if (
+    rateLimit?.limit == null ||
+    rateLimit.remaining == null ||
+    rateLimit.limit <= 0
+  ) {
+    return "";
+  }
+  const used = Math.max(0, rateLimit.limit - rateLimit.remaining);
+  return `(${used}/${rateLimit.limit} used)`;
+}
+
+function formatResetClause(
+  rateLimit: BannerRateLimitSnapshot | undefined,
+  now?: () => number,
+): string {
+  if (rateLimit?.resetAt == null) {
+    return "";
+  }
+  const resetAtMs = rateLimit.resetAt * 1000;
+  const nowMs = (now ?? Date.now)();
+  const deltaMs = resetAtMs - nowMs;
+  if (deltaMs <= 0) {
+    return "shortly";
+  }
+  const minutes = Math.ceil(deltaMs / 60_000);
+  if (minutes <= 1) {
+    return "in about 1 minute";
+  }
+  if (minutes < 60) {
+    return `in about ${minutes} minutes`;
+  }
+  const hours = Math.round(minutes / 60);
+  return hours === 1 ? "in about 1 hour" : `in about ${hours} hours`;
 }

--- a/src/runtime/reviewer-fetch.ts
+++ b/src/runtime/reviewer-fetch.ts
@@ -21,10 +21,18 @@ export type CancelPullReviewerSummaryMessage = {
   requestId: string;
 };
 
+export type ReviewerFetchRateLimitSnapshot = {
+  limit: number | null;
+  remaining: number | null;
+  resource: string | null;
+  resetAt: number | null;
+};
+
 export type ReviewerFetchFailure = {
   status: number;
   endpoint: string | null;
   rateLimited: boolean;
+  rateLimit?: ReviewerFetchRateLimitSnapshot;
 };
 
 export type ReviewerFetchErrorEnvelope = {
@@ -85,11 +93,7 @@ export function serializeReviewerFetchError(
     return {
       kind: "github-endpoints",
       status: extractGitHubApiStatus(error),
-      failures: error.failures.map((failure) => ({
-        status: failure.status,
-        endpoint: failure.endpoint?.path ?? null,
-        rateLimited: isRateLimitError(failure),
-      })),
+      failures: error.failures.map(toReviewerFetchFailure),
       message: error.message,
     };
   }
@@ -98,13 +102,7 @@ export function serializeReviewerFetchError(
     return {
       kind: "github-api",
       status: error.status,
-      failures: [
-        {
-          status: error.status,
-          endpoint: error.endpoint?.path ?? null,
-          rateLimited: isRateLimitError(error),
-        },
-      ],
+      failures: [toReviewerFetchFailure(error)],
       message: error.message,
     };
   }
@@ -139,21 +137,11 @@ export function extractReviewerFetchFailures(
   }
 
   if (error instanceof GitHubPullRequestEndpointsError) {
-    return error.failures.map((failure) => ({
-      status: failure.status,
-      endpoint: failure.endpoint?.path ?? null,
-      rateLimited: isRateLimitError(failure),
-    }));
+    return error.failures.map(toReviewerFetchFailure);
   }
 
   if (error instanceof GitHubApiError) {
-    return [
-      {
-        status: error.status,
-        endpoint: error.endpoint?.path ?? null,
-        rateLimited: isRateLimitError(error),
-      },
-    ];
+    return [toReviewerFetchFailure(error)];
   }
 
   if (
@@ -163,21 +151,33 @@ export function extractReviewerFetchFailures(
     Array.isArray((error as { failures: unknown }).failures)
   ) {
     return (
-      error as { failures: Array<{ status?: unknown; endpoint?: unknown; rateLimited?: unknown }> }
+      error as {
+        failures: Array<{
+          status?: unknown;
+          endpoint?: unknown;
+          rateLimited?: unknown;
+          rateLimit?: unknown;
+        }>;
+      }
     ).failures
       .filter(
         (failure): failure is {
           status: number;
           endpoint?: string | null;
           rateLimited?: boolean;
+          rateLimit?: unknown;
         } => typeof failure?.status === "number",
       )
-      .map((failure) => ({
-        status: failure.status,
-        endpoint:
-          typeof failure.endpoint === "string" ? failure.endpoint : null,
-        rateLimited: failure.rateLimited === true,
-      }));
+      .map((failure) => {
+        const base: ReviewerFetchFailure = {
+          status: failure.status,
+          endpoint:
+            typeof failure.endpoint === "string" ? failure.endpoint : null,
+          rateLimited: failure.rateLimited === true,
+        };
+        const rateLimit = parseRateLimitSnapshot(failure.rateLimit);
+        return rateLimit == null ? base : { ...base, rateLimit };
+      });
   }
 
   if (
@@ -196,6 +196,63 @@ export function extractReviewerFetchFailures(
   }
 
   return [];
+}
+
+function toReviewerFetchFailure(failure: GitHubApiError): ReviewerFetchFailure {
+  const base: ReviewerFetchFailure = {
+    status: failure.status,
+    endpoint: failure.endpoint?.path ?? null,
+    rateLimited: isRateLimitError(failure),
+  };
+  const rateLimit = readGitHubApiErrorRateLimit(failure);
+  return rateLimit == null ? base : { ...base, rateLimit };
+}
+
+function readGitHubApiErrorRateLimit(
+  failure: GitHubApiError,
+): ReviewerFetchRateLimitSnapshot | undefined {
+  const snapshot = failure.rateLimit;
+  if (snapshot == null) {
+    return undefined;
+  }
+  if (
+    snapshot.limit == null &&
+    snapshot.remaining == null &&
+    snapshot.resource == null &&
+    snapshot.resetAt == null
+  ) {
+    return undefined;
+  }
+  return {
+    limit: snapshot.limit,
+    remaining: snapshot.remaining,
+    resource: snapshot.resource,
+    resetAt: snapshot.resetAt,
+  };
+}
+
+function parseRateLimitSnapshot(
+  value: unknown,
+): ReviewerFetchRateLimitSnapshot | undefined {
+  if (value == null || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const candidate: ReviewerFetchRateLimitSnapshot = {
+    limit: typeof record.limit === "number" ? record.limit : null,
+    remaining: typeof record.remaining === "number" ? record.remaining : null,
+    resource: typeof record.resource === "string" ? record.resource : null,
+    resetAt: typeof record.resetAt === "number" ? record.resetAt : null,
+  };
+  if (
+    candidate.limit == null &&
+    candidate.remaining == null &&
+    candidate.resource == null &&
+    candidate.resetAt == null
+  ) {
+    return undefined;
+  }
+  return candidate;
 }
 
 function hasNonEmptyString(value: unknown): value is string {

--- a/tests/access-banner.test.ts
+++ b/tests/access-banner.test.ts
@@ -129,6 +129,91 @@ describe("bannerAggregator", () => {
     expect(b.getState().dismissed).toBe(false);
   });
 
+  it("carries the rate-limit snapshot when reportFailure is called with one", () => {
+    const aggregator = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
+    const snapshot = {
+      limit: 5000,
+      remaining: 0,
+      resource: "core",
+      resetAt: 1_700_000_300,
+    };
+    aggregator.reportFailure("auth-rate-limit", { rateLimit: snapshot });
+    expect(aggregator.getState()).toMatchObject({
+      current: "auth-rate-limit",
+      rateLimit: snapshot,
+    });
+  });
+
+  it("ignores info passed for non-rate-limit kinds", () => {
+    const aggregator = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
+    aggregator.reportFailure("auth-expired", {
+      rateLimit: { limit: 1, remaining: 0, resource: null, resetAt: null },
+    });
+    expect(aggregator.getState().rateLimit).toBeUndefined();
+  });
+
+  it("backfills the rate-limit snapshot when a later same-kind report carries one", () => {
+    const aggregator = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
+    aggregator.reportFailure("auth-rate-limit");
+    expect(aggregator.getState().rateLimit).toBeUndefined();
+    const snapshot = {
+      limit: 5000,
+      remaining: 0,
+      resource: "core",
+      resetAt: 1_700_000_300,
+    };
+    aggregator.reportFailure("auth-rate-limit", { rateLimit: snapshot });
+    expect(aggregator.getState().rateLimit).toEqual(snapshot);
+  });
+
+  it("keeps the first rate-limit snapshot when a later same-kind report has a different one", () => {
+    const aggregator = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
+    const first = {
+      limit: 5000,
+      remaining: 0,
+      resource: "core",
+      resetAt: 1_700_000_300,
+    };
+    const second = {
+      limit: 5000,
+      remaining: 1,
+      resource: "core",
+      resetAt: 1_700_001_000,
+    };
+    aggregator.reportFailure("auth-rate-limit", { rateLimit: first });
+    aggregator.reportFailure("auth-rate-limit", { rateLimit: second });
+    expect(aggregator.getState().rateLimit).toEqual(first);
+  });
+
+  it("clears the rate-limit snapshot when a higher-priority non-rate-limit kind takes over", () => {
+    const aggregator = createBannerAggregator({
+      pathname: "/cinev/shotloom/pulls",
+      repo: TEST_REPO,
+    });
+    aggregator.reportFailure("auth-rate-limit", {
+      rateLimit: {
+        limit: 5000,
+        remaining: 0,
+        resource: "core",
+        resetAt: 1_700_000_300,
+      },
+    });
+    aggregator.reportFailure("auth-expired");
+    expect(aggregator.getState().rateLimit).toBeUndefined();
+  });
+
   it("re-reads dismissed from storage when current is upgraded to a kind dismissed earlier", () => {
     const seed = createBannerAggregator({
       pathname: "/cinev/shotloom/pulls",
@@ -178,7 +263,104 @@ describe("formatBannerMessage", () => {
     expect(
       formatBannerMessage({ current: "unauth-rate-limit", repo: TEST_REPO }),
     ).toBe(
-      "GitHub's unauthenticated request limit (60/hr) was reached. Sign in to raise it to 5,000/hr.",
+      "GitHub's unauthenticated request limit was reached. (60/hr unauthenticated cap) Sign in to raise it to 5,000/hr.",
+    );
+  });
+
+  it("includes used/limit details for auth-rate-limit when a snapshot is present", () => {
+    expect(
+      formatBannerMessage(
+        {
+          current: "auth-rate-limit",
+          repo: TEST_REPO,
+          rateLimit: {
+            limit: 5000,
+            remaining: 0,
+            resource: "core",
+            resetAt: 1_700_000_300,
+          },
+        },
+        { now: () => 1_700_000_000 * 1000 }, // ~5 minutes before reset
+      ),
+    ).toBe(
+      "GitHub's hourly request limit was reached. (5000/5000 used) Reviewers will resume in about 5 minutes.",
+    );
+  });
+
+  it("includes used/limit details and reset time for unauth-rate-limit when a snapshot is present", () => {
+    expect(
+      formatBannerMessage(
+        {
+          current: "unauth-rate-limit",
+          repo: TEST_REPO,
+          rateLimit: {
+            limit: 60,
+            remaining: 0,
+            resource: "core",
+            resetAt: 1_700_000_300,
+          },
+        },
+        { now: () => 1_700_000_000 * 1000 },
+      ),
+    ).toBe(
+      "GitHub's unauthenticated request limit was reached. (60/60 used) Sign in to raise it to 5,000/hr. Resets in about 5 minutes.",
+    );
+  });
+
+  it("falls back to the limit-only segment when only the reset time is missing", () => {
+    expect(
+      formatBannerMessage({
+        current: "auth-rate-limit",
+        repo: TEST_REPO,
+        rateLimit: {
+          limit: 5000,
+          remaining: 0,
+          resource: "core",
+          resetAt: null,
+        },
+      }),
+    ).toBe(
+      "GitHub's hourly request limit was reached. (5000/5000 used) Reviewers will resume automatically when the limit resets.",
+    );
+  });
+
+  it("falls back to the reset-time segment when limit/remaining are missing", () => {
+    expect(
+      formatBannerMessage(
+        {
+          current: "auth-rate-limit",
+          repo: TEST_REPO,
+          rateLimit: {
+            limit: null,
+            remaining: null,
+            resource: null,
+            resetAt: 1_700_003_600,
+          },
+        },
+        { now: () => 1_700_000_000 * 1000 }, // ~1 hour before reset
+      ),
+    ).toBe(
+      "GitHub's hourly request limit was reached. Reviewers will resume in about 1 hour.",
+    );
+  });
+
+  it("uses 'shortly' when the reset time is already in the past", () => {
+    expect(
+      formatBannerMessage(
+        {
+          current: "auth-rate-limit",
+          repo: TEST_REPO,
+          rateLimit: {
+            limit: null,
+            remaining: null,
+            resource: null,
+            resetAt: 1_699_999_000,
+          },
+        },
+        { now: () => 1_700_000_000 * 1000 },
+      ),
+    ).toBe(
+      "GitHub's hourly request limit was reached. Reviewers will resume shortly.",
     );
   });
 

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -137,7 +137,10 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(401)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-expired");
+      expect(aggregator.reportFailure).toHaveBeenCalledWith(
+        "auth-expired",
+        undefined,
+      );
     });
 
     it("emits app-uncovered for account + 404 (no rate-limit signal)", async () => {
@@ -154,7 +157,10 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(404)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("app-uncovered");
+      expect(aggregator.reportFailure).toHaveBeenCalledWith(
+        "app-uncovered",
+        undefined,
+      );
     });
 
     it("emits app-uncovered for account + 403 without rate-limit signal", async () => {
@@ -173,10 +179,13 @@ describe("content entrypoint", () => {
         ]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("app-uncovered");
+      expect(aggregator.reportFailure).toHaveBeenCalledWith(
+        "app-uncovered",
+        undefined,
+      );
     });
 
-    it("emits auth-rate-limit for account + 403 with rate-limit headers", async () => {
+    it("emits auth-rate-limit with the response snapshot for account + 403 + rate-limit headers", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
       const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
@@ -197,10 +206,17 @@ describe("content entrypoint", () => {
         ]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit");
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit", {
+        rateLimit: {
+          limit: 5000,
+          remaining: 0,
+          resource: "core",
+          resetAt: 1,
+        },
+      });
     });
 
-    it("emits auth-rate-limit for account + 429", async () => {
+    it("emits auth-rate-limit without a snapshot for account + 429 with no headers", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
       const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
@@ -214,10 +230,12 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(429)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit");
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit", {
+        rateLimit: undefined,
+      });
     });
 
-    it("emits unauth-rate-limit for no account + 403 with rate-limit headers", async () => {
+    it("emits unauth-rate-limit with the response snapshot for no account + 403 + rate-limit headers", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
       const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
@@ -238,7 +256,17 @@ describe("content entrypoint", () => {
         ]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("unauth-rate-limit");
+      expect(aggregator.reportFailure).toHaveBeenCalledWith(
+        "unauth-rate-limit",
+        {
+          rateLimit: {
+            limit: 60,
+            remaining: 0,
+            resource: "core",
+            resetAt: 1,
+          },
+        },
+      );
     });
 
     it("emits signin-required for no account + 403 without rate-limit signal", async () => {
@@ -255,7 +283,10 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(403)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("signin-required");
+      expect(aggregator.reportFailure).toHaveBeenCalledWith(
+        "signin-required",
+        undefined,
+      );
     });
 
     it("emits signin-required for no account + 401", async () => {
@@ -272,10 +303,13 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(401)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("signin-required");
+      expect(aggregator.reportFailure).toHaveBeenCalledWith(
+        "signin-required",
+        undefined,
+      );
     });
 
-    it("emits unauth-rate-limit for no account + 429", async () => {
+    it("emits unauth-rate-limit without a snapshot for no account + 429 with no headers", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);
       const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
@@ -289,7 +323,10 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(429)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("unauth-rate-limit");
+      expect(aggregator.reportFailure).toHaveBeenCalledWith(
+        "unauth-rate-limit",
+        { rateLimit: undefined },
+      );
     });
 
     it("emits signin-required for no account + 404", async () => {
@@ -306,7 +343,10 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(404)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("signin-required");
+      expect(aggregator.reportFailure).toHaveBeenCalledWith(
+        "signin-required",
+        undefined,
+      );
     });
 
     it("picks the highest-priority kind across mixed failures (auth-expired wins over app-uncovered)", async () => {
@@ -327,7 +367,8 @@ describe("content entrypoint", () => {
       });
 
       expect(aggregator.reportFailure).toHaveBeenCalledTimes(1);
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-expired");
+      const [winningKind] = aggregator.reportFailure.mock.calls[0];
+      expect(winningKind).toBe("auth-expired");
     });
 
     it("does not emit any kind for unattributed errors (network, schema, unknown envelope, empty failures)", async () => {
@@ -367,12 +408,25 @@ describe("content entrypoint", () => {
               status: 403,
               endpoint: "/repos/cinev/shotloom/pulls/42",
               rateLimited: true,
+              rateLimit: {
+                limit: 5000,
+                remaining: 0,
+                resource: "core",
+                resetAt: 1_700_000_000,
+              },
             },
           ],
         },
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit");
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit", {
+        rateLimit: {
+          limit: 5000,
+          remaining: 0,
+          resource: "core",
+          resetAt: 1_700_000_000,
+        },
+      });
     });
   });
 });

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -235,6 +235,38 @@ describe("content entrypoint", () => {
       });
     });
 
+    it("backfills rate-limit details from a later same-kind failure", async () => {
+      const aggregator = makeAggregator();
+      const { onRowFailure } = await bootContent(aggregator);
+      const { GitHubApiError, GitHubPullRequestEndpointsError } = await import(
+        "../src/github/api"
+      );
+
+      onRowFailure({
+        owner: "cinev",
+        repo: "shotloom",
+        account: { id: "acc-1" },
+        error: new GitHubPullRequestEndpointsError([
+          new GitHubApiError(429),
+          new GitHubApiError(403, undefined, undefined, {
+            limit: 5000,
+            remaining: 0,
+            resource: "core",
+            resetAt: 1,
+          }),
+        ]),
+      });
+
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit", {
+        rateLimit: {
+          limit: 5000,
+          remaining: 0,
+          resource: "core",
+          resetAt: 1,
+        },
+      });
+    });
+
     it("emits unauth-rate-limit with the response snapshot for no account + 403 + rate-limit headers", async () => {
       const aggregator = makeAggregator();
       const { onRowFailure } = await bootContent(aggregator);

--- a/tests/reviewer-fetch.test.ts
+++ b/tests/reviewer-fetch.test.ts
@@ -18,7 +18,7 @@ const reviewsEndpoint = {
 };
 
 describe("serializeReviewerFetchError", () => {
-  it("flags rateLimited=true when the GitHubApiError signals rate-limit headers", () => {
+  it("flags rateLimited=true and carries the rate-limit snapshot when GitHub headers are present", () => {
     const error = new GitHubApiError(
       403,
       undefined,
@@ -30,11 +30,16 @@ describe("serializeReviewerFetchError", () => {
 
     expect(envelope.kind).toBe("github-api");
     expect(envelope.failures).toEqual([
-      { status: 403, endpoint: pullEndpoint.path, rateLimited: true },
+      {
+        status: 403,
+        endpoint: pullEndpoint.path,
+        rateLimited: true,
+        rateLimit: { limit: 60, remaining: 0, resource: "core", resetAt: 1 },
+      },
     ]);
   });
 
-  it("flags rateLimited=false when the GitHubApiError is a 404 with no rate-limit signal", () => {
+  it("flags rateLimited=false and omits the snapshot when the GitHubApiError is a 404 with no rate-limit signal", () => {
     const error = new GitHubApiError(404, undefined, pullEndpoint);
 
     const envelope = serializeReviewerFetchError(error);
@@ -44,10 +49,15 @@ describe("serializeReviewerFetchError", () => {
     ]);
   });
 
-  it("preserves rateLimited per failure inside a GitHubPullRequestEndpointsError", () => {
+  it("preserves rateLimited per failure inside a GitHubPullRequestEndpointsError and carries the snapshot only on the rate-limit failure", () => {
     const error = new GitHubPullRequestEndpointsError([
       new GitHubApiError(404, undefined, pullEndpoint),
-      new GitHubApiError(429, undefined, reviewsEndpoint),
+      new GitHubApiError(429, undefined, reviewsEndpoint, {
+        limit: 5_000,
+        remaining: 0,
+        resource: "core",
+        resetAt: 9_999,
+      }),
     ]);
 
     const envelope = serializeReviewerFetchError(error);
@@ -55,13 +65,37 @@ describe("serializeReviewerFetchError", () => {
     expect(envelope.kind).toBe("github-endpoints");
     expect(envelope.failures).toEqual([
       { status: 404, endpoint: pullEndpoint.path, rateLimited: false },
-      { status: 429, endpoint: reviewsEndpoint.path, rateLimited: true },
+      {
+        status: 429,
+        endpoint: reviewsEndpoint.path,
+        rateLimited: true,
+        rateLimit: {
+          limit: 5_000,
+          remaining: 0,
+          resource: "core",
+          resetAt: 9_999,
+        },
+      },
     ]);
+  });
+
+  it("omits the rate-limit snapshot when every header is null", () => {
+    const error = new GitHubApiError(
+      429,
+      undefined,
+      pullEndpoint,
+      { limit: null, remaining: null, resource: null, resetAt: null },
+    );
+
+    const envelope = serializeReviewerFetchError(error);
+
+    expect(envelope.failures?.[0]).toMatchObject({ rateLimited: true });
+    expect(envelope.failures?.[0]?.rateLimit).toBeUndefined();
   });
 });
 
 describe("extractReviewerFetchFailures", () => {
-  it("computes rateLimited from a live GitHubApiError instance", () => {
+  it("computes rateLimited and carries the snapshot from a live GitHubApiError instance", () => {
     const error = new GitHubApiError(
       403,
       undefined,
@@ -70,7 +104,12 @@ describe("extractReviewerFetchFailures", () => {
     );
 
     expect(extractReviewerFetchFailures(error)).toEqual([
-      { status: 403, endpoint: pullEndpoint.path, rateLimited: true },
+      {
+        status: 403,
+        endpoint: pullEndpoint.path,
+        rateLimited: true,
+        rateLimit: { limit: 60, remaining: 0, resource: "core", resetAt: 1 },
+      },
     ]);
   });
 
@@ -87,6 +126,40 @@ describe("extractReviewerFetchFailures", () => {
     expect(extractReviewerFetchFailures(envelope)).toEqual([
       { status: 403, endpoint: "/repos/cinev/shotloom/pulls/42", rateLimited: true },
       { status: 404, endpoint: "/repos/cinev/shotloom/pulls/42/reviews", rateLimited: false },
+    ]);
+  });
+
+  it("preserves the rate-limit snapshot when the envelope already includes one", () => {
+    const envelope = {
+      kind: "github-api" as const,
+      status: 429,
+      failures: [
+        {
+          status: 429,
+          endpoint: "/repos/cinev/shotloom/pulls/42",
+          rateLimited: true,
+          rateLimit: {
+            limit: 5_000,
+            remaining: 0,
+            resource: "core",
+            resetAt: 1_700_000_000,
+          },
+        },
+      ],
+    };
+
+    expect(extractReviewerFetchFailures(envelope)).toEqual([
+      {
+        status: 429,
+        endpoint: "/repos/cinev/shotloom/pulls/42",
+        rateLimited: true,
+        rateLimit: {
+          limit: 5_000,
+          remaining: 0,
+          resource: "core",
+          resetAt: 1_700_000_000,
+        },
+      },
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Adds an optional `rateLimit` snapshot (`limit / remaining / resource / resetAt`) to `ReviewerFetchFailure` and plumbs it through `serializeReviewerFetchError` / `extractReviewerFetchFailures`.
- Carries the snapshot to the banner aggregator on `auth-rate-limit` and `unauth-rate-limit` reports; the first non-empty snapshot for the active kind is preserved across same-kind reports and cleared when a higher-priority non-rate-limit kind takes over.
- Updates `formatBannerMessage` so rate-limit copy interpolates `(used/limit)` and a relative reset time when the snapshot is present, and falls back to the static copy when the headers are missing or partial.

The snapshot lives only in the in-memory message envelope and the banner state — nothing new is persisted, so the privacy notes are unaffected.

Closes #45

## Test plan

- [x] `pnpm test` (277 vitest tests, including new aggregator + format coverage)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Reviewer exhausts the unauthenticated rate limit on a public PR list and confirms the banner shows `(60/60 used)` and a relative reset time