### PR TITLE
test(e2e): cover access-banner failure flows in the packaged extension

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -100,6 +100,17 @@ snapshot is in-memory only — it is never persisted.
 - Collapse request volume further where practical.
 - Add more fixture-backed extension boot coverage for GitHub DOM variants.
 
+## End-to-end banner coverage
+
+- `tests/e2e/extension.spec.ts` covers two access-banner failure flows on the
+  packaged MV3 build using fixture HTML with a `<main>` mount target:
+  - Signed-out 429 with rate-limit headers — asserts the
+    `unauth-rate-limit` copy, the `Sign in` CTA, and the relative reset time.
+  - Signed-in 404 against a covered owner — seeds an account into
+    `chrome.storage.local` from a chrome-extension page, then asserts the
+    `app-uncovered` copy and the `Configure access` CTA pointing at the App
+    installation URL.
+
 ## Device flow
 
 - Polling lives on the options page because MV3 service workers unload on idle.

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -91,6 +91,110 @@ test("omits the inline reviewer row when both requested and reviewed are empty",
   });
 });
 
+test("renders unauth-rate-limit banner with Sign in CTA when an unauthenticated row hits a 429", async () => {
+  await withExtensionContext(async (context) => {
+    const fixtureHtml = await readFile(
+      path.join(fixturesDir, "github-pulls-with-banner-target.html"),
+      "utf8",
+    );
+
+    await routeFixturePage(context, fixtureHtml);
+    await context.route(
+      "https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/42",
+      async (route) => {
+        await route.fulfill({
+          status: 429,
+          contentType: "application/json",
+          headers: {
+            "x-ratelimit-limit": "60",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-resource": "core",
+            "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 600),
+          },
+          body: JSON.stringify({
+            message: "API rate limit exceeded for 127.0.0.1.",
+          }),
+        });
+      },
+    );
+    await context.route(
+      "https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/42/reviews**",
+      async (route) => {
+        await route.fulfill({
+          status: 429,
+          contentType: "application/json",
+          headers: {
+            "x-ratelimit-limit": "60",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-resource": "core",
+            "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 600),
+          },
+          body: JSON.stringify({
+            message: "API rate limit exceeded for 127.0.0.1.",
+          }),
+        });
+      },
+    );
+
+    const page = await context.newPage();
+    await page.goto("https://github.com/hon454/github-pulls-show-reviewers/pulls");
+
+    const banner = page.locator("[data-ghpsr-banner]");
+    await expect(banner).toContainText(
+      "GitHub's unauthenticated request limit was reached.",
+    );
+    await expect(banner).toContainText("Sign in to raise it to 5,000/hr.");
+    // The fresh reset header (~10 minutes from now) should surface in the copy.
+    await expect(banner).toContainText("Resets in about");
+    await expect(banner.locator("a")).toHaveText("Sign in");
+  });
+});
+
+test("renders app-uncovered banner with Configure access CTA when a signed-in row hits a 404", async () => {
+  await withExtensionContext(async (context) => {
+    const fixtureHtml = await readFile(
+      path.join(fixturesDir, "github-pulls-with-banner-target.html"),
+      "utf8",
+    );
+
+    // Cover the test owner with an "all" installation so resolveAccountForRepo
+    // finds the seeded account. The 404 stub below then exercises the
+    // app-uncovered branch (signed in, but GitHub denies the specific repo).
+    await seedSignedInAccount(context, {
+      accountId: "acc-banner",
+      login: "hon454",
+      installationOwner: "hon454",
+    });
+
+    await routeFixturePage(context, fixtureHtml);
+    // Defensive stub: in case the background ever calls the installations API,
+    // return an empty list rather than letting the real network handle it.
+    await context.route("https://api.github.com/user/installations**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ total_count: 0, installations: [] }),
+      });
+    });
+    await routePullApiError(context, "42", 404);
+    await routeReviewsApiError(context, "42", 404);
+
+    const page = await context.newPage();
+    await page.goto("https://github.com/hon454/github-pulls-show-reviewers/pulls");
+
+    const banner = page.locator("[data-ghpsr-banner]");
+    await expect(banner).toContainText(
+      "Add hon454/github-pulls-show-reviewers to @hon454's GitHub App installation",
+    );
+    const cta = banner.locator("a");
+    await expect(cta).toHaveText("Configure access");
+    await expect(cta).toHaveAttribute(
+      "href",
+      /github\.com\/apps\/.*\/installations\/new/,
+    );
+  });
+});
+
 test("clears the reviewer slot silently when review history is denied", async () => {
   await withExtensionContext(async (context) => {
     const fixtureHtml = await readFile(path.join(fixturesDir, "github-pulls.html"), "utf8");
@@ -228,4 +332,97 @@ async function routeReviewsApi(
       });
     },
   );
+}
+
+async function routePullApiError(
+  context: Awaited<ReturnType<typeof chromium.launchPersistentContext>>,
+  pullNumber: string,
+  status: number,
+): Promise<void> {
+  await context.route(
+    `https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/${pullNumber}`,
+    async (route) => {
+      await route.fulfill({
+        status,
+        contentType: "application/json",
+        body: JSON.stringify({ message: `status ${status}` }),
+      });
+    },
+  );
+}
+
+async function routeReviewsApiError(
+  context: Awaited<ReturnType<typeof chromium.launchPersistentContext>>,
+  pullNumber: string,
+  status: number,
+): Promise<void> {
+  await context.route(
+    `https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/${pullNumber}/reviews**`,
+    async (route) => {
+      await route.fulfill({
+        status,
+        contentType: "application/json",
+        body: JSON.stringify({ message: `status ${status}` }),
+      });
+    },
+  );
+}
+
+async function seedSignedInAccount(
+  context: Awaited<ReturnType<typeof chromium.launchPersistentContext>>,
+  input: {
+    accountId: string;
+    login: string;
+    installationOwner: string;
+  },
+): Promise<void> {
+  const serviceWorker =
+    context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+  const extensionId = new URL(serviceWorker.url()).host;
+  const optionsPage = await context.newPage();
+  try {
+    await optionsPage.goto(`chrome-extension://${extensionId}/options.html`);
+    await optionsPage.evaluate((seed) => {
+      const now = Date.now();
+      const storage = (
+        globalThis as unknown as {
+          chrome: { storage: { local: { set(items: object): Promise<void> } } };
+        }
+      ).chrome.storage.local;
+      return storage.set({
+        settings: { version: 4, accountIds: [seed.accountId] },
+        [`account:profile:${seed.accountId}`]: {
+          id: seed.accountId,
+          login: seed.login,
+          avatarUrl: null,
+          createdAt: now,
+        },
+        [`account:auth:${seed.accountId}`]: {
+          token: "ghu_seeded",
+          invalidated: false,
+          invalidatedReason: null,
+          refreshToken: null,
+          expiresAt: null,
+          refreshTokenExpiresAt: null,
+        },
+        [`account:installations:${seed.accountId}`]: {
+          installations: [
+            {
+              id: 1,
+              account: {
+                login: seed.installationOwner,
+                type: "Organization",
+                avatarUrl: null,
+              },
+              repositorySelection: "all",
+              repoFullNames: null,
+            },
+          ],
+          installationsRefreshedAt: now,
+        },
+      });
+    }, input);
+  } finally {
+    await optionsPage.close();
+  }
 }

