### PR TITLE
feat(reviewers): revalidate stale reviewer cache

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -24,19 +24,28 @@
 3. Extract the pull request number from the row id or primary pull request link.
 4. Resolve the covering account for `owner/repo` via `resolveAccountForRepo`.
 5. Send one `fetchPullReviewerMetadataBatch` message per page/account when the
-   cache is cold. The background reads the first REST pull-list page with the
-   matched account token (or no token if none matches), returning requested user
-   reviewers, requested teams, and author logins that can be reused across
-   visible rows.
-6. Send a `fetchPullReviewerSummary` message for each uncached row. When the
-   page-level metadata contains that pull request number, the background skips
-   the per-row pull endpoint and reads only the reviews endpoint. If the pull
-   number is absent from the batch result, the summary request falls back to the
-   original per-row `pull + reviews` REST path.
+   page-level metadata cache is cold or stale. The background reads the first
+   REST pull-list page with the matched account token (or no token if none
+   matches), returning requested user reviewers, requested teams, and author
+   logins that can be reused across visible rows. Page metadata has a shorter
+   freshness window than row summaries because re-review requests primarily
+   change `requested_reviewers` / `requested_teams`.
+6. Send a `fetchPullReviewerSummary` message for each uncached or stale row.
+   Fresh cache hits render without refetching. Stale cache hits render the
+   cached chips immediately, then revalidate in the background and rerender only
+   the affected row when fresh data arrives. When the page-level metadata
+   contains that pull request number, the background skips the per-row pull
+   endpoint and reads only the reviews endpoint. If the pull number is absent
+   from the batch result, the summary request falls back to the original per-row
+   `pull + reviews` REST path.
 7. Render a single `Reviewers` section inline in the PR row metadata area. Each reviewer is an avatar chip. Requested reviewers keep the blue requested ring. Completed reviewers show a ring and badge derived from one `(isRequested, state)` mapping. Review selection prefers the latest non-`COMMENTED` review for a reviewer, falling back to the latest `COMMENTED` review only when no non-comment review exists. A still-requested reviewer with prior `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` evidence shows the refresh badge instead of the prior state badge. Requested teams keep the text chip shape. User chip links follow the same primary axis as the ring color: blue-ring (still-requested) chips link to `review-requested:<login>`; colored-ring (completed) chips link to `reviewed-by:<login>`. Reviewer chip links use `is:pr is:open` searches by default.
 8. On API errors, emit a signal to the banner aggregator; do not render
    row-level error text.
-9. Re-run row processing when GitHub mutates the page or performs SPA navigation.
+9. Re-run row processing when GitHub mutates the page or performs SPA
+   navigation. Same-repository navigation/render events mark visible row
+   summaries stale instead of trusting the active page-session cache forever.
+   Existing-row DOM mutations use a lightweight row fingerprint so unrelated
+   attribute changes do not trigger reviewer API requests.
 
 ## Current limitations
 
@@ -64,8 +73,9 @@
   `GET /repos/{owner}/{repo}/pulls?per_page=100&state=all` as a page-level
   metadata hint before row summaries.
 - The content script de-duplicates in-flight row fetches, caches each pull
-  request summary for the active page session, and caches the page-level
-  metadata result per `owner/repo/account`.
+  request summary for the active page session with freshness metadata, and
+  caches the page-level metadata result per `owner/repo/account` with a shorter
+  freshness window.
 - A GraphQL-first rewrite is not the next step because it would push the product away from the current no-token public-repository path and add a second transport model to maintain.
 - If request volume remains the next bottleneck, the preferred follow-up is to
   make the REST batch smarter for filtered and paginated GitHub list pages
@@ -73,14 +83,14 @@
 
 ## Access banner classification
 
