### PR TITLE
perf(reviewers): batch cold pull metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Core behavior:
 - Link reviewer chips to open PR searches by default, with an option to include
   closed PRs in those searches
 - Keep rendering deterministic with pure view-model helpers and centralized selectors
-- Reuse per-page cache entries to avoid duplicate row fetches
+- Reuse page-level reviewer request metadata and per-page cache entries to
+  reduce duplicate cold-row fetches
 - Re-run safely across GitHub SPA navigation and DOM mutations
 
 Review states currently surfaced in the UI:

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -23,19 +23,28 @@
 2. Find PR rows with centralized GitHub selectors.
 3. Extract the pull request number from the row id or primary pull request link.
 4. Resolve the covering account for `owner/repo` via `resolveAccountForRepo`.
-5. Send a `fetchPullReviewerSummary` message to the background service
-   worker when the cache is cold. The background resolves the matched
-   account's token (or no token if none matches), performs the GitHub REST
-   calls, and returns the parsed summary or a typed error.
-6. Render a single `Reviewers` section inline in the PR row metadata area. Each reviewer is an avatar chip. Requested reviewers keep the blue requested ring. Completed reviewers show a ring and badge derived from one `(isRequested, state)` mapping. Review selection prefers the latest non-`COMMENTED` review for a reviewer, falling back to the latest `COMMENTED` review only when no non-comment review exists. A still-requested reviewer with prior `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` evidence shows the refresh badge instead of the prior state badge. Requested teams keep the text chip shape. User chip links follow the same primary axis as the ring color: blue-ring (still-requested) chips link to `review-requested:<login>`; colored-ring (completed) chips link to `reviewed-by:<login>`. Reviewer chip links use `is:pr is:open` searches by default.
-7. On API errors, emit a signal to the banner aggregator; do not render
+5. Send one `fetchPullReviewerMetadataBatch` message per page/account when the
+   cache is cold. The background reads the first REST pull-list page with the
+   matched account token (or no token if none matches), returning requested user
+   reviewers, requested teams, and author logins that can be reused across
+   visible rows.
+6. Send a `fetchPullReviewerSummary` message for each uncached row. When the
+   page-level metadata contains that pull request number, the background skips
+   the per-row pull endpoint and reads only the reviews endpoint. If the pull
+   number is absent from the batch result, the summary request falls back to the
+   original per-row `pull + reviews` REST path.
+7. Render a single `Reviewers` section inline in the PR row metadata area. Each reviewer is an avatar chip. Requested reviewers keep the blue requested ring. Completed reviewers show a ring and badge derived from one `(isRequested, state)` mapping. Review selection prefers the latest non-`COMMENTED` review for a reviewer, falling back to the latest `COMMENTED` review only when no non-comment review exists. A still-requested reviewer with prior `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` evidence shows the refresh badge instead of the prior state badge. Requested teams keep the text chip shape. User chip links follow the same primary axis as the ring color: blue-ring (still-requested) chips link to `review-requested:<login>`; colored-ring (completed) chips link to `reviewed-by:<login>`. Reviewer chip links use `is:pr is:open` searches by default.
+8. On API errors, emit a signal to the banner aggregator; do not render
    row-level error text.
-8. Re-run row processing when GitHub mutates the page or performs SPA navigation.
+9. Re-run row processing when GitHub mutates the page or performs SPA navigation.
 
 ## Current limitations
 
 - The extension still depends on GitHub metadata DOM structure.
-- API requests are still one pull request plus one reviews request per uncached row.
+- Cold rows on a typical first PR-list page use one pull-list metadata request
+  plus one reviews request per uncached row. Filtered, searched, or older pages
+  can still fall back to one pull request plus one reviews request for rows that
+  are not present in the first REST pull-list page.
 - Public-repository no-token access still depends on GitHub's unauthenticated REST availability and rate limits.
 - PAT-era single-token settings are not migrated; users must sign in again with
   the GitHub App account flow.
@@ -51,10 +60,16 @@
 ## Request volume decision
 
 - ADR: [0001 - Keep No-Token Support For Public Repositories](./adr/0001-keep-no-token-support-for-public-repositories.md)
-- `v1.0.0` keeps the current `pull + reviews` REST model for cold rows.
-- The current implementation already de-duplicates in-flight row fetches and caches each pull request summary for the active page session, so the immediate duplication risk is contained.
+- The current implementation keeps the REST-only public path and uses
+  `GET /repos/{owner}/{repo}/pulls?per_page=100&state=all` as a page-level
+  metadata hint before row summaries.
+- The content script de-duplicates in-flight row fetches, caches each pull
+  request summary for the active page session, and caches the page-level
+  metadata result per `owner/repo/account`.
 - A GraphQL-first rewrite is not the next step because it would push the product away from the current no-token public-repository path and add a second transport model to maintain.
-- If request volume becomes the next real bottleneck after launch, the preferred follow-up is a page-level batch strategy on the existing REST path before considering a broader API migration.
+- If request volume remains the next bottleneck, the preferred follow-up is to
+  make the REST batch smarter for filtered and paginated GitHub list pages
+  before considering a broader API migration.
 
 ## Access banner classification
 
@@ -97,7 +112,8 @@ snapshot is in-memory only — it is never persisted.
 
 ## Next implementation targets
 
