### PR TITLE
fix(options): surface async action failures

### DIFF
--- a/entrypoints/options/components/AccountsList.tsx
+++ b/entrypoints/options/components/AccountsList.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties } from "react";
+import { useRef, useState, type CSSProperties } from "react";
 
 import { retryWithAccountRefresh } from "../../../src/auth/account-token-refresh";
 import {
@@ -18,39 +18,83 @@ type Props = {
   onReauthenticate: (account: Account) => void;
 };
 
-export function AccountsList({ accounts, onChange, onReauthenticate }: Props) {
-  async function handleRefresh(account: Account) {
-    const installations = await retryWithAccountRefresh({
-      account,
-      execute: async (token) => {
-        if (token == null) {
-          throw new Error("Account token is required to refresh installations.");
-        }
+type AccountAction = "refresh" | "remove";
 
-        const apiInstallations = await fetchUserInstallations({ token });
-        return Promise.all(
-          apiInstallations.map(async (installation): Promise<Installation> => ({
-            id: installation.id,
-            account: installation.account,
-            repositorySelection: installation.repositorySelection,
-            repoFullNames:
-              installation.repositorySelection === "selected"
-                ? await fetchInstallationRepositories({
-                    token,
-                    installationId: installation.id,
-                  })
-                : null,
-          })),
-        );
-      },
+export function AccountsList({ accounts, onChange, onReauthenticate }: Props) {
+  const inFlightAccountIds = useRef(new Set<string>());
+  const [busyActions, setBusyActions] = useState<
+    Record<string, AccountAction | undefined>
+  >({});
+  const [actionErrors, setActionErrors] = useState<
+    Record<string, string | undefined>
+  >({});
+
+  async function runAccountAction(
+    account: Account,
+    action: AccountAction,
+    execute: () => Promise<void>,
+  ) {
+    if (inFlightAccountIds.current.has(account.id)) {
+      return;
+    }
+
+    inFlightAccountIds.current.add(account.id);
+    setBusyActions((current) => ({ ...current, [account.id]: action }));
+    setActionErrors((current) => ({ ...current, [account.id]: undefined }));
+
+    try {
+      await execute();
+    } catch (error) {
+      setActionErrors((current) => ({
+        ...current,
+        [account.id]: `${actionFailureLabel(action)} ${errorMessage(error)}`,
+      }));
+    } finally {
+      inFlightAccountIds.current.delete(account.id);
+      setBusyActions((current) => {
+        const next = { ...current };
+        delete next[account.id];
+        return next;
+      });
+    }
+  }
+
+  async function handleRefresh(account: Account) {
+    await runAccountAction(account, "refresh", async () => {
+      const installations = await retryWithAccountRefresh({
+        account,
+        execute: async (token) => {
+          if (token == null) {
+            throw new Error("Account token is required to refresh installations.");
+          }
+
+          const apiInstallations = await fetchUserInstallations({ token });
+          return Promise.all(
+            apiInstallations.map(async (installation): Promise<Installation> => ({
+              id: installation.id,
+              account: installation.account,
+              repositorySelection: installation.repositorySelection,
+              repoFullNames:
+                installation.repositorySelection === "selected"
+                  ? await fetchInstallationRepositories({
+                      token,
+                      installationId: installation.id,
+                    })
+                  : null,
+            })),
+          );
+        },
+      });
+      await replaceInstallations(account.id, installations);
+      await onChange();
     });
-    await replaceInstallations(account.id, installations);
-    await onChange();
   }
 
   async function handleRemove(account: Account) {
-    await removeAccount(account.id);
-    await onChange();
+    await runAccountAction(account, "remove", async () => {
+      await removeAccount(account.id);
+      await onChange();
+    });
   }
 
   if (accounts.length === 0) {
@@ -63,54 +107,93 @@ export function AccountsList({ accounts, onChange, onReauthenticate }: Props) {
 
   return (
     <div style={styles.list}>
-      {accounts.map((account) => (
-        <div
-          key={account.id}
-          style={{
-            ...styles.card,
-            opacity: account.invalidated ? 0.6 : 1,
-          }}
-          data-testid={`account-card-${account.login}`}
-        >
-          <p style={styles.login}>@{account.login}</p>
-          <p style={styles.meta}>
-            Installed on:{" "}
-            {account.installations.length === 0
-              ? "none yet"
-              : account.installations
-                  .map((installation) => `@${installation.account.login}`)
-                  .join(", ")}
-          </p>
-          {account.invalidated ? (
-            <button
-              type="button"
-              onClick={() => onReauthenticate(account)}
-              style={styles.primaryButton}
-            >
-              Sign in again
-            </button>
-          ) : (
-            <div style={styles.actions}>
+      {accounts.map((account) => {
+        const busyAction = busyActions[account.id];
+        const isBusy = busyAction != null;
+        const actionError = actionErrors[account.id];
+
+        return (
+          <div
+            key={account.id}
+            style={{
+              ...styles.card,
+              opacity: account.invalidated ? 0.6 : 1,
+            }}
+            data-testid={`account-card-${account.login}`}
+          >
+            <p style={styles.login}>@{account.login}</p>
+            <p style={styles.meta}>
+              Installed on:{" "}
+              {account.installations.length === 0
+                ? "none yet"
+                : account.installations
+                    .map((installation) => `@${installation.account.login}`)
+                    .join(", ")}
+            </p>
+            {account.invalidated ? (
               <button
                 type="button"
-                onClick={() => void handleRefresh(account)}
-                style={styles.secondaryButton}
+                onClick={() => onReauthenticate(account)}
+                style={styles.primaryButton}
               >
-                Refresh installations
+                Sign in again
               </button>
-              <button
-                type="button"
-                onClick={() => void handleRemove(account)}
-                style={styles.dangerButton}
+            ) : (
+              <div style={styles.actions}>
+                <button
+                  type="button"
+                  onClick={() => void handleRefresh(account)}
+                  disabled={isBusy}
+                  style={{
+                    ...styles.secondaryButton,
+                    ...(isBusy ? styles.disabledButton : null),
+                  }}
+                >
+                  {busyAction === "refresh"
+                    ? "Refreshing..."
+                    : "Refresh installations"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleRemove(account)}
+                  disabled={isBusy}
+                  style={{
+                    ...styles.dangerButton,
+                    ...(isBusy ? styles.disabledButton : null),
+                  }}
+                >
+                  {busyAction === "remove" ? "Removing..." : "Remove"}
+                </button>
+              </div>
+            )}
+            {actionError ? (
+              <p
+                style={styles.error}
+                role="status"
+                aria-live="polite"
+                data-testid={`account-action-error-${account.id}`}
               >
-                Remove
-              </button>
-            </div>
-          )}
-        </div>
-      ))}
+                {actionError}
+              </p>
+            ) : null}
+          </div>
+        );
+      })}
     </div>
   );
+}
+
+function actionFailureLabel(action: AccountAction): string {
+  if (action === "refresh") {
+    return "Could not refresh installations.";
+  }
+  return "Could not remove account.";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message
+    ? error.message
+    : "Please try again.";
 }
 
 const styles: Record<string, CSSProperties> = {
@@ -152,5 +235,15 @@ const styles: Record<string, CSSProperties> = {
     color: "#cf222e",
     fontWeight: 700,
     cursor: "pointer",
+  },
+  disabledButton: {
+    opacity: 0.65,
+    cursor: "not-allowed",
+  },
+  error: {
+    margin: "10px 0 0",
+    color: "#cf222e",
+    fontSize: 13,
+    lineHeight: 1.5,
   },
 };

--- a/entrypoints/options/components/DiagnosticsPanel.tsx
+++ b/entrypoints/options/components/DiagnosticsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties } from "react";
+import { useRef, useState, type CSSProperties } from "react";
 
 import { validateRepositoryAccessWithAccount } from "../../../src/auth/account-token-refresh";
 import { validateGitHubRepositoryAccess } from "../../../src/github/api";
@@ -16,6 +16,28 @@ export function DiagnosticsPanel() {
   const [status, setStatus] = useState<Status>(null);
   const [matchedAccount, setMatchedAccount] = useState<Account | null>(null);
   const [busy, setBusy] = useState(false);
+  const busyRef = useRef(false);
+
+  async function runDiagnostic(execute: () => Promise<void>) {
+    if (busyRef.current) {
+      return;
+    }
+
+    busyRef.current = true;
+    setBusy(true);
+    setStatus({ tone: "neutral", message: "Running diagnostics..." });
+    try {
+      await execute();
+    } catch (error) {
+      setStatus({
+        tone: "error",
+        message: `Could not run diagnostics. ${errorMessage(error)}`,
+      });
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  }
 
   async function runMatched() {
     const trimmed = repository.trim();
@@ -27,8 +49,7 @@ export function DiagnosticsPanel() {
       });
       return;
     }
-    setBusy(true);
-    try {
+    await runDiagnostic(async () => {
       const account = await resolveAccountForRepo(match[1], match[2]);
       setMatchedAccount(account);
       if (account == null) {
@@ -43,9 +64,7 @@ export function DiagnosticsPanel() {
         repository: trimmed,
       });
       setStatus({ tone: result.ok ? "success" : "error", message: result.message });
-    } finally {
-      setBusy(false);
-    }
+    });
   }
 
   async function runNoToken() {
@@ -57,14 +76,11 @@ export function DiagnosticsPanel() {
       });
       return;
     }
-    setBusy(true);
     setMatchedAccount(null);
-    try {
+    await runDiagnostic(async () => {
       const result = await validateGitHubRepositoryAccess(null, trimmed);
       setStatus({ tone: result.ok ? "success" : "error", message: result.message });
-    } finally {
-      setBusy(false);
-    }
+    });
   }
 
   return (
@@ -102,12 +118,23 @@ export function DiagnosticsPanel() {
         <p style={styles.hint}>Matched account: @{matchedAccount.login}.</p>
       ) : null}
       {status ? (
-        <p style={{ ...styles.hint, color: toneColor(status.tone) }}>
+        <p
+          style={{ ...styles.hint, color: toneColor(status.tone) }}
+          role="status"
+          aria-live="polite"
+          data-testid="diagnostics-status"
+        >
           {status.message}
         </p>
       ) : null}
     </section>
   );
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message
+    ? error.message
+    : "Please try again.";
 }
 
 function toneColor(tone: "neutral" | "success" | "error"): string {

--- a/entrypoints/options/components/DisplaySettingsPanel.tsx
+++ b/entrypoints/options/components/DisplaySettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type CSSProperties } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 
 import {
   DEFAULT_PREFERENCES,
@@ -10,16 +10,47 @@ import {
 export function DisplaySettingsPanel() {
   const [preferences, setPreferences] =
     useState<Preferences>(DEFAULT_PREFERENCES);
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<{
+    tone: "neutral" | "error";
+    message: string;
+  } | null>(null);
+  const busyRef = useRef(false);
 
   useEffect(() => {
     void (async () => {
-      setPreferences(await getPreferences());
+      try {
+        setPreferences(await getPreferences());
+      } catch (error) {
+        setStatus({
+          tone: "error",
+          message: `Could not load display settings. ${errorMessage(error)}`,
+        });
+      }
     })();
   }, []);
 
   async function handleChange(patch: Partial<Omit<Preferences, "version">>) {
-    const next = await updatePreferences(patch);
-    setPreferences(next);
+    if (busyRef.current) {
+      return;
+    }
+
+    busyRef.current = true;
+    setBusy(true);
+    setStatus({ tone: "neutral", message: "Saving display settings..." });
+    try {
+      const next = await updatePreferences(patch);
+      setPreferences(next);
+      setStatus(null);
+    } catch (error) {
+      setStatus({
+        tone: "error",
+        message: `Could not save display settings. ${errorMessage(error)}`,
+      });
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
   }
 
   return (
@@ -33,8 +64,9 @@ export function DisplaySettingsPanel() {
           data-testid="prefs-show-state-badge"
           type="checkbox"
           checked={preferences.showStateBadge}
+          disabled={busy}
           onChange={(event) =>
-            handleChange({ showStateBadge: event.target.checked })
+            void handleChange({ showStateBadge: event.target.checked })
           }
         />
         <span>Show review state badge on avatars</span>
@@ -44,8 +76,9 @@ export function DisplaySettingsPanel() {
           data-testid="prefs-show-reviewer-name"
           type="checkbox"
           checked={preferences.showReviewerName}
+          disabled={busy}
           onChange={(event) =>
-            handleChange({ showReviewerName: event.target.checked })
+            void handleChange({ showReviewerName: event.target.checked })
           }
         />
         <span>Show reviewer names</span>
@@ -55,14 +88,34 @@ export function DisplaySettingsPanel() {
           data-testid="prefs-open-pulls-only"
           type="checkbox"
           checked={preferences.openPullsOnly}
+          disabled={busy}
           onChange={(event) =>
-            handleChange({ openPullsOnly: event.target.checked })
+            void handleChange({ openPullsOnly: event.target.checked })
           }
         />
         <span>Open pull requests only in reviewer links</span>
       </label>
+      {status ? (
+        <p
+          style={{
+            ...styles.status,
+            color: status.tone === "error" ? "#cf222e" : "#52463b",
+          }}
+          role="status"
+          aria-live="polite"
+          data-testid={status.tone === "error" ? "prefs-error" : "prefs-status"}
+        >
+          {status.message}
+        </p>
+      ) : null}
     </section>
   );
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message
+    ? error.message
+    : "Please try again.";
 }
 
 const styles: Record<string, CSSProperties> = {
@@ -86,5 +139,10 @@ const styles: Record<string, CSSProperties> = {
     fontSize: 14,
     color: "#221d18",
     cursor: "pointer",
+  },
+  status: {
+    margin: "8px 0 0",
+    fontSize: 13,
+    lineHeight: 1.5,
   },
 };

--- a/tests/options-page.test.ts
+++ b/tests/options-page.test.ts
@@ -1,11 +1,14 @@
 // @vitest-environment jsdom
+import { fireEvent } from "@testing-library/react";
 import { act, createElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type * as GitHubApiModule from "../src/github/api";
 import type { Account } from "../src/storage/accounts";
 import type * as AccountsModule from "../src/storage/accounts";
 
 type AccountsModuleType = typeof AccountsModule;
+type GitHubApiModuleType = typeof GitHubApiModule;
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -15,7 +18,9 @@ const listAccountsMock = vi.fn<() => Promise<Account[]>>(async () => []);
 const getAccountByIdMock = vi.fn<() => Promise<Account | null>>(
   async () => null,
 );
+const removeAccountMock = vi.fn(async () => {});
 const replaceInstallationsMock = vi.fn(async () => {});
+const resolveAccountForRepoMock = vi.fn(async () => null);
 
 const getPreferencesMock = vi.fn(async () => ({
   version: 1 as const,
@@ -51,10 +56,10 @@ vi.mock("../src/storage/accounts", async (importActual) => {
       invalidated: false,
       invalidatedReason: null,
     })),
-    removeAccount: vi.fn(async () => {}),
+    removeAccount: removeAccountMock,
     replaceInstallations: replaceInstallationsMock,
     getAccountById: getAccountByIdMock,
-    resolveAccountForRepo: vi.fn(async () => null),
+    resolveAccountForRepo: resolveAccountForRepoMock,
   };
 });
 
@@ -78,6 +83,16 @@ vi.mock("../src/github/auth", () => ({
   fetchUserInstallations: vi.fn(),
   fetchInstallationRepositories: vi.fn(),
   DeviceFlowError: class extends Error {},
+}));
+
+const validateGitHubRepositoryAccessMock = vi.fn(async () => ({
+  ok: true,
+  message: "Repository is accessible.",
+}));
+
+vi.mock("../src/github/api", async (importActual) => ({
+  ...(await importActual<GitHubApiModuleType>()),
+  validateGitHubRepositoryAccess: validateGitHubRepositoryAccessMock,
 }));
 
 async function renderOptionsPage() {
@@ -120,9 +135,12 @@ beforeEach(() => {
   vi.clearAllMocks();
   listAccountsMock.mockReset();
   getAccountByIdMock.mockReset();
+  removeAccountMock.mockReset();
   replaceInstallationsMock.mockReset();
+  resolveAccountForRepoMock.mockReset();
   listAccountsMock.mockResolvedValue([]);
   getAccountByIdMock.mockResolvedValue(null);
+  removeAccountMock.mockResolvedValue(undefined);
   getPreferencesMock.mockClear();
   updatePreferencesMock.mockClear();
   getPreferencesMock.mockResolvedValue({
@@ -130,6 +148,17 @@ beforeEach(() => {
     showStateBadge: true,
     showReviewerName: false,
     openPullsOnly: true,
+  });
+  updatePreferencesMock.mockResolvedValue({
+    version: 1,
+    showStateBadge: true,
+    showReviewerName: false,
+    openPullsOnly: true,
+  });
+  resolveAccountForRepoMock.mockResolvedValue(null);
+  validateGitHubRepositoryAccessMock.mockResolvedValue({
+    ok: true,
+    message: "Repository is accessible.",
   });
   vi.stubGlobal("browser", {
     runtime: {
@@ -276,6 +305,94 @@ describe("OptionsPage", () => {
         repoFullNames: ["cinev/shotloom"],
       },
     ]);
+  });
+
+  it("shows an inline error and re-enables account actions when refresh fails", async () => {
+    listAccountsMock.mockResolvedValue([
+      {
+        id: "acc",
+        login: "hon454",
+        avatarUrl: null,
+        token: "ghu_old",
+        createdAt: 1,
+        installations: [],
+        installationsRefreshedAt: 1,
+        invalidated: false,
+        invalidatedReason: null,
+        refreshToken: null,
+        expiresAt: null,
+        refreshTokenExpiresAt: null,
+      },
+    ]);
+    await renderOptionsPage();
+
+    const auth = await import("../src/github/auth");
+    const fetchUserInstallations =
+      auth.fetchUserInstallations as unknown as ReturnType<typeof vi.fn>;
+    fetchUserInstallations.mockRejectedValueOnce(
+      new Error("GitHub API temporarily unavailable."),
+    );
+
+    const refreshButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.trim() === "Refresh installations");
+    expect(refreshButton).toBeDefined();
+
+    await act(async () => {
+      refreshButton!.click();
+      refreshButton!.click();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(fetchUserInstallations).toHaveBeenCalledTimes(1);
+    expect(refreshButton!.disabled).toBe(false);
+    expect(
+      document.querySelector('[data-testid="account-action-error-acc"]')
+        ?.textContent,
+    ).toContain("Could not refresh installations");
+  });
+
+  it("shows an inline error and prevents duplicate remove clicks while removing an account", async () => {
+    listAccountsMock.mockResolvedValue([
+      {
+        id: "acc",
+        login: "hon454",
+        avatarUrl: null,
+        token: "ghu_old",
+        createdAt: 1,
+        installations: [],
+        installationsRefreshedAt: 1,
+        invalidated: false,
+        invalidatedReason: null,
+        refreshToken: null,
+        expiresAt: null,
+        refreshTokenExpiresAt: null,
+      },
+    ]);
+    removeAccountMock.mockRejectedValueOnce(
+      new Error("Storage write failed."),
+    );
+    await renderOptionsPage();
+
+    const removeButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.trim() === "Remove");
+    expect(removeButton).toBeDefined();
+
+    await act(async () => {
+      removeButton!.click();
+      removeButton!.click();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(removeAccountMock).toHaveBeenCalledTimes(1);
+    expect(removeButton!.disabled).toBe(false);
+    expect(
+      document.querySelector('[data-testid="account-action-error-acc"]')
+        ?.textContent,
+    ).toContain("Could not remove account");
   });
 
   it("shows a configuration warning instead of blanking the page when production config is missing", async () => {
@@ -512,5 +629,63 @@ describe("OptionsPage", () => {
     expect(updatePreferencesMock).toHaveBeenCalledWith({
       showStateBadge: false,
     });
+  });
+
+  it("shows an inline error and reverts checkbox state when a preference update fails", async () => {
+    updatePreferencesMock.mockRejectedValueOnce(
+      new Error("Storage write failed."),
+    );
+    await renderOptionsPage();
+    const badgeCheckbox = document.querySelector<HTMLInputElement>(
+      '[data-testid="prefs-show-state-badge"]',
+    )!;
+
+    await act(async () => {
+      badgeCheckbox.click();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(updatePreferencesMock).toHaveBeenCalledWith({
+      showStateBadge: false,
+    });
+    expect(badgeCheckbox.checked).toBe(true);
+    expect(
+      document.querySelector('[data-testid="prefs-error"]')?.textContent,
+    ).toContain("Could not save display settings");
+  });
+
+  it("shows an inline diagnostics error and re-enables buttons when no-token validation throws", async () => {
+    validateGitHubRepositoryAccessMock.mockRejectedValueOnce(
+      new Error("Network offline."),
+    );
+    await renderOptionsPage();
+
+    const input = document.querySelector<HTMLInputElement>(
+      '[data-testid="diagnostics-repo"]',
+    )!;
+    const noTokenButton = document.querySelector<HTMLButtonElement>(
+      '[data-testid="diagnostics-no-token"]',
+    )!;
+
+    await act(async () => {
+      fireEvent.change(input, {
+        target: { value: "hon454/github-pulls-show-reviewers" },
+      });
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      noTokenButton.click();
+      noTokenButton.click();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(validateGitHubRepositoryAccessMock).toHaveBeenCalledTimes(1);
+    expect(noTokenButton.disabled).toBe(false);
+    expect(
+      document.querySelector('[data-testid="diagnostics-status"]')?.textContent,
+    ).toContain("Could not run diagnostics");
   });
 });


### PR DESCRIPTION
## Summary

- Adds visible busy, duplicate-click, and inline failure handling for options-page account actions.
- Makes diagnostics and display preference failures recover cleanly with accessible status text.

## Why

Options-page async actions could fail silently or allow repeated clicks while work was still in flight. That left users unsure whether account refresh, account removal, diagnostics, or preference changes had completed.

## Changes

- Account actions now track per-account in-flight work, disable duplicate refresh/remove clicks, and show concise inline errors.
- Diagnostics now catches thrown validation failures, clears busy state consistently, and announces status updates via aria-live.
- Display settings now reports load/save failures, disables controls while saving, and keeps the previous checkbox state when storage writes fail.
- Options-page tests cover failure paths for account refresh, account removal, preference save, and diagnostics.

## Impact

- User-facing impact: failed options-page actions now show recoverable inline feedback instead of disappearing into the console.
- API/schema impact: None.
- Performance impact: None.
- Operational or rollout impact: None.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (307 tests passed)
- `pnpm build`

## Breaking Changes

- None

## Related Issues

Resolves #44

<!-- Co-location checklist: no reviewer UX state mapping, selectors, permissions, storage schema, auth flow, release artifact, or Chrome Web Store copy updates apply. -->