-| Account state | Failure pattern                                           | Banner kind          | CTA              |
-| ------------- | --------------------------------------------------------- | -------------------- | ---------------- |
-| Signed in     | 401 on any reviewer endpoint                              | `auth-expired`       | Sign in          |
-| Signed in     | 404 / 403 with no rate-limit signal                       | `app-uncovered`      | Configure access |
-| Signed in     | 429, or 403 with `x-ratelimit-remaining: 0`               | `auth-rate-limit`    | (passive wait)   |
-| No account    | 429, or 403 with rate-limit signal                        | `unauth-rate-limit`  | Sign in          |
-| No account    | 401, 403, or 404 without rate-limit signal                | `signin-required`    | Sign in          |
-| Either        | Network / schema / unknown / empty endpoint envelope      | (silent, console.warn) | —             |
+| Account state | Failure pattern                                      | Banner kind            | CTA              |
+| ------------- | ---------------------------------------------------- | ---------------------- | ---------------- |
+| Signed in     | 401 on any reviewer endpoint                         | `auth-expired`         | Sign in          |
+| Signed in     | 404 / 403 with no rate-limit signal                  | `app-uncovered`        | Configure access |
+| Signed in     | 429, or 403 with `x-ratelimit-remaining: 0`          | `auth-rate-limit`      | (passive wait)   |
+| No account    | 429, or 403 with rate-limit signal                   | `unauth-rate-limit`    | Sign in          |
+| No account    | 401, 403, or 404 without rate-limit signal           | `signin-required`      | Sign in          |
+| Either        | Network / schema / unknown / empty endpoint envelope | (silent, console.warn) | —                |
 
 Severity priority for cross-row resolution: `auth-expired` > `app-uncovered` >
 `auth-rate-limit` > `unauth-rate-limit` > `signin-required`. The highest-priority

--- a/src/cache/reviewer-cache.ts
+++ b/src/cache/reviewer-cache.ts
@@ -1,13 +1,19 @@
 import type { PullReviewerSummary } from "../github/api";
 
 export type CacheKey = `${string}/${string}#${string}`;
+export type ReviewerCacheEntry = {
+  summary: PullReviewerSummary;
+  fetchedAt: number;
+  stale: boolean;
+};
 
 const DEFAULT_MAX_ENTRIES = 500;
+export const REVIEWER_SUMMARY_FRESH_MS = 30_000;
 
 let maxEntries = DEFAULT_MAX_ENTRIES;
-const reviewerCache = new Map<CacheKey, PullReviewerSummary>();
+const reviewerCache = new Map<CacheKey, ReviewerCacheEntry>();
 