-- Collapse request volume further where practical.
+- Extend the REST metadata batch to better cover searched, filtered, and older
+  paginated GitHub PR list pages.
 - Add more fixture-backed extension boot coverage for GitHub DOM variants.
 
 ## End-to-end banner coverage

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -5,6 +5,7 @@ import { createReviewerFetchService } from "../src/background/reviewer-fetch";
 import { getGitHubAppConfig } from "../src/config/github-app";
 import {
   isCancelPullReviewerSummaryMessage,
+  isFetchPullReviewerMetadataBatchMessage,
   isFetchPullReviewerSummaryMessage,
 } from "../src/runtime/reviewer-fetch";
 import {
@@ -123,6 +124,19 @@ export default defineBackground(() => {
       if (isCancelPullReviewerSummaryMessage(message)) {
         reviewerFetchService.cancelRequest(message.requestId);
         return undefined;
+      }
+      if (isFetchPullReviewerMetadataBatchMessage(message)) {
+        reviewerFetchService.handleMetadataBatchMessage(message).then(
+          (response) => sendResponse(response),
+          (error) => {
+            console.error(
+              "[GitHub Pulls Show Reviewers] Reviewer metadata batch handler crashed.",
+              error,
+            );
+            sendResponse(undefined);
+          },
+        );
+        return true;
       }
       if (isRefreshAccountInstallationsMessage(message)) {
         installationRefreshService

--- a/src/background/reviewer-fetch.ts
+++ b/src/background/reviewer-fetch.ts
@@ -1,8 +1,14 @@
 import type { RefreshCoordinator } from "../auth/refresh-coordinator";
-import { fetchPullReviewerSummary, extractGitHubApiStatus } from "../github/api";
+import {
+  fetchPullReviewerMetadataBatch,
+  fetchPullReviewerSummary,
+  extractGitHubApiStatus,
+} from "../github/api";
 import { getAccountById, markAccountInvalidated } from "../storage/accounts";
 import {
   serializeReviewerFetchError,
+  type FetchPullReviewerMetadataBatchMessage,
+  type FetchPullReviewerMetadataBatchResponse,
   type FetchPullReviewerSummaryMessage,
   type FetchPullReviewerSummaryResponse,
 } from "../runtime/reviewer-fetch";
@@ -14,6 +20,9 @@ export type ReviewerFetchService = {
   handleFetchMessage(
     message: FetchPullReviewerSummaryMessage,
   ): Promise<FetchPullReviewerSummaryResponse>;
+  handleMetadataBatchMessage(
+    message: FetchPullReviewerMetadataBatchMessage,
+  ): Promise<FetchPullReviewerMetadataBatchResponse>;
 };
 
 export function createReviewerFetchService(input: {
@@ -67,6 +76,7 @@ export function createReviewerFetchService(input: {
             repo: message.repo,
             pullNumber: message.pullNumber,
             githubToken: token,
+            pullMetadata: message.pullMetadata,
             signal: controller.signal,
           });
 
@@ -101,6 +111,75 @@ export function createReviewerFetchService(input: {
           try {
             const summary = await execute(refreshed?.token ?? outcome.token);
             return { ok: true, summary };
+          } catch (retryError) {
+            if (extractGitHubApiStatus(retryError) === 401) {
+              await markAccountInvalidated(account.id, "revoked");
+            }
+            return {
+              ok: false,
+              error: serializeReviewerFetchError(retryError),
+            };
+          }
+        }
+      } finally {
+        inFlightControllers.delete(message.requestId);
+      }
+    },
+    async handleMetadataBatchMessage(
+      message: FetchPullReviewerMetadataBatchMessage,
+    ): Promise<FetchPullReviewerMetadataBatchResponse> {
+      pruneCanceledRequestIds(Date.now());
+
+      const controller = new AbortController();
+      inFlightControllers.set(message.requestId, controller);
+
+      if (canceledRequestIds.delete(message.requestId)) {
+        controller.abort();
+      }
+
+      try {
+        const account =
+          message.accountId == null ? null : await getAccountById(message.accountId);
+
+        const execute = (token: string | null) =>
+          fetchPullReviewerMetadataBatch({
+            owner: message.owner,
+            repo: message.repo,
+            githubToken: token,
+            signal: controller.signal,
+          });
+
+        try {
+          const metadata = await execute(account?.token ?? null);
+          return { ok: true, metadata };
+        } catch (error) {
+          if (extractGitHubApiStatus(error) !== 401 || account == null) {
+            return {
+              ok: false,
+              error: serializeReviewerFetchError(error),
+            };
+          }
+
+          if (account.refreshToken == null) {
+            await markAccountInvalidated(account.id, "revoked");
+            return {
+              ok: false,
+              error: serializeReviewerFetchError(error),
+            };
+          }
+
+          const outcome = await refreshCoordinator.refreshAccountToken(account.id);
+          if (outcome.ok !== true) {
+            return {
+              ok: false,
+              error: serializeReviewerFetchError(error),
+            };
+          }
+
+          const refreshed = await getAccountById(account.id);
+          try {
+            const metadata = await execute(refreshed?.token ?? outcome.token);
+            return { ok: true, metadata };
           } catch (retryError) {
             if (extractGitHubApiStatus(retryError) === 401) {
               await markAccountInvalidated(account.id, "revoked");

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -6,12 +6,13 @@ import {
   getCachedReviewerSummary,
   setCachedReviewerSummary,
 } from "../../cache/reviewer-cache";
-import type { PullReviewerSummary } from "../../github/api";
+import type { PullReviewerMetadata, PullReviewerSummary } from "../../github/api";
 import { parsePullListRoute } from "../../github/routes";
 import { githubSelectors } from "../../github/selectors";
 import type { RefreshAccountInstallationsResponse } from "../../runtime/installation-refresh";
 import {
   ReviewerFetchRuntimeError,
+  type FetchPullReviewerMetadataBatchResponse,
   type FetchPullReviewerSummaryResponse,
 } from "../../runtime/reviewer-fetch";
 import { type Account } from "../../storage/accounts";
@@ -56,7 +57,22 @@ export function bootReviewerListPage(
     promise: Promise<void>;
     controller: AbortController;
   };
+  type PageMetadataRequest = {
+    owner: string;
+    repo: string;
+    accountId: string | null;
+    promise: Promise<Map<string, PullReviewerMetadata>>;
+    controller: AbortController;
+  };
+  type PageMetadataCache = {
+    owner: string;
+    repo: string;
+    accountId: string | null;
+    metadata: Map<string, PullReviewerMetadata>;
+  };
   const inflightRequests = new Map<string, InflightRequest>();
+  let pageMetadataRequest: PageMetadataRequest | null = null;
+  let pageMetadataCache: PageMetadataCache | null = null;
   let cachedPreferences: Promise<Preferences> | null = null;
   const accountResolver = createSelfHealingAccountResolver({
     requestRefresh: requestInstallationsRefresh,
@@ -67,6 +83,9 @@ export function bootReviewerListPage(
       request.controller.abort();
     }
     inflightRequests.clear();
+    pageMetadataRequest?.controller.abort();
+    pageMetadataRequest = null;
+    pageMetadataCache = null;
   }
 
   function readPreferences(): Promise<Preferences> {
@@ -90,6 +109,83 @@ export function bootReviewerListPage(
       showStateBadge: preferences.showStateBadge,
       showReviewerName: preferences.showReviewerName,
     });
+  }
+
+  async function getPageMetadata(
+    route: NonNullable<typeof currentRoute>,
+    account: Account | null,
+    signal: AbortSignal,
+  ): Promise<Map<string, PullReviewerMetadata>> {
+    const accountId = account?.id ?? null;
+    if (
+      pageMetadataCache != null &&
+      pageMetadataCache.owner === route.owner &&
+      pageMetadataCache.repo === route.repo &&
+      pageMetadataCache.accountId === accountId
+    ) {
+      return pageMetadataCache.metadata;
+    }
+
+    if (
+      pageMetadataRequest != null &&
+      pageMetadataRequest.owner === route.owner &&
+      pageMetadataRequest.repo === route.repo &&
+      pageMetadataRequest.accountId === accountId
+    ) {
+      return pageMetadataRequest.promise;
+    }
+
+    const controller = new AbortController();
+    signal.addEventListener(
+      "abort",
+      () => {
+        controller.abort();
+      },
+      { once: true },
+    );
+
+    const request: PageMetadataRequest = {
+      owner: route.owner,
+      repo: route.repo,
+      accountId,
+      controller,
+      promise: fetchPageMetadata({
+        account,
+        owner: route.owner,
+        repo: route.repo,
+        signal: controller.signal,
+      })
+        .then((metadata) => {
+          const metadataByNumber = new Map(
+            metadata.map((pullMetadata) => [pullMetadata.number, pullMetadata]),
+          );
+          pageMetadataCache = {
+            owner: route.owner,
+            repo: route.repo,
+            accountId,
+            metadata: metadataByNumber,
+          };
+          return metadataByNumber;
+        })
+        .catch((error) => {
+          if (!isAbortError(error) && !controller.signal.aborted) {
+            pageMetadataCache = {
+              owner: route.owner,
+              repo: route.repo,
+              accountId,
+              metadata: new Map(),
+            };
+          }
+          return new Map<string, PullReviewerMetadata>();
+        })
+        .finally(() => {
+          if (pageMetadataRequest === request) {
+            pageMetadataRequest = null;
+          }
+        }),
+    };
+    pageMetadataRequest = request;
+    return request.promise;
   }
 
   async function processRow(row: Element): Promise<void> {
@@ -138,6 +234,12 @@ export function bootReviewerListPage(
     let request: InflightRequest | null = null;
     const promise = (async () => {
       const account = await accountResolver.resolveAccount(route.owner, route.repo);
+      const pullMetadata = (
+        await getPageMetadata(route, account, controller.signal)
+      ).get(pullNumber);
+      if (controller.signal.aborted) {
+        return;
+      }
 
       try {
         const summary = await fetchWithRefresh({
@@ -145,6 +247,7 @@ export function bootReviewerListPage(
           owner: route.owner,
           repo: route.repo,
           pullNumber,
+          pullMetadata,
           signal: controller.signal,
         });
         if (controller.signal.aborted) {
@@ -266,9 +369,10 @@ async function fetchWithRefresh(args: {
   owner: string;
   repo: string;
   pullNumber: string;
+  pullMetadata?: PullReviewerMetadata;
   signal: AbortSignal;
 }): Promise<PullReviewerSummary> {
-  const { account, owner, repo, pullNumber, signal } = args;
+  const { account, owner, repo, pullNumber, pullMetadata, signal } = args;
 
   if (signal.aborted) {
     throw createAbortError();
@@ -282,6 +386,7 @@ async function fetchWithRefresh(args: {
     repo,
     pullNumber,
     accountId: account?.id ?? null,
+    ...(pullMetadata == null ? {} : { pullMetadata }),
   }) as Promise<FetchPullReviewerSummaryResponse | undefined>;
 
   const abortListenerController = new AbortController();
@@ -315,6 +420,58 @@ async function fetchWithRefresh(args: {
   }
 }
 
+async function fetchPageMetadata(args: {
+  account: Account | null;
+  owner: string;
+  repo: string;
+  signal: AbortSignal;
+}): Promise<PullReviewerMetadata[]> {
+  const { account, owner, repo, signal } = args;
+
+  if (signal.aborted) {
+    throw createAbortError();
+  }
+
+  const requestId = createReviewerFetchRequestId();
+  const responsePromise = browser.runtime.sendMessage({
+    type: "fetchPullReviewerMetadataBatch",
+    requestId,
+    owner,
+    repo,
+    accountId: account?.id ?? null,
+  }) as Promise<FetchPullReviewerMetadataBatchResponse | undefined>;
+
+  const abortListenerController = new AbortController();
+  const abortPromise = new Promise<never>((_, reject) => {
+    const onAbort = () => {
+      void browser.runtime
+        .sendMessage({
+          type: "cancelPullReviewerSummary",
+          requestId,
+        })
+        .catch(() => undefined);
+      reject(createAbortError());
+    };
+
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+
+    signal.addEventListener("abort", onAbort, {
+      once: true,
+      signal: abortListenerController.signal,
+    });
+  });
+
+  try {
+    const response = await Promise.race([responsePromise, abortPromise]);
+    return unwrapReviewerMetadataBatchResponse(response);
+  } finally {
+    abortListenerController.abort();
+  }
+}
+
 function isAbortError(error: unknown): boolean {
   if (error instanceof DOMException && error.name === "AbortError") {
     return true;
@@ -342,6 +499,20 @@ function unwrapReviewerFetchResponse(
   }
 
   throw new Error("Background reviewer fetch failed.");
+}
+
+function unwrapReviewerMetadataBatchResponse(
+  response: FetchPullReviewerMetadataBatchResponse | undefined,
+): PullReviewerMetadata[] {
+  if (response?.ok === true) {
+    return response.metadata;
+  }
+
+  if (response?.ok === false) {
+    throw new ReviewerFetchRuntimeError(response.error);
+  }
+
+  throw new Error("Background reviewer metadata fetch failed.");
 }
 
 let reviewerFetchRequestCounter = 0;

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -31,6 +31,12 @@ const pullSchema = z.object({
     .default([]),
 });
 
+const pullReviewerMetadataSchema = pullSchema.extend({
+  number: z.number(),
+});
+
+const pullReviewerMetadataListSchema = z.array(pullReviewerMetadataSchema);
+
 const pullListSchema = z.array(
   z.object({
     number: z.number(),
@@ -67,6 +73,13 @@ export type ReviewState =
 export type ReviewerUser = { login: string; avatarUrl: string | null };
 
 export type CompletedReview = ReviewerUser & { state: ReviewState };
+
+export type PullReviewerMetadata = {
+  number: string;
+  authorLogin: string;
+  requestedUsers: ReviewerUser[];
+  requestedTeams: string[];
+};
 
 export type PullReviewerSummary = {
   status: PullReviewerSummaryStatus;
@@ -234,21 +247,47 @@ export async function fetchPullReviewerSummary(input: {
   repo: string;
   pullNumber: string;
   githubToken: string | null;
+  pullMetadata?: PullReviewerMetadata;
   signal?: AbortSignal;
 }): Promise<PullReviewerSummary> {
   const headers = createGitHubHeaders(input.githubToken);
-  const pullEndpoint = buildPullEndpoint(
-    input.owner,
-    input.repo,
-    input.pullNumber,
-  );
   const reviewsEndpoint = buildReviewsEndpoint(
     input.owner,
     input.repo,
     input.pullNumber,
   );
-  const pullUrl = `https://api.github.com${pullEndpoint.path}`;
   const reviewsFirstPageUrl = `https://api.github.com${reviewsEndpoint.path}?per_page=100`;
+
+  if (input.pullMetadata != null) {
+    const reviewsFirstResponse = await fetch(reviewsFirstPageUrl, {
+      headers,
+      signal: input.signal,
+    });
+
+    const failure = await createGitHubApiErrorFromResponse(
+      reviewsFirstResponse,
+      reviewsEndpoint,
+    );
+    if (failure != null) {
+      throw new GitHubPullRequestEndpointsError([failure]);
+    }
+
+    const reviews = await collectReviewsAcrossPages({
+      firstResponse: reviewsFirstResponse,
+      endpoint: reviewsEndpoint,
+      headers,
+      signal: input.signal,
+    });
+
+    return buildPullReviewerSummary(input.pullMetadata, reviews);
+  }
+
+  const pullEndpoint = buildPullEndpoint(
+    input.owner,
+    input.repo,
+    input.pullNumber,
+  );
+  const pullUrl = `https://api.github.com${pullEndpoint.path}`;
 
   const [pullResponse, reviewsFirstResponse] = await Promise.all([
     fetch(pullUrl, { headers, signal: input.signal }),
@@ -277,7 +316,43 @@ export async function fetchPullReviewerSummary(input: {
     headers,
     signal: input.signal,
   });
-  const pull = pullParsed.data;
+
+  return buildPullReviewerSummary(
+    toPullReviewerMetadata(input.pullNumber, pullParsed.data),
+    reviews,
+  );
+}
+
+export async function fetchPullReviewerMetadataBatch(input: {
+  owner: string;
+  repo: string;
+  githubToken: string | null;
+  signal?: AbortSignal;
+}): Promise<PullReviewerMetadata[]> {
+  const headers = createGitHubHeaders(input.githubToken);
+  const endpoint = buildPullsMetadataEndpoint(input.owner, input.repo);
+  const response = await fetch(`https://api.github.com${endpoint.path}`, {
+    headers,
+    signal: input.signal,
+  });
+
+  const failure = await createGitHubApiErrorFromResponse(response, endpoint);
+  if (failure != null) {
+    throw failure;
+  }
+
+  const parsed = pullReviewerMetadataListSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new GitHubApiSchemaError(endpoint, parsed.error.issues);
+  }
+
+  return parsed.data.map((pull) => toPullReviewerMetadata(String(pull.number), pull));
+}
+
+function buildPullReviewerSummary(
+  pullMetadata: PullReviewerMetadata,
+  reviews: z.infer<typeof reviewsSchema>,
+): PullReviewerSummary {
   const latestNonCommentByUser = new Map<
     string,
     {
@@ -303,7 +378,7 @@ export async function fetchPullReviewerSummary(input: {
     if (
       normalizedState == null ||
       reviewer == null ||
-      reviewer === pull.user.login
+      reviewer === pullMetadata.authorLogin
     ) {
       return;
     }
@@ -363,12 +438,24 @@ export async function fetchPullReviewerSummary(input: {
 
   return {
     status: "ok" as const,
+    requestedUsers: pullMetadata.requestedUsers,
+    requestedTeams: pullMetadata.requestedTeams,
+    completedReviews,
+  };
+}
+
+function toPullReviewerMetadata(
+  pullNumber: string,
+  pull: z.infer<typeof pullSchema>,
+): PullReviewerMetadata {
+  return {
+    number: pullNumber,
+    authorLogin: pull.user.login,
     requestedUsers: pull.requested_reviewers.map((reviewer) => ({
       login: reviewer.login,
       avatarUrl: normalizeAvatarUrl(reviewer.avatar_url),
     })),
     requestedTeams: pull.requested_teams.map((team) => team.slug),
-    completedReviews,
   };
 }
 
@@ -748,6 +835,17 @@ function buildPullsListEndpoint(
     name: "pulls-list",
     method: "GET",
     path: `/repos/${owner}/${repo}/pulls?per_page=1&state=all`,
+  };
+}
+
+function buildPullsMetadataEndpoint(
+  owner: string,
+  repo: string,
+): GitHubEndpointDescriptor {
+  return {
+    name: "pulls-list",
+    method: "GET",
+    path: `/repos/${owner}/${repo}/pulls?per_page=100&state=all`,
   };
 }
 

--- a/src/runtime/reviewer-fetch.ts
+++ b/src/runtime/reviewer-fetch.ts
@@ -4,6 +4,7 @@ import {
   GitHubPullRequestEndpointsError,
   extractGitHubApiStatus,
   isRateLimitError,
+  type PullReviewerMetadata,
   type PullReviewerSummary,
 } from "../github/api";
 
@@ -14,11 +15,20 @@ export type FetchPullReviewerSummaryMessage = {
   repo: string;
   pullNumber: string;
   accountId: string | null;
+  pullMetadata?: PullReviewerMetadata;
 };
 
 export type CancelPullReviewerSummaryMessage = {
   type: "cancelPullReviewerSummary";
   requestId: string;
+};
+
+export type FetchPullReviewerMetadataBatchMessage = {
+  type: "fetchPullReviewerMetadataBatch";
+  requestId: string;
+  owner: string;
+  repo: string;
+  accountId: string | null;
 };
 
 export type ReviewerFetchRateLimitSnapshot = {
@@ -52,6 +62,16 @@ export type FetchPullReviewerSummaryResponse =
       error: ReviewerFetchErrorEnvelope;
     };
 
+export type FetchPullReviewerMetadataBatchResponse =
+  | {
+      ok: true;
+      metadata: PullReviewerMetadata[];
+    }
+  | {
+      ok: false;
+      error: ReviewerFetchErrorEnvelope;
+    };
+
 export class ReviewerFetchRuntimeError extends Error {
   constructor(public readonly envelope: ReviewerFetchErrorEnvelope) {
     super(envelope.message ?? "Background reviewer fetch failed.");
@@ -71,7 +91,10 @@ export function isFetchPullReviewerSummaryMessage(
     hasNonEmptyString((value as { repo?: unknown }).repo) &&
     hasNonEmptyString((value as { pullNumber?: unknown }).pullNumber) &&
     (((value as { accountId?: unknown }).accountId === null) ||
-      typeof (value as { accountId?: unknown }).accountId === "string")
+      typeof (value as { accountId?: unknown }).accountId === "string") &&
+    (!("pullMetadata" in value) ||
+      (value as { pullMetadata?: unknown }).pullMetadata === undefined ||
+      isPullReviewerMetadata((value as { pullMetadata?: unknown }).pullMetadata))
   );
 }
 
@@ -83,6 +106,21 @@ export function isCancelPullReviewerSummaryMessage(
     typeof value === "object" &&
     (value as { type?: unknown }).type === "cancelPullReviewerSummary" &&
     hasNonEmptyString((value as { requestId?: unknown }).requestId)
+  );
+}
+
+export function isFetchPullReviewerMetadataBatchMessage(
+  value: unknown,
+): value is FetchPullReviewerMetadataBatchMessage {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    (value as { type?: unknown }).type === "fetchPullReviewerMetadataBatch" &&
+    hasNonEmptyString((value as { requestId?: unknown }).requestId) &&
+    hasNonEmptyString((value as { owner?: unknown }).owner) &&
+    hasNonEmptyString((value as { repo?: unknown }).repo) &&
+    (((value as { accountId?: unknown }).accountId === null) ||
+      typeof (value as { accountId?: unknown }).accountId === "string")
   );
 }
 
@@ -257,4 +295,30 @@ function parseRateLimitSnapshot(
 
 function hasNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function isPullReviewerMetadata(value: unknown): value is PullReviewerMetadata {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    hasNonEmptyString(record.number) &&
+    hasNonEmptyString(record.authorLogin) &&
+    Array.isArray(record.requestedUsers) &&
+    record.requestedUsers.every(isReviewerUser) &&
+    Array.isArray(record.requestedTeams) &&
+    record.requestedTeams.every((team) => typeof team === "string")
+  );
+}
+
+function isReviewerUser(value: unknown): value is PullReviewerMetadata["requestedUsers"][number] {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    hasNonEmptyString(record.login) &&
+    (record.avatarUrl === null || typeof record.avatarUrl === "string")
+  );
 }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -6,6 +6,7 @@ import {
   GitHubApiError,
   GitHubApiSchemaError,
   fetchPullReviewerSummary,
+  fetchPullReviewerMetadataBatch,
   describeGitHubApiError,
   isRateLimitError,
   parseRepositoryReference,
@@ -152,6 +153,52 @@ describe("isRateLimitError", () => {
 });
 
 describe("fetchPullReviewerSummary", () => {
+  it("skips the pull endpoint when page-level pull metadata is already available", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "APPROVED",
+              submitted_at: "2026-04-20T12:00:00Z",
+              user: { login: "bob" },
+            },
+            {
+              state: "APPROVED",
+              submitted_at: "2026-04-20T12:05:00Z",
+              user: { login: "hon454" },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+      pullMetadata: {
+        number: "42",
+        authorLogin: "hon454",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: ["platform"],
+      },
+    });
+
+    expect(summary).toEqual({
+      status: "ok",
+      requestedUsers: [{ login: "alice", avatarUrl: null }],
+      requestedTeams: ["platform"],
+      completedReviews: [{ login: "bob", avatarUrl: null, state: "APPROVED" }],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/42/reviews?per_page=100",
+    );
+  });
+
   it("supports public repository reads without sending an authorization header", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
@@ -848,6 +895,70 @@ describe("fetchPullReviewerSummary", () => {
     expect(summary.completedReviews).toEqual([
       { login: "eve", avatarUrl: null, state: "APPROVED" },
     ]);
+  });
+});
+
+describe("fetchPullReviewerMetadataBatch", () => {
+  it("reads requested reviewer metadata for a page of pull requests without a token", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              number: 42,
+              user: { login: "hon454" },
+              requested_reviewers: [
+                {
+                  login: "alice",
+                  avatar_url: "https://avatars.githubusercontent.com/u/1?v=4",
+                },
+              ],
+              requested_teams: [{ slug: "platform" }],
+            },
+            {
+              number: 41,
+              user: { login: "octocat" },
+              requested_reviewers: [],
+              requested_teams: [],
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const metadata = await fetchPullReviewerMetadataBatch({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      githubToken: null,
+    });
+
+    expect(metadata).toEqual([
+      {
+        number: "42",
+        authorLogin: "hon454",
+        requestedUsers: [
+          {
+            login: "alice",
+            avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+          },
+        ],
+        requestedTeams: ["platform"],
+      },
+      {
+        number: "41",
+        authorLogin: "octocat",
+        requestedUsers: [],
+        requestedTeams: [],
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls?per_page=100&state=all",
+    );
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers;
+    expect(headers).toBeInstanceOf(Headers);
+    expect((headers as Headers).get("Authorization")).toBeNull();
   });
 });
 

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -46,6 +46,14 @@ for (const fixtureCase of renderCases) {
       const fixtureHtml = await readFile(path.join(fixturesDir, fixtureCase.fixture), "utf8");
 
       await routeFixturePage(context, fixtureHtml);
+      await routePullListApi(context, [
+        {
+          number: Number(fixtureCase.pullNumber),
+          user: { login: "hon454" },
+          requested_reviewers: [{ login: "alice" }],
+          requested_teams: [{ slug: "platform" }],
+        },
+      ]);
       await routePullApi(context, fixtureCase.pullNumber, {
         user: { login: "hon454" },
         requested_reviewers: [{ login: "alice" }],
@@ -78,6 +86,14 @@ test("omits the inline reviewer row when both requested and reviewed are empty",
     const fixtureHtml = await readFile(path.join(fixturesDir, singleRowFixture), "utf8");
 
     await routeFixturePage(context, fixtureHtml);
+    await routePullListApi(context, [
+      {
+        number: 42,
+        user: { login: "hon454" },
+        requested_reviewers: [],
+        requested_teams: [],
+      },
+    ]);
     await routePullApi(context, "42", {
       user: { login: "hon454" },
       requested_reviewers: [],
@@ -100,6 +116,7 @@ test("renders unauth-rate-limit banner with Sign in CTA when an unauthenticated 
     );
 
     await routeFixturePage(context, fixtureHtml);
+    await routePullListApi(context, []);
     await context.route(
       "https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/42",
       async (route) => {
@@ -168,6 +185,7 @@ test("renders app-uncovered banner with Configure access CTA when a signed-in ro
     });
 
     await routeFixturePage(context, fixtureHtml);
+    await routePullListApi(context, []);
     // Defensive stub: in case the background ever calls the installations API,
     // return an empty list rather than letting the real network handle it.
     await context.route("https://api.github.com/user/installations**", async (route) => {
@@ -201,6 +219,7 @@ test("clears the reviewer slot silently when review history is denied", async ()
     const fixtureHtml = await readFile(path.join(fixturesDir, singleRowFixture), "utf8");
 
     await routeFixturePage(context, fixtureHtml);
+    await routePullListApi(context, []);
     await routePullApi(context, "42", {
       user: { login: "hon454" },
       requested_reviewers: [{ login: "alice" }],
@@ -308,6 +327,22 @@ async function routePullApi(
 ): Promise<void> {
   await context.route(
     `https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/${pullNumber}`,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(payload),
+      });
+    },
+  );
+}
+
+async function routePullListApi(
+  context: Awaited<ReturnType<typeof chromium.launchPersistentContext>>,
+  payload: object,
+): Promise<void> {
+  await context.route(
+    /^https:\/\/api\.github\.com\/repos\/hon454\/github-pulls-show-reviewers\/pulls\?/,
     async (route) => {
       await route.fulfill({
         status: 200,

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -63,6 +63,12 @@ function getRegisteredListener(
   )?.[2] as (() => void) | undefined;
 }
 
+function getRuntimeMessages(type: string): Array<Record<string, unknown>> {
+  return runtimeSendMessageMock.mock.calls
+    .map(([message]) => message as Record<string, unknown>)
+    .filter((message) => message.type === type);
+}
+
 beforeEach(() => {
   vi.resetModules();
   resolveAccountForRepoMock.mockReset();
@@ -117,14 +123,19 @@ describe("bootReviewerListPage", () => {
       requestedTeams: [],
       completedReviews: [],
     };
-    runtimeSendMessageMock.mockResolvedValue({ ok: true, summary });
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({ ok: true, metadata: [] });
+      }
+      return Promise.resolve({ ok: true, summary });
+    });
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
     bootReviewerListPage(makeCtx());
 
     await flushMicrotasks();
     await flushMicrotasks();
-    expect(runtimeSendMessageMock).toHaveBeenCalledTimes(1);
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(1);
     expect(document.querySelector("a.ghpsr-pill")).toBeNull();
     expect(document.querySelector("a.ghpsr-avatar")).not.toBeNull();
 
@@ -157,7 +168,7 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(runtimeSendMessageMock).toHaveBeenCalledTimes(1);
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(1);
     expect(document.querySelector("a.ghpsr-pill")).not.toBeNull();
   });
 
@@ -169,14 +180,19 @@ describe("bootReviewerListPage", () => {
       requestedTeams: [],
       completedReviews: [],
     };
-    runtimeSendMessageMock.mockResolvedValue({ ok: true, summary });
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({ ok: true, metadata: [] });
+      }
+      return Promise.resolve({ ok: true, summary });
+    });
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
     bootReviewerListPage(makeCtx());
 
     await flushMicrotasks();
     await flushMicrotasks();
-    expect(runtimeSendMessageMock).toHaveBeenCalledTimes(1);
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(1);
 
     capturedStorageListener!(
       {
@@ -191,7 +207,7 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(runtimeSendMessageMock).toHaveBeenCalledTimes(2);
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(2);
   });
 
   it("sends reviewer fetch requests through the background runtime contract", async () => {
@@ -208,7 +224,12 @@ describe("bootReviewerListPage", () => {
       token: "ghu_old",
       refreshToken: "ghr_old",
     });
-    runtimeSendMessageMock.mockResolvedValueOnce({ ok: true, summary });
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({ ok: true, metadata: [] });
+      }
+      return Promise.resolve({ ok: true, summary });
+    });
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
     bootReviewerListPage(makeCtx());
@@ -216,6 +237,15 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
+    expect(runtimeSendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "fetchPullReviewerMetadataBatch",
+        owner: "cinev",
+        repo: "shotloom",
+        accountId: "acc-1",
+        requestId: expect.any(String),
+      }),
+    );
     expect(runtimeSendMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "fetchPullReviewerSummary",
@@ -226,7 +256,79 @@ describe("bootReviewerListPage", () => {
         requestId: expect.any(String),
       }),
     );
-    expect(runtimeSendMessageMock).toHaveBeenCalledTimes(1);
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(1);
+  });
+
+  it("requests page-level pull metadata once and reuses it for matching row summaries", async () => {
+    document.body.innerHTML = `
+      <div class="js-issue-row" id="issue_42">
+        <a class="Link--primary" href="/cinev/shotloom/pull/42">PR #42</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+      <div class="js-issue-row" id="issue_41">
+        <a class="Link--primary" href="/cinev/shotloom/pull/41">PR #41</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+    `;
+    resolveAccountForRepoMock.mockResolvedValue(null);
+    const summary: PullReviewerSummary = {
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: [],
+      completedReviews: [],
+    };
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({
+          ok: true,
+          metadata: [
+            {
+              number: "42",
+              authorLogin: "cinev",
+              requestedUsers: [{ login: "alice", avatarUrl: null }],
+              requestedTeams: ["platform"],
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ ok: true, summary });
+    });
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const metadataCall = runtimeSendMessageMock.mock.calls.find(
+      ([message]) => message.type === "fetchPullReviewerMetadataBatch",
+    )?.[0];
+    const summaryCalls = runtimeSendMessageMock.mock.calls
+      .map(([message]) => message)
+      .filter((message) => message.type === "fetchPullReviewerSummary");
+
+    expect(metadataCall).toMatchObject({
+      type: "fetchPullReviewerMetadataBatch",
+      owner: "cinev",
+      repo: "shotloom",
+      accountId: null,
+      requestId: expect.any(String),
+    });
+    expect(summaryCalls).toHaveLength(2);
+    expect(
+      summaryCalls.find((message) => message.pullNumber === "42"),
+    ).toMatchObject({
+      pullMetadata: {
+        number: "42",
+        authorLogin: "cinev",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: ["platform"],
+      },
+    });
+    expect(
+      summaryCalls.find((message) => message.pullNumber === "41"),
+    ).not.toHaveProperty("pullMetadata");
   });
 
   it("does not flash loading text on a cache-hit re-render", async () => {
@@ -269,15 +371,22 @@ describe("bootReviewerListPage", () => {
     resolveAccountForRepoMock.mockResolvedValue(null);
 
     let resolveFetch: ((summary: PullReviewerSummary) => void) | null = null;
-    runtimeSendMessageMock
-      .mockImplementationOnce(
-        () =>
-          new Promise<{ ok: true; summary: PullReviewerSummary }>((resolve) => {
-            resolveFetch = (summary) => resolve({ ok: true, summary });
-          }),
-      )
-      .mockResolvedValueOnce(undefined)
-      .mockImplementationOnce(() => new Promise<void>(() => {}));
+    let summaryRequestCount = 0;
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({ ok: true, metadata: [] });
+      }
+      if (message.type === "cancelPullReviewerSummary") {
+        return Promise.resolve(undefined);
+      }
+      summaryRequestCount += 1;
+      if (summaryRequestCount === 1) {
+        return new Promise<{ ok: true; summary: PullReviewerSummary }>((resolve) => {
+          resolveFetch = (summary) => resolve({ ok: true, summary });
+        });
+      }
+      return new Promise<void>(() => {});
+    });
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
     bootReviewerListPage(makeCtx());
@@ -310,11 +419,11 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(runtimeSendMessageMock.mock.calls[1]?.[0]).toMatchObject({
+    expect(getRuntimeMessages("cancelPullReviewerSummary")[0]).toMatchObject({
       type: "cancelPullReviewerSummary",
       requestId: expect.any(String),
     });
-    expect(runtimeSendMessageMock.mock.calls[2]?.[0]).toMatchObject({
+    expect(getRuntimeMessages("fetchPullReviewerSummary")[1]).toMatchObject({
       type: "fetchPullReviewerSummary",
       requestId: expect.any(String),
     });
@@ -329,14 +438,29 @@ describe("bootReviewerListPage", () => {
 
   it("shows loading again after a failed refetch clears a previously rendered row", async () => {
     resolveAccountForRepoMock.mockResolvedValue(null);
-    runtimeSendMessageMock.mockResolvedValueOnce({
-      ok: true,
-      summary: {
-        status: "ok",
-        requestedUsers: [{ login: "alice", avatarUrl: null }],
-        requestedTeams: [],
-        completedReviews: [],
+    const summaryResponses: unknown[] = [
+      {
+        ok: true,
+        summary: {
+          status: "ok",
+          requestedUsers: [{ login: "alice", avatarUrl: null }],
+          requestedTeams: [],
+          completedReviews: [],
+        },
       },
+    ];
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({ ok: true, metadata: [] });
+      }
+      if (message.type === "cancelPullReviewerSummary") {
+        return Promise.resolve(undefined);
+      }
+      const response = summaryResponses.shift();
+      if (response != null) {
+        return Promise.resolve(response);
+      }
+      return new Promise<void>(() => {});
     });
 
     const { bootReviewerListPage } = await import("../src/features/reviewers");
@@ -346,7 +470,7 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
     expect(document.querySelector("a.ghpsr-avatar")).not.toBeNull();
 
-    runtimeSendMessageMock.mockResolvedValueOnce({
+    summaryResponses.push({
       ok: false,
       error: { kind: "unknown", status: null, message: "boom" },
     });
@@ -365,9 +489,6 @@ describe("bootReviewerListPage", () => {
     expect(document.body.textContent).not.toContain("alice");
     expect(document.body.textContent).not.toContain("Loading reviewers");
 
-    runtimeSendMessageMock.mockImplementationOnce(
-      () => new Promise<never>(() => {}),
-    );
     capturedStorageListener!(
       {
         settings: {


### PR DESCRIPTION
## Summary

- Reduces cold PR-list request volume by batching pull-list reviewer metadata once per page/account.
- Preserves no-token public repository support and signed-in private repository routing through the background service worker.
- Documents the new REST batching behavior and fallback limits.

## Why

Issue #40 calls out the current cold-row path as the largest remaining rate-limit and perceived-performance pressure: every uncached row needed both a pull endpoint request and a reviews endpoint request. This keeps the REST/no-token path intact while avoiding the per-row pull request call when first-page pull-list metadata already contains the row.

## Changes

- Adds a REST pull-list metadata batch fetch for requested reviewers, requested teams, and author login.
- Reuses page-level metadata in the content script and passes matching metadata through the runtime contract to summary fetches.
- Skips the per-row pull endpoint when metadata is available, while falling back to the original `pull + reviews` path for rows not covered by the batch.
- Extends unit and packaged extension E2E coverage for the new runtime messages and fixture mocks.
- Updates README and implementation notes for the new request-volume behavior and remaining limitations.

## Impact

- User-facing impact: Reviewer chips render with the same semantics; cold first-page PR lists use fewer GitHub API requests.
- API/schema impact: Adds internal runtime message `fetchPullReviewerMetadataBatch` and optional `pullMetadata` on summary messages; no external user-facing API.
- Performance impact: Typical first PR-list page changes from `2N` cold row requests to `1 + N` requests when all visible rows are covered by the first REST pull-list page.
- Operational or rollout impact: Public no-token and private GitHub App account paths are preserved; filtered or older pages can still fall back per row.

## Testing

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

### Test details

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (310 tests)
- `pnpm test:e2e` (8 packaged extension tests)

## Breaking Changes

- None

## Related Issues

Resolves #40

<!-- Co-location checklist: reviewer runtime behavior changed, so README.md and docs/implementation-notes.md were updated. -->