--- a/tests/fixtures/github-pulls-with-banner-target.html
+++ b/tests/fixtures/github-pulls-with-banner-target.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>GitHub Pulls Fixture (with banner mount target)</title>
+  </head>
+  <body>
+    <main>
+      <div class="js-navigation-container js-active-navigation-container">
+        <div class="js-issue-row" id="issue_42">
+          <a class="Link--primary" href="/hon454/github-pulls-show-reviewers/pull/42">
+            Add reviewer chips
+          </a>
+          <div class="d-flex mt-1 text-small color-fg-muted">
+            <span class="d-none d-md-inline-flex">
+              <span class="issue-meta-section ml-2">#42 opened by hon454</span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Adds two Playwright tests against the built MV3 extension that drive the access banner end-to-end:
  - **Signed-out 429** — asserts the `unauth-rate-limit` copy, the `Sign in` CTA, and the relative reset time from the response headers.
  - **Signed-in 404** — seeds an account into `chrome.storage.local` from a chrome-extension page, then asserts the `app-uncovered` copy and the `Configure access` CTA pointing at the App installation URL.
- Adds a fixture (`tests/fixtures/github-pulls-with-banner-target.html`) that wraps the existing PR-row markup in a `<main>` so the access banner has a mount target.

> ⚠️ Stacked on #50 — the unauth-rate-limit assertion checks the new `Resets in about` copy added there. Targeting `feat/rate-limit-banner-details` so CI is green; will auto-rebase to `main` once #50 merges.

Closes #43

## Test plan

- [x] `pnpm test` (277 vitest tests)
- [x] `pnpm test:e2e` (8 Playwright tests, including the two new banner flows)
- [x] `pnpm typecheck`
- [x] `pnpm lint`