-export function getCachedReviewerSummary(key: CacheKey): PullReviewerSummary | undefined {
+function promoteEntry(key: CacheKey): ReviewerCacheEntry | undefined {
   const value = reviewerCache.get(key);
   if (value !== undefined) {
     // LRU: re-insert to move the entry to the most-recently-used end.
@@ -17,11 +23,38 @@ export function getCachedReviewerSummary(key: CacheKey): PullReviewerSummary | u
   return value;
 }
 
-export function setCachedReviewerSummary(key: CacheKey, value: PullReviewerSummary): void {
+export function getCachedReviewerSummary(
+  key: CacheKey,
+): PullReviewerSummary | undefined {
+  return promoteEntry(key)?.summary;
+}
+
+export function getReviewerCacheEntry(
+  key: CacheKey,
+): ReviewerCacheEntry | undefined {
+  return promoteEntry(key);
+}
+
+export function isReviewerCacheEntryFresh(
+  entry: ReviewerCacheEntry,
+  now = Date.now(),
+): boolean {
+  return !entry.stale && now - entry.fetchedAt <= REVIEWER_SUMMARY_FRESH_MS;
+}
+
+export function setCachedReviewerSummary(
+  key: CacheKey,
+  value: PullReviewerSummary,
+  options: { fetchedAt?: number } = {},
+): void {
   if (reviewerCache.has(key)) {
     reviewerCache.delete(key);
   }
-  reviewerCache.set(key, value);
+  reviewerCache.set(key, {
+    summary: value,
+    fetchedAt: options.fetchedAt ?? Date.now(),
+    stale: false,
+  });
   while (reviewerCache.size > maxEntries) {
     const oldest = reviewerCache.keys().next().value;
     if (oldest === undefined) {
@@ -31,8 +64,30 @@ export function setCachedReviewerSummary(key: CacheKey, value: PullReviewerSumma
   }
 }
 
-export function buildReviewerCacheKey(owner: string, repo: string, pullNumber: string): CacheKey {
+export function buildReviewerCacheKey(
+  owner: string,
+  repo: string,
+  pullNumber: string,
+): CacheKey {
   return `${owner}/${repo}#${pullNumber}`;
+}
+
+export function markReviewerCacheStale(key: CacheKey): void {
+  const entry = reviewerCache.get(key);
+  if (entry == null) return;
+  reviewerCache.set(key, { ...entry, stale: true });
+}
+
+export function markReviewerCacheStaleForRepository(
+  owner: string,
+  repo: string,
+): void {
+  const prefix = `${owner}/${repo}#`;
+  for (const [key, entry] of reviewerCache) {
+    if (key.startsWith(prefix)) {
+      reviewerCache.set(key, { ...entry, stale: true });
+    }
+  }
 }
 
 export function clearReviewerCache(): void {

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -386,6 +386,7 @@ export function bootReviewerListPage(
         processMutatedRow(mutation.target);
         continue;
       }
+      processMutatedRow(mutation.target);
       mutation.addedNodes.forEach((node) => {
         if (!(node instanceof Element)) return;
         if (node.closest("[data-ghpsr-root]") != null) return;

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -3,10 +3,16 @@ import type { ContentScriptContext } from "wxt/utils/content-script-context";
 import {
   buildReviewerCacheKey,
   clearReviewerCache,
-  getCachedReviewerSummary,
+  getReviewerCacheEntry,
+  isReviewerCacheEntryFresh,
+  markReviewerCacheStale,
+  markReviewerCacheStaleForRepository,
   setCachedReviewerSummary,
 } from "../../cache/reviewer-cache";
-import type { PullReviewerMetadata, PullReviewerSummary } from "../../github/api";
+import type {
+  PullReviewerMetadata,
+  PullReviewerSummary,
+} from "../../github/api";
 import { parsePullListRoute } from "../../github/routes";
 import { githubSelectors } from "../../github/selectors";
 import type { RefreshAccountInstallationsResponse } from "../../runtime/installation-refresh";
@@ -35,6 +41,8 @@ import {
   renderReviewers,
 } from "./dom";
 import { buildReviewers } from "./view-model";
+
+const PAGE_METADATA_FRESH_MS = 10_000;
 
 export type ReviewerBootOptions = {
   onRowFailure?: (signal: {
@@ -69,8 +77,11 @@ export function bootReviewerListPage(
     repo: string;
     accountId: string | null;
     metadata: Map<string, PullReviewerMetadata>;
+    fetchedAt: number;
+    stale: boolean;
   };
   const inflightRequests = new Map<string, InflightRequest>();
+  const rowFingerprints = new Map<string, string>();
   let pageMetadataRequest: PageMetadataRequest | null = null;
   let pageMetadataCache: PageMetadataCache | null = null;
   let cachedPreferences: Promise<Preferences> | null = null;
@@ -98,7 +109,7 @@ export function bootReviewerListPage(
   async function renderSummaryForMount(
     mount: HTMLElement,
     route: NonNullable<typeof currentRoute>,
-    summary: ReturnType<typeof getCachedReviewerSummary>,
+    summary: PullReviewerSummary | undefined,
   ): Promise<void> {
     if (!summary) return;
     const preferences = await readPreferences();
@@ -121,7 +132,9 @@ export function bootReviewerListPage(
       pageMetadataCache != null &&
       pageMetadataCache.owner === route.owner &&
       pageMetadataCache.repo === route.repo &&
-      pageMetadataCache.accountId === accountId
+      pageMetadataCache.accountId === accountId &&
+      !pageMetadataCache.stale &&
+      Date.now() - pageMetadataCache.fetchedAt <= PAGE_METADATA_FRESH_MS
     ) {
       return pageMetadataCache.metadata;
     }
@@ -164,6 +177,8 @@ export function bootReviewerListPage(
             repo: route.repo,
             accountId,
             metadata: metadataByNumber,
+            fetchedAt: Date.now(),
+            stale: false,
           };
           return metadataByNumber;
         })
@@ -174,6 +189,8 @@ export function bootReviewerListPage(
               repo: route.repo,
               accountId,
               metadata: new Map(),
+              fetchedAt: Date.now(),
+              stale: false,
             };
           }
           return new Map<string, PullReviewerMetadata>();
@@ -199,10 +216,13 @@ export function bootReviewerListPage(
 
     const route = currentRoute;
     const cacheKey = buildReviewerCacheKey(route.owner, route.repo, pullNumber);
-    const cachedSummary = getCachedReviewerSummary(cacheKey);
-    if (cachedSummary) {
-      await renderSummaryForMount(mount, route, cachedSummary);
-      return;
+    rowFingerprints.set(cacheKey, createRowFingerprint(row, pullNumber));
+    const cachedEntry = getReviewerCacheEntry(cacheKey);
+    if (cachedEntry != null) {
+      await renderSummaryForMount(mount, route, cachedEntry.summary);
+      if (isReviewerCacheEntryFresh(cachedEntry)) {
+        return;
+      }
     }
 
     const existingRequest = inflightRequests.get(cacheKey);
@@ -211,9 +231,9 @@ export function bootReviewerListPage(
       // key, render it immediately instead of flashing the loading text.
       // This also covers the race where the cache has just been set but the
       // inflight entry has not been deleted yet.
-      const existingSummary = getCachedReviewerSummary(cacheKey);
-      if (existingSummary) {
-        await renderSummaryForMount(mount, route, existingSummary);
+      const existingEntry = getReviewerCacheEntry(cacheKey);
+      if (existingEntry != null) {
+        await renderSummaryForMount(mount, route, existingEntry.summary);
       } else if (!mountHasRenderedChips(mount)) {
         renderLoading(mount);
       }
@@ -222,18 +242,25 @@ export function bootReviewerListPage(
       } catch {
         // Existing request errors are reported via its own onRowFailure; swallow here.
       }
-      await renderSummaryForMount(mount, route, getCachedReviewerSummary(cacheKey));
+      await renderSummaryForMount(
+        mount,
+        route,
+        getReviewerCacheEntry(cacheKey)?.summary,
+      );
       return;
     }
 
-    if (!mountHasRenderedChips(mount)) {
+    if (cachedEntry == null && !mountHasRenderedChips(mount)) {
       renderLoading(mount);
     }
 
     const controller = new AbortController();
     let request: InflightRequest | null = null;
     const promise = (async () => {
-      const account = await accountResolver.resolveAccount(route.owner, route.repo);
+      const account = await accountResolver.resolveAccount(
+        route.owner,
+        route.repo,
+      );
       const pullMetadata = (
         await getPageMetadata(route, account, controller.signal)
       ).get(pullNumber);
@@ -287,7 +314,11 @@ export function bootReviewerListPage(
       return;
     }
 
-    await renderSummaryForMount(mount, route, getCachedReviewerSummary(cacheKey));
+    await renderSummaryForMount(
+      mount,
+      route,
+      getReviewerCacheEntry(cacheKey)?.summary,
+    );
   }
 
   function processRows(root: ParentNode = document): void {
@@ -295,6 +326,33 @@ export function bootReviewerListPage(
     root.querySelectorAll(githubSelectors.row).forEach((row) => {
       void processRow(row);
     });
+  }
+
+  function processMutatedRow(target: Node): void {
+    if (currentRoute == null) return;
+    const element = target instanceof Element ? target : target.parentElement;
+    if (element == null || element.closest("[data-ghpsr-root]") != null) {
+      return;
+    }
+    const row = element.closest(githubSelectors.row);
+    if (row == null) return;
+    const pullNumber = extractPullNumber(row);
+    if (pullNumber == null) return;
+    const cacheKey = buildReviewerCacheKey(
+      currentRoute.owner,
+      currentRoute.repo,
+      pullNumber,
+    );
+    const nextFingerprint = createRowFingerprint(row, pullNumber);
+    const previousFingerprint = rowFingerprints.get(cacheKey);
+    rowFingerprints.set(cacheKey, nextFingerprint);
+    if (previousFingerprint === nextFingerprint) {
+      return;
+    }
+    markReviewerCacheStale(cacheKey);
+    pageMetadataCache =
+      pageMetadataCache == null ? null : { ...pageMetadataCache, stale: true };
+    void processRow(row);
   }
 
   function refreshRoute(force = false): void {
@@ -311,6 +369,12 @@ export function bootReviewerListPage(
       previousRoute?.repo !== currentRoute?.repo
     ) {
       clearReviewerCache();
+      rowFingerprints.clear();
+    } else if (currentRoute != null) {
+      markReviewerCacheStaleForRepository(
+        currentRoute.owner,
+        currentRoute.repo,
+      );
     }
 
     processRows();
@@ -318,8 +382,13 @@ export function bootReviewerListPage(
 
   const observer = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
+      if (mutation.type !== "childList" || mutation.addedNodes.length === 0) {
+        processMutatedRow(mutation.target);
+        continue;
+      }
       mutation.addedNodes.forEach((node) => {
         if (!(node instanceof Element)) return;
+        if (node.closest("[data-ghpsr-root]") != null) return;
         if (node.matches(githubSelectors.row)) {
           void processRow(node);
           return;
@@ -329,7 +398,12 @@ export function bootReviewerListPage(
     }
   });
 
-  observer.observe(document.body, { childList: true, subtree: true });
+  observer.observe(document.body, {
+    attributes: true,
+    childList: true,
+    characterData: true,
+    subtree: true,
+  });
   processRows();
 
   ctx.addEventListener(window, "wxt:locationchange", () => refreshRoute(true));
@@ -337,10 +411,9 @@ export function bootReviewerListPage(
   ctx.addEventListener(document, "turbo:render", () => refreshRoute(true));
   ctx.addEventListener(document, "pjax:end", () => refreshRoute(true));
 
-  const storageListener: Parameters<typeof browser.storage.onChanged.addListener>[0] = (
-    changes,
-    areaName,
-  ) => {
+  const storageListener: Parameters<
+    typeof browser.storage.onChanged.addListener
+  >[0] = (changes, areaName) => {
     if (areaName !== "local") return;
 
     if (isPreferencesChange(changes)) {
@@ -362,6 +435,34 @@ export function bootReviewerListPage(
     observer.disconnect();
     browser.storage.onChanged.removeListener(storageListener);
   });
+}
+
+function createRowFingerprint(row: Element, pullNumber: string): string {
+  const link = row.querySelector<HTMLAnchorElement>(
+    githubSelectors.primaryLink,
+  );
+  const href = link?.getAttribute("href") ?? "";
+  const metaContainer = findFirst(row, githubSelectors.metaContainers);
+  return [pullNumber, href, readRowMetadataText(metaContainer)].join("|");
+}
+
+function findFirst(
+  root: ParentNode,
+  selectors: readonly string[],
+): Element | null {
+  for (const selector of selectors) {
+    const match = root.querySelector(selector);
+    if (match != null) return match;
+  }
+  return null;
+}
+
+function readRowMetadataText(metaContainer: Element | null): string {
+  if (metaContainer == null) return "";
+  const clone = metaContainer.cloneNode(true);
+  if (!(clone instanceof Element)) return "";
+  clone.querySelectorAll("[data-ghpsr-root]").forEach((node) => node.remove());
+  return (clone.textContent ?? "").replace(/\s+/g, " ").trim();
 }
 
 async function fetchWithRefresh(args: {
@@ -539,7 +640,9 @@ function createAbortError(): Error {
   return error;
 }
 
-async function requestInstallationsRefresh(accountId: string): Promise<boolean> {
+async function requestInstallationsRefresh(
+  accountId: string,
+): Promise<boolean> {
   try {
     const response = (await browser.runtime.sendMessage({
       type: "refreshAccountInstallations",

--- a/tests/reviewer-cache.test.ts
+++ b/tests/reviewer-cache.test.ts
@@ -7,6 +7,11 @@ import {
   buildReviewerCacheKey,
   clearReviewerCache,
   getCachedReviewerSummary,
+  getReviewerCacheEntry,
+  isReviewerCacheEntryFresh,
+  markReviewerCacheStale,
+  markReviewerCacheStaleForRepository,
+  REVIEWER_SUMMARY_FRESH_MS,
   setCachedReviewerSummary,
 } from "../src/cache/reviewer-cache";
 
@@ -69,5 +74,60 @@ describe("reviewer cache", () => {
     setCachedReviewerSummary(a, summary("a2"));
     expect(getCachedReviewerSummary(a)?.requestedUsers[0].login).toBe("a2");
     expect(getCachedReviewerSummary(b)?.requestedUsers[0].login).toBe("b");
+  });
+
+  it("tracks freshness without changing the summary getter contract", () => {
+    const key = buildReviewerCacheKey("org", "repo", "1");
+    const fetchedAt = 1_000;
+    setCachedReviewerSummary(key, summary("alice"), { fetchedAt });
+
+    expect(getCachedReviewerSummary(key)?.requestedUsers[0].login).toBe(
+      "alice",
+    );
+
+    const entry = getReviewerCacheEntry(key);
+    expect(entry?.summary.requestedUsers[0].login).toBe("alice");
+    expect(entry?.fetchedAt).toBe(fetchedAt);
+    expect(
+      isReviewerCacheEntryFresh(entry!, fetchedAt + REVIEWER_SUMMARY_FRESH_MS),
+    ).toBe(true);
+    expect(
+      isReviewerCacheEntryFresh(
+        entry!,
+        fetchedAt + REVIEWER_SUMMARY_FRESH_MS + 1,
+      ),
+    ).toBe(false);
+  });
+
+  it("can mark a single cache entry stale for targeted revalidation", () => {
+    const key = buildReviewerCacheKey("org", "repo", "1");
+    setCachedReviewerSummary(key, summary("alice"), { fetchedAt: 10_000 });
+
+    markReviewerCacheStale(key);
+
+    const entry = getReviewerCacheEntry(key);
+    expect(entry?.summary.requestedUsers[0].login).toBe("alice");
+    expect(isReviewerCacheEntryFresh(entry!, 10_001)).toBe(false);
+  });
+
+  it("can mark entries stale for one repository without touching other repositories", () => {
+    const a = buildReviewerCacheKey("org", "repo", "1");
+    const b = buildReviewerCacheKey("org", "repo", "2");
+    const c = buildReviewerCacheKey("other", "repo", "1");
+    setCachedReviewerSummary(a, summary("a"), { fetchedAt: 10_000 });
+    setCachedReviewerSummary(b, summary("b"), { fetchedAt: 10_000 });
+    setCachedReviewerSummary(c, summary("c"), { fetchedAt: 10_000 });
+
+    markReviewerCacheStaleForRepository("org", "repo");
+
+    expect(isReviewerCacheEntryFresh(getReviewerCacheEntry(a)!, 10_001)).toBe(
+      false,
+    );
+    expect(isReviewerCacheEntryFresh(getReviewerCacheEntry(b)!, 10_001)).toBe(
+      false,
+    );
+    expect(isReviewerCacheEntryFresh(getReviewerCacheEntry(c)!, 10_001)).toBe(
+      true,
+    );
   });
 });

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -367,6 +367,227 @@ describe("bootReviewerListPage", () => {
     clearReviewerCache();
   });
 
+  it("renders stale cached reviewers immediately then revalidates and rerenders the row", async () => {
+    getPreferencesMock.mockResolvedValue({
+      version: 1,
+      showStateBadge: true,
+      showReviewerName: true,
+      openPullsOnly: true,
+    });
+    resolveAccountForRepoMock.mockResolvedValue(null);
+
+    let resolveSummary: ((summary: PullReviewerSummary) => void) | null = null;
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({ ok: true, metadata: [] });
+      }
+      if (message.type === "fetchPullReviewerSummary") {
+        return new Promise<{ ok: true; summary: PullReviewerSummary }>(
+          (resolve) => {
+            resolveSummary = (summary) => resolve({ ok: true, summary });
+          },
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const {
+      buildReviewerCacheKey,
+      clearReviewerCache,
+      markReviewerCacheStale,
+      setCachedReviewerSummary,
+    } = await import("../src/cache/reviewer-cache");
+    const cacheKey = buildReviewerCacheKey("cinev", "shotloom", "42");
+    clearReviewerCache();
+    setCachedReviewerSummary(
+      cacheKey,
+      {
+        status: "ok",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+        completedReviews: [],
+      },
+      { fetchedAt: 10_000 },
+    );
+    markReviewerCacheStale(cacheKey);
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(document.body.textContent).toContain("@alice");
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(1);
+
+    resolveSummary!({
+      status: "ok",
+      requestedUsers: [{ login: "bob", avatarUrl: null }],
+      requestedTeams: [],
+      completedReviews: [],
+    });
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(document.body.textContent).not.toContain("@alice");
+    expect(document.body.textContent).toContain("@bob");
+
+    clearReviewerCache();
+  });
+
+  it("treats same-repository render events as reviewer cache revalidation triggers", async () => {
+    getPreferencesMock.mockResolvedValue({
+      version: 1,
+      showStateBadge: true,
+      showReviewerName: true,
+      openPullsOnly: true,
+    });
+    resolveAccountForRepoMock.mockResolvedValue(null);
+
+    let resolveSummary: ((summary: PullReviewerSummary) => void) | null = null;
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({ ok: true, metadata: [] });
+      }
+      if (message.type === "fetchPullReviewerSummary") {
+        return new Promise<{ ok: true; summary: PullReviewerSummary }>(
+          (resolve) => {
+            resolveSummary = (summary) => resolve({ ok: true, summary });
+          },
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const {
+      buildReviewerCacheKey,
+      clearReviewerCache,
+      setCachedReviewerSummary,
+    } = await import("../src/cache/reviewer-cache");
+    clearReviewerCache();
+    setCachedReviewerSummary(
+      buildReviewerCacheKey("cinev", "shotloom", "42"),
+      {
+        status: "ok",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+        completedReviews: [],
+      },
+      { fetchedAt: Date.now() },
+    );
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    const ctx = makeCtx();
+    bootReviewerListPage(ctx);
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(document.body.textContent).toContain("@alice");
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(0);
+
+    getRegisteredListener(ctx, "turbo:render")?.();
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(document.body.textContent).toContain("@alice");
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(1);
+
+    resolveSummary!({
+      status: "ok",
+      requestedUsers: [{ login: "carol", avatarUrl: null }],
+      requestedTeams: [],
+      completedReviews: [],
+    });
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(document.body.textContent).not.toContain("@alice");
+    expect(document.body.textContent).toContain("@carol");
+
+    clearReviewerCache();
+  });
+
+  it("only revalidates mutated existing rows when the row fingerprint changes", async () => {
+    getPreferencesMock.mockResolvedValue({
+      version: 1,
+      showStateBadge: true,
+      showReviewerName: true,
+      openPullsOnly: true,
+    });
+    resolveAccountForRepoMock.mockResolvedValue(null);
+
+    let resolveSummary: ((summary: PullReviewerSummary) => void) | null = null;
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({ ok: true, metadata: [] });
+      }
+      if (message.type === "fetchPullReviewerSummary") {
+        return new Promise<{ ok: true; summary: PullReviewerSummary }>(
+          (resolve) => {
+            resolveSummary = (summary) => resolve({ ok: true, summary });
+          },
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const {
+      buildReviewerCacheKey,
+      clearReviewerCache,
+      setCachedReviewerSummary,
+    } = await import("../src/cache/reviewer-cache");
+    clearReviewerCache();
+    setCachedReviewerSummary(
+      buildReviewerCacheKey("cinev", "shotloom", "42"),
+      {
+        status: "ok",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+        completedReviews: [],
+      },
+      { fetchedAt: Date.now() },
+    );
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const link = document.querySelector<HTMLAnchorElement>("a.Link--primary")!;
+    link.setAttribute("data-hovercard-url", "/cinev/shotloom/pull/42");
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(0);
+
+    link.setAttribute("href", "/cinev/shotloom/pull/42?updated=1");
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(1);
+
+    resolveSummary!({
+      status: "ok",
+      requestedUsers: [{ login: "dana", avatarUrl: null }],
+      requestedTeams: [],
+      completedReviews: [],
+    });
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(document.body.textContent).toContain("@dana");
+
+    clearReviewerCache();
+  });
+
   it("aborts in-flight summary fetches on storage (accounts) change and drops the late result", async () => {
     resolveAccountForRepoMock.mockResolvedValue(null);
 
@@ -381,9 +602,11 @@ describe("bootReviewerListPage", () => {
       }
       summaryRequestCount += 1;
       if (summaryRequestCount === 1) {
-        return new Promise<{ ok: true; summary: PullReviewerSummary }>((resolve) => {
-          resolveFetch = (summary) => resolve({ ok: true, summary });
-        });
+        return new Promise<{ ok: true; summary: PullReviewerSummary }>(
+          (resolve) => {
+            resolveFetch = (summary) => resolve({ ok: true, summary });
+          },
+        );
       }
       return new Promise<void>(() => {});
     });

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -588,6 +588,80 @@ describe("bootReviewerListPage", () => {
     clearReviewerCache();
   });
 
+  it("revalidates mutated existing rows when metadata children are added", async () => {
+    getPreferencesMock.mockResolvedValue({
+      version: 1,
+      showStateBadge: true,
+      showReviewerName: true,
+      openPullsOnly: true,
+    });
+    resolveAccountForRepoMock.mockResolvedValue(null);
+
+    let resolveSummary: ((summary: PullReviewerSummary) => void) | null = null;
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({ ok: true, metadata: [] });
+      }
+      if (message.type === "fetchPullReviewerSummary") {
+        return new Promise<{ ok: true; summary: PullReviewerSummary }>(
+          (resolve) => {
+            resolveSummary = (summary) => resolve({ ok: true, summary });
+          },
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const {
+      buildReviewerCacheKey,
+      clearReviewerCache,
+      setCachedReviewerSummary,
+    } = await import("../src/cache/reviewer-cache");
+    clearReviewerCache();
+    setCachedReviewerSummary(
+      buildReviewerCacheKey("cinev", "shotloom", "42"),
+      {
+        status: "ok",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+        completedReviews: [],
+      },
+      { fetchedAt: Date.now() },
+    );
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const metadata = document.querySelector<HTMLElement>(
+      ".d-flex.mt-1.text-small.color-fg-muted",
+    )!;
+    const stateText = document.createElement("span");
+    stateText.textContent = "Review requested";
+    metadata.append(stateText);
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(1);
+
+    resolveSummary!({
+      status: "ok",
+      requestedUsers: [{ login: "erin", avatarUrl: null }],
+      requestedTeams: [],
+      completedReviews: [],
+    });
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(document.body.textContent).toContain("@erin");
+
+    clearReviewerCache();
+  });
+
   it("aborts in-flight summary fetches on storage (accounts) change and drops the late result", async () => {
     resolveAccountForRepoMock.mockResolvedValue(null);
 


### PR DESCRIPTION
## Summary

- Adds freshness-aware reviewer caching so stale reviewer chips render immediately while background revalidation refreshes the row.
- Marks same-repository GitHub SPA render/navigation events as reviewer revalidation triggers.
- Documents the new cache freshness behavior and expands regression coverage for stale rows, route events, and row fingerprints.

## Why

Re-review requests can change `requested_reviewers` / `requested_teams` after the extension has already cached a row summary. The old cache had no freshness metadata, so the PR list could keep showing stale reviewer state until a full reload or another cache-clearing event. This keeps the list fast while allowing reviewer state to catch up automatically.

## Changes

- Reviewer cache entries now track `fetchedAt` and targeted stale state while preserving the existing summary getter contract.
- Content row processing now uses stale-while-revalidate behavior: fresh cache hits skip network work, stale hits render cached chips and dedupe a background summary request.
- Page metadata has a shorter freshness window and is marked stale when row fingerprints or same-repository render events indicate reviewer-related state may have changed.
- Existing-row mutation handling uses lightweight fingerprints so unrelated attribute changes do not trigger reviewer API requests.
- Regression tests cover freshness helpers, stale rerendering, same-repo render revalidation, and mutation fingerprint behavior.

## Impact

- User-facing impact: Re-requested reviewers can update on pull-list pages without requiring a full browser reload.
- API/schema impact: None.
- Performance impact: Fresh cache hits remain request-free; stale and route-triggered rows may revalidate in the background with existing in-flight dedupe.
- Operational or rollout impact: None.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Breaking Changes

- None

## Related Issues

Resolves #61
