### PR TITLE
fix(reviewers): resolve stale review requests

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -38,10 +38,19 @@
    endpoint and reads only the reviews endpoint. If the pull number is absent
    from the batch result, the summary request falls back to the original per-row
    `pull + reviews` REST path.
-7. Render a single `Reviewers` section inline in the PR row metadata area. Each reviewer is an avatar chip. Requested reviewers keep the blue requested ring. Completed reviewers show a ring and badge derived from one `(isRequested, state)` mapping. Review selection prefers the latest non-`COMMENTED` review for a reviewer, falling back to the latest `COMMENTED` review only when no non-comment review exists. A still-requested reviewer with prior `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` evidence shows the refresh badge instead of the prior state badge. Requested teams keep the text chip shape. User chip links follow the same primary axis as the ring color: blue-ring (still-requested) chips link to `review-requested:<login>`; colored-ring (completed) chips link to `reviewed-by:<login>`. Reviewer chip links use `is:pr is:open` searches by default.
-8. On API errors, emit a signal to the banner aggregator; do not render
+7. For ambiguous user reviewers that appear in both `requested_reviewers` and
+   the latest non-`COMMENTED` review set (`APPROVED`, `CHANGES_REQUESTED`, or
+   `DISMISSED`), read the pull request's issue events and compare ordering.
+   When the latest `review_requested` event for that user is newer than the
+   latest completed review, keep the user requested so the row shows the
+   refresh badge. Otherwise, drop the stale requested marker so the row shows
+   the completed review state. If this targeted issue-event lookup fails, fall
+   back to the completed review state instead of labeling the reviewer as
+   re-requested.
+8. Render a single `Reviewers` section inline in the PR row metadata area. Each reviewer is an avatar chip. Requested reviewers keep the blue requested ring. Completed reviewers show a ring and badge derived from one `(isRequested, state)` mapping. Review selection prefers the latest non-`COMMENTED` review for a reviewer, falling back to the latest `COMMENTED` review only when no non-comment review exists. A still-requested reviewer with prior `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` evidence shows the refresh badge only when the event ordering confirms a later re-request. Requested teams keep the text chip shape. User chip links follow the same primary axis as the ring color: blue-ring (still-requested) chips link to `review-requested:<login>`; colored-ring (completed) chips link to `reviewed-by:<login>`. Reviewer chip links use `is:pr is:open` searches by default.
+9. On API errors, emit a signal to the banner aggregator; do not render
    row-level error text.
-9. Re-run row processing when GitHub mutates the page or performs SPA
+10. Re-run row processing when GitHub mutates the page or performs SPA
    navigation. Same-repository navigation/render events mark visible row
    summaries stale instead of trusting the active page-session cache forever.
    Existing-row DOM mutations use a lightweight row fingerprint so unrelated
@@ -76,6 +85,9 @@
   request summary for the active page session with freshness metadata, and
   caches the page-level metadata result per `owner/repo/account` with a shorter
   freshness window.
+- Issue-event requests are targeted to ambiguous requested+completed reviewer
+  overlaps only. Rows whose requested users do not overlap a latest
+  non-`COMMENTED` review keep the lower-volume pull metadata plus reviews path.
 - A GraphQL-first rewrite is not the next step because it would push the product away from the current no-token public-repository path and add a second transport model to maintain.
 - If request volume remains the next bottleneck, the preferred follow-up is to
   make the REST batch smarter for filtered and paginated GitHub list pages

--- a/docs/manual-chrome-testing.md
+++ b/docs/manual-chrome-testing.md
@@ -65,7 +65,8 @@ This extension is intentionally narrow. Manual verification should stay focused 
 - Requested reviewers render inline on PR rows.
 - Requested teams render inline on PR rows.
 - Completed review state prefers the latest non-`COMMENTED` review for each reviewer, and falls back to the latest `COMMENTED` review only when no non-comment review exists.
-- A still-requested reviewer with prior `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` evidence shows the refresh badge instead of the old state badge.
+- A still-requested reviewer with prior `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` evidence shows the refresh badge only when a later `review_requested` event confirms re-review.
+- A reviewer who remains in `requested_reviewers` after submitting `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED`, with no later `review_requested` event, renders the completed review state.
 - No unrelated PR dashboard data appears.
 - Display preference changes should rerender from cache rather than refetch reviewer API data.
 - Re-requested reviewers or teams should update after GitHub rerenders the PR
@@ -220,7 +221,8 @@ Before considering a manual check complete, verify at least these cases:
 - A requested team is shown with the expected team label format.
 - A reviewer with `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` followed by a later `COMMENTED` review still renders the non-comment state.
 - A reviewer with only `COMMENTED` reviews renders the latest `COMMENTED` state.
-- A still-requested reviewer with prior `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` evidence renders the refresh badge.
+- A still-requested reviewer with prior `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` evidence renders the refresh badge when a later `review_requested` event exists.
+- A stale requested reviewer whose latest `review_requested` event predates the latest non-comment review renders the completed review state, such as `changes requested`.
 - Toggling **Show reviewer names** rerenders the current PR list without extra reviewer API requests.
 - GitHub SPA navigation still leaves reviewer chips visible after moving between PR list views.
 - A changed review request is revalidated after same-repository GitHub

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -51,6 +51,14 @@ const reviewsSchema = z.array(
   }),
 );
 
+const reviewRequestEventsSchema = z.array(
+  z.object({
+    event: z.string(),
+    created_at: z.string(),
+    requested_reviewer: userLiteSchema.nullable().optional(),
+  }),
+);
+
 const rateLimitSchema = z.object({
   rate: z.object({
     limit: z.number(),
@@ -130,7 +138,7 @@ export type RepositoryValidationResult =
       pullNumber?: string;
     };
 
-type GitHubEndpointName = "pull" | "reviews" | "pulls-list";
+type GitHubEndpointName = "pull" | "reviews" | "issue-events" | "pulls-list";
 
 type GitHubEndpointDescriptor = {
   name: GitHubEndpointName;
@@ -143,6 +151,19 @@ type GitHubRateLimitSnapshot = {
   remaining: number | null;
   resource: string | null;
   resetAt: number | null;
+};
+
+type LatestNonCommentReview = {
+  state: Exclude<ReviewState, "COMMENTED">;
+  avatarUrl: string | null;
+  submittedAt: string | null;
+  index: number;
+};
+
+type LatestCommentReview = {
+  avatarUrl: string | null;
+  submittedAt: string | null;
+  index: number;
 };
 
 export class GitHubApiError extends Error {
@@ -279,7 +300,22 @@ export async function fetchPullReviewerSummary(input: {
       signal: input.signal,
     });
 
-    return buildPullReviewerSummary(input.pullMetadata, reviews);
+    const latestReviewRequestByLogin =
+      await fetchLatestReviewRequestEventsForAmbiguousReviewers({
+        owner: input.owner,
+        repo: input.repo,
+        pullNumber: input.pullNumber,
+        pullMetadata: input.pullMetadata,
+        reviews,
+        headers,
+        signal: input.signal,
+      });
+
+    return buildPullReviewerSummary(
+      input.pullMetadata,
+      reviews,
+      latestReviewRequestByLogin,
+    );
   }
 
   const pullEndpoint = buildPullEndpoint(
@@ -317,9 +353,22 @@ export async function fetchPullReviewerSummary(input: {
     signal: input.signal,
   });
 
+  const pullMetadata = toPullReviewerMetadata(input.pullNumber, pullParsed.data);
+  const latestReviewRequestByLogin =
+    await fetchLatestReviewRequestEventsForAmbiguousReviewers({
+      owner: input.owner,
+      repo: input.repo,
+      pullNumber: input.pullNumber,
+      pullMetadata,
+      reviews,
+      headers,
+      signal: input.signal,
+    });
+
   return buildPullReviewerSummary(
-    toPullReviewerMetadata(input.pullNumber, pullParsed.data),
+    pullMetadata,
     reviews,
+    latestReviewRequestByLogin,
   );
 }
 
@@ -352,24 +401,56 @@ export async function fetchPullReviewerMetadataBatch(input: {
 function buildPullReviewerSummary(
   pullMetadata: PullReviewerMetadata,
   reviews: z.infer<typeof reviewsSchema>,
+  latestReviewRequestByLogin: Map<string, string> | null = null,
 ): PullReviewerSummary {
-  const latestNonCommentByUser = new Map<
-    string,
-    {
-      state: Exclude<ReviewState, "COMMENTED">;
-      avatarUrl: string | null;
-      submittedAt: string | null;
-      index: number;
-    }
-  >();
-  const latestCommentByUser = new Map<
-    string,
-    {
-      avatarUrl: string | null;
-      submittedAt: string | null;
-      index: number;
-    }
-  >();
+  const { latestNonCommentByUser, latestCommentByUser } =
+    collectLatestReviewEvidence(pullMetadata, reviews);
+
+  const reviewerLogins = new Set<string>([
+    ...latestNonCommentByUser.keys(),
+    ...latestCommentByUser.keys(),
+  ]);
+
+  const completedReviews: CompletedReview[] = Array.from(reviewerLogins)
+    .map((login) => {
+      const nonComment = latestNonCommentByUser.get(login);
+      if (nonComment != null) {
+        return {
+          login,
+          avatarUrl: nonComment.avatarUrl,
+          state: nonComment.state as ReviewState,
+        };
+      }
+      const comment = latestCommentByUser.get(login)!;
+      return {
+        login,
+        avatarUrl: comment.avatarUrl,
+        state: "COMMENTED" as ReviewState,
+      };
+    })
+    .sort((left, right) => left.login.localeCompare(right.login));
+
+  return {
+    status: "ok" as const,
+    requestedUsers: filterStaleRequestedUsers(
+      pullMetadata.requestedUsers,
+      latestNonCommentByUser,
+      latestReviewRequestByLogin,
+    ),
+    requestedTeams: pullMetadata.requestedTeams,
+    completedReviews,
+  };
+}
+
+function collectLatestReviewEvidence(
+  pullMetadata: PullReviewerMetadata,
+  reviews: z.infer<typeof reviewsSchema>,
+): {
+  latestNonCommentByUser: Map<string, LatestNonCommentReview>;
+  latestCommentByUser: Map<string, LatestCommentReview>;
+} {
+  const latestNonCommentByUser = new Map<string, LatestNonCommentReview>();
+  const latestCommentByUser = new Map<string, LatestCommentReview>();
 
   reviews.forEach((review, index) => {
     const normalizedState = normalizeReviewState(review.state);
@@ -412,36 +493,104 @@ function buildPullReviewerSummary(
     }
   });
 
-  const reviewerLogins = new Set<string>([
-    ...latestNonCommentByUser.keys(),
-    ...latestCommentByUser.keys(),
-  ]);
+  return { latestNonCommentByUser, latestCommentByUser };
+}
 
-  const completedReviews: CompletedReview[] = Array.from(reviewerLogins)
-    .map((login) => {
-      const nonComment = latestNonCommentByUser.get(login);
-      if (nonComment != null) {
-        return {
-          login,
-          avatarUrl: nonComment.avatarUrl,
-          state: nonComment.state as ReviewState,
-        };
-      }
-      const comment = latestCommentByUser.get(login)!;
-      return {
-        login,
-        avatarUrl: comment.avatarUrl,
-        state: "COMMENTED" as ReviewState,
-      };
-    })
-    .sort((left, right) => left.login.localeCompare(right.login));
+async function fetchLatestReviewRequestEventsForAmbiguousReviewers(params: {
+  owner: string;
+  repo: string;
+  pullNumber: string;
+  pullMetadata: PullReviewerMetadata;
+  reviews: z.infer<typeof reviewsSchema>;
+  headers: Headers;
+  signal?: AbortSignal;
+}): Promise<Map<string, string> | null> {
+  const { latestNonCommentByUser } = collectLatestReviewEvidence(
+    params.pullMetadata,
+    params.reviews,
+  );
+  const ambiguousLogins = params.pullMetadata.requestedUsers
+    .map((user) => user.login)
+    .filter((login) => latestNonCommentByUser.has(login));
 
-  return {
-    status: "ok" as const,
-    requestedUsers: pullMetadata.requestedUsers,
-    requestedTeams: pullMetadata.requestedTeams,
-    completedReviews,
-  };
+  if (ambiguousLogins.length === 0) {
+    return null;
+  }
+
+  const endpoint = buildIssueEventsEndpoint(
+    params.owner,
+    params.repo,
+    params.pullNumber,
+  );
+  const firstPageUrl = `https://api.github.com${endpoint.path}?per_page=100`;
+
+  try {
+    const firstResponse = await fetch(firstPageUrl, {
+      headers: params.headers,
+      signal: params.signal,
+    });
+
+    const failure = await createGitHubApiErrorFromResponse(firstResponse, endpoint);
+    if (failure != null) {
+      throw new GitHubPullRequestEndpointsError([failure]);
+    }
+
+    const events = await collectReviewRequestEventsAcrossPages({
+      firstResponse,
+      endpoint,
+      headers: params.headers,
+      signal: params.signal,
+    });
+
+    return selectLatestReviewRequestByLogin(events, new Set(ambiguousLogins));
+  } catch {
+    return new Map();
+  }
+}
+
+function filterStaleRequestedUsers(
+  requestedUsers: ReviewerUser[],
+  latestNonCommentByUser: Map<string, LatestNonCommentReview>,
+  latestReviewRequestByLogin: Map<string, string> | null,
+): ReviewerUser[] {
+  if (latestReviewRequestByLogin == null) {
+    return requestedUsers;
+  }
+
+  return requestedUsers.filter((user) => {
+    const latestReview = latestNonCommentByUser.get(user.login);
+    if (latestReview == null) {
+      return true;
+    }
+
+    return isReviewRequestAfterReview(
+      latestReviewRequestByLogin.get(user.login) ?? null,
+      latestReview.submittedAt,
+    );
+  });
+}
+
+function selectLatestReviewRequestByLogin(
+  events: z.infer<typeof reviewRequestEventsSchema>,
+  targetLogins: Set<string>,
+): Map<string, string> {
+  const latestByLogin = new Map<string, string>();
+
+  for (const event of events) {
+    if (event.event !== "review_requested") {
+      continue;
+    }
+    const login = event.requested_reviewer?.login;
+    if (login == null || !targetLogins.has(login)) {
+      continue;
+    }
+    const existing = latestByLogin.get(login);
+    if (existing == null || event.created_at > existing) {
+      latestByLogin.set(login, event.created_at);
+    }
+  }
+
+  return latestByLogin;
 }
 
 function toPullReviewerMetadata(
@@ -673,6 +822,42 @@ async function collectReviewsAcrossPages(params: {
   }
 }
 
+async function collectReviewRequestEventsAcrossPages(params: {
+  firstResponse: Response;
+  endpoint: GitHubEndpointDescriptor;
+  headers: Headers;
+  signal?: AbortSignal;
+}): Promise<z.infer<typeof reviewRequestEventsSchema>> {
+  const collected: z.infer<typeof reviewRequestEventsSchema> = [];
+
+  let response = params.firstResponse;
+  while (true) {
+    const parsed = reviewRequestEventsSchema.safeParse(await response.json());
+    if (!parsed.success) {
+      throw new GitHubApiSchemaError(params.endpoint, parsed.error.issues);
+    }
+    collected.push(...parsed.data);
+
+    const nextUrl = parseNextPageUrl(response.headers.get("Link"));
+    if (nextUrl == null) {
+      return collected;
+    }
+
+    response = await fetch(nextUrl, {
+      headers: params.headers,
+      signal: params.signal,
+    });
+
+    const error = await createGitHubApiErrorFromResponse(
+      response,
+      params.endpoint,
+    );
+    if (error != null) {
+      throw new GitHubPullRequestEndpointsError([error]);
+    }
+  }
+}
+
 function parseNextPageUrl(linkHeader: string | null): string | null {
   if (linkHeader == null) {
     return null;
@@ -725,6 +910,23 @@ function isNewerReview(
   }
 
   return index >= existing.index;
+}
+
+function isReviewRequestAfterReview(
+  requestedAt: string | null,
+  reviewedAt: string | null,
+): boolean {
+  if (requestedAt == null || reviewedAt == null) {
+    return false;
+  }
+
+  const requestedTime = Date.parse(requestedAt);
+  const reviewedTime = Date.parse(reviewedAt);
+  if (Number.isNaN(requestedTime) || Number.isNaN(reviewedTime)) {
+    return false;
+  }
+
+  return requestedTime > reviewedTime;
 }
 
 function describeRepositoryValidationError(
@@ -824,6 +1026,18 @@ function buildReviewsEndpoint(
     name: "reviews",
     method: "GET",
     path: `/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`,
+  };
+}
+
+function buildIssueEventsEndpoint(
+  owner: string,
+  repo: string,
+  pullNumber: string,
+): GitHubEndpointDescriptor {
+  return {
+    name: "issue-events",
+    method: "GET",
+    path: `/repos/${owner}/${repo}/issues/${pullNumber}/events`,
   };
 }
 

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -166,6 +166,11 @@ type LatestCommentReview = {
   index: number;
 };
 
+type LatestReviewEvidence = {
+  latestNonCommentByUser: Map<string, LatestNonCommentReview>;
+  latestCommentByUser: Map<string, LatestCommentReview>;
+};
+
 export class GitHubApiError extends Error {
   constructor(
     public readonly status: number,
@@ -300,20 +305,24 @@ export async function fetchPullReviewerSummary(input: {
       signal: input.signal,
     });
 
+    const latestReviewEvidence = collectLatestReviewEvidence(
+      input.pullMetadata,
+      reviews,
+    );
     const latestReviewRequestByLogin =
       await fetchLatestReviewRequestEventsForAmbiguousReviewers({
         owner: input.owner,
         repo: input.repo,
         pullNumber: input.pullNumber,
         pullMetadata: input.pullMetadata,
-        reviews,
+        latestNonCommentByUser: latestReviewEvidence.latestNonCommentByUser,
         headers,
         signal: input.signal,
       });
 
     return buildPullReviewerSummary(
       input.pullMetadata,
-      reviews,
+      latestReviewEvidence,
       latestReviewRequestByLogin,
     );
   }
@@ -354,20 +363,21 @@ export async function fetchPullReviewerSummary(input: {
   });
 
   const pullMetadata = toPullReviewerMetadata(input.pullNumber, pullParsed.data);
+  const latestReviewEvidence = collectLatestReviewEvidence(pullMetadata, reviews);
   const latestReviewRequestByLogin =
     await fetchLatestReviewRequestEventsForAmbiguousReviewers({
       owner: input.owner,
       repo: input.repo,
       pullNumber: input.pullNumber,
       pullMetadata,
-      reviews,
+      latestNonCommentByUser: latestReviewEvidence.latestNonCommentByUser,
       headers,
       signal: input.signal,
     });
 
   return buildPullReviewerSummary(
     pullMetadata,
-    reviews,
+    latestReviewEvidence,
     latestReviewRequestByLogin,
   );
 }
@@ -400,11 +410,11 @@ export async function fetchPullReviewerMetadataBatch(input: {
 
 function buildPullReviewerSummary(
   pullMetadata: PullReviewerMetadata,
-  reviews: z.infer<typeof reviewsSchema>,
+  latestReviewEvidence: LatestReviewEvidence,
   latestReviewRequestByLogin: Map<string, string> | null = null,
 ): PullReviewerSummary {
   const { latestNonCommentByUser, latestCommentByUser } =
-    collectLatestReviewEvidence(pullMetadata, reviews);
+    latestReviewEvidence;
 
   const reviewerLogins = new Set<string>([
     ...latestNonCommentByUser.keys(),
@@ -445,10 +455,7 @@ function buildPullReviewerSummary(
 function collectLatestReviewEvidence(
   pullMetadata: PullReviewerMetadata,
   reviews: z.infer<typeof reviewsSchema>,
-): {
-  latestNonCommentByUser: Map<string, LatestNonCommentReview>;
-  latestCommentByUser: Map<string, LatestCommentReview>;
-} {
+): LatestReviewEvidence {
   const latestNonCommentByUser = new Map<string, LatestNonCommentReview>();
   const latestCommentByUser = new Map<string, LatestCommentReview>();
 
@@ -501,17 +508,13 @@ async function fetchLatestReviewRequestEventsForAmbiguousReviewers(params: {
   repo: string;
   pullNumber: string;
   pullMetadata: PullReviewerMetadata;
-  reviews: z.infer<typeof reviewsSchema>;
+  latestNonCommentByUser: Map<string, LatestNonCommentReview>;
   headers: Headers;
   signal?: AbortSignal;
 }): Promise<Map<string, string> | null> {
-  const { latestNonCommentByUser } = collectLatestReviewEvidence(
-    params.pullMetadata,
-    params.reviews,
-  );
   const ambiguousLogins = params.pullMetadata.requestedUsers
     .map((user) => user.login)
-    .filter((login) => latestNonCommentByUser.has(login));
+    .filter((login) => params.latestNonCommentByUser.has(login));
 
   if (ambiguousLogins.length === 0) {
     return null;
@@ -543,7 +546,13 @@ async function fetchLatestReviewRequestEventsForAmbiguousReviewers(params: {
     });
 
     return selectLatestReviewRequestByLogin(events, new Set(ambiguousLogins));
-  } catch {
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
+    if (error instanceof GitHubApiSchemaError) {
+      console.warn(error.message, error.issues);
+    }
     return new Map();
   }
 }
@@ -554,9 +563,13 @@ function filterStaleRequestedUsers(
   latestReviewRequestByLogin: Map<string, string> | null,
 ): ReviewerUser[] {
   if (latestReviewRequestByLogin == null) {
+    // No requested/completed overlap existed, so the issue-events lookup was
+    // intentionally skipped and every requested user remains requested.
     return requestedUsers;
   }
 
+  // A present map means the lookup was attempted. Missing login entries are
+  // treated as no confirmed re-request and drop the stale requested marker.
   return requestedUsers.filter((user) => {
     const latestReview = latestNonCommentByUser.get(user.login);
     if (latestReview == null) {
@@ -585,7 +598,7 @@ function selectLatestReviewRequestByLogin(
       continue;
     }
     const existing = latestByLogin.get(login);
-    if (existing == null || event.created_at > existing) {
+    if (existing == null || isTimestampAfter(event.created_at, existing)) {
       latestByLogin.set(login, event.created_at);
     }
   }
@@ -916,17 +929,31 @@ function isReviewRequestAfterReview(
   requestedAt: string | null,
   reviewedAt: string | null,
 ): boolean {
-  if (requestedAt == null || reviewedAt == null) {
+  // GitHub should provide submitted_at for non-PENDING reviews. If it is
+  // absent, prefer the completed review state over showing a refresh badge.
+  return isTimestampAfter(requestedAt, reviewedAt);
+}
+
+function isTimestampAfter(left: string | null, right: string | null): boolean {
+  if (left == null || right == null) {
     return false;
   }
 
-  const requestedTime = Date.parse(requestedAt);
-  const reviewedTime = Date.parse(reviewedAt);
-  if (Number.isNaN(requestedTime) || Number.isNaN(reviewedTime)) {
+  const leftTime = Date.parse(left);
+  const rightTime = Date.parse(right);
+  if (Number.isNaN(leftTime) || Number.isNaN(rightTime)) {
     return false;
   }
 
-  return requestedTime > reviewedTime;
+  return leftTime > rightTime;
+}
+
+function isAbortError(error: unknown): boolean {
+  if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+    return error.name === "AbortError";
+  }
+
+  return error instanceof Error && error.name === "AbortError";
 }
 
 function describeRepositoryValidationError(

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -545,6 +545,246 @@ describe("fetchPullReviewerSummary", () => {
     ]);
   });
 
+  it("drops a stale requested reviewer when the latest review request predates CHANGES_REQUESTED", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "CHANGES_REQUESTED",
+              submitted_at: "2026-05-07T02:03:16Z",
+              user: { login: "hon454", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              event: "review_requested",
+              created_at: "2026-05-06T12:43:42Z",
+              requested_reviewer: { login: "hon454", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+      pullMetadata: {
+        number: "42",
+        authorLogin: "author",
+        requestedUsers: [{ login: "hon454", avatarUrl: null }],
+        requestedTeams: [],
+      },
+    });
+
+    expect(summary).toEqual({
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: [],
+      completedReviews: [
+        { login: "hon454", avatarUrl: null, state: "CHANGES_REQUESTED" },
+      ],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://api.github.com/repos/hon454/github-pulls-show-reviewers/issues/42/events?per_page=100",
+    );
+  });
+
+  it("keeps a requested reviewer when the latest review request follows the latest non-comment review", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "APPROVED",
+              submitted_at: "2026-05-07T02:03:16Z",
+              user: { login: "alice", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              event: "review_requested",
+              created_at: "2026-05-07T03:00:00Z",
+              requested_reviewer: { login: "alice", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+      pullMetadata: {
+        number: "42",
+        authorLogin: "author",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+      },
+    });
+
+    expect(summary.requestedUsers).toEqual([
+      { login: "alice", avatarUrl: null },
+    ]);
+    expect(summary.completedReviews).toEqual([
+      { login: "alice", avatarUrl: null, state: "APPROVED" },
+    ]);
+  });
+
+  it("does not fetch issue events when requested reviewers have no non-comment review overlap", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "COMMENTED",
+              submitted_at: "2026-05-07T02:03:16Z",
+              user: { login: "alice", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+      pullMetadata: {
+        number: "42",
+        authorLogin: "author",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+      },
+    });
+
+    expect(summary.requestedUsers).toEqual([
+      { login: "alice", avatarUrl: null },
+    ]);
+    expect(summary.completedReviews).toEqual([
+      { login: "alice", avatarUrl: null, state: "COMMENTED" },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows paginated issue events when resolving an ambiguous requested reviewer", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "DISMISSED",
+              submitted_at: "2026-05-07T02:03:16Z",
+              user: { login: "alice", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            Link: '<https://api.github.com/repos/hon454/github-pulls-show-reviewers/issues/42/events?per_page=100&page=2>; rel="next"',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              event: "review_requested",
+              created_at: "2026-05-07T03:00:00Z",
+              requested_reviewer: { login: "alice", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+      pullMetadata: {
+        number: "42",
+        authorLogin: "author",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+      },
+    });
+
+    expect(summary.requestedUsers).toEqual([
+      { login: "alice", avatarUrl: null },
+    ]);
+    expect(fetchMock.mock.calls).toHaveLength(3);
+    expect(fetchMock.mock.calls[2]?.[0]).toBe(
+      "https://api.github.com/repos/hon454/github-pulls-show-reviewers/issues/42/events?per_page=100&page=2",
+    );
+  });
+
+  it("falls back to completed review state when an ambiguous issue-events lookup fails", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "CHANGES_REQUESTED",
+              submitted_at: "2026-05-07T02:03:16Z",
+              user: { login: "alice", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+      pullMetadata: {
+        number: "42",
+        authorLogin: "author",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+      },
+    });
+
+    expect(summary.requestedUsers).toEqual([]);
+    expect(summary.completedReviews).toEqual([
+      { login: "alice", avatarUrl: null, state: "CHANGES_REQUESTED" },
+    ]);
+  });
+
   it("keeps DISMISSED when a later COMMENTED review is submitted by the same reviewer", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -785,6 +785,93 @@ describe("fetchPullReviewerSummary", () => {
     ]);
   });
 
+  it("rethrows AbortError from an ambiguous issue-events lookup", async () => {
+    const abortError = new Error("The operation was aborted.");
+    abortError.name = "AbortError";
+
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "CHANGES_REQUESTED",
+              submitted_at: "2026-05-07T02:03:16Z",
+              user: { login: "alice", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockRejectedValueOnce(abortError);
+
+    await expect(
+      fetchPullReviewerSummary({
+        owner: "hon454",
+        repo: "github-pulls-show-reviewers",
+        pullNumber: "42",
+        githubToken: null,
+        pullMetadata: {
+          number: "42",
+          authorLogin: "author",
+          requestedUsers: [{ login: "alice", avatarUrl: null }],
+          requestedTeams: [],
+        },
+      }),
+    ).rejects.toBe(abortError);
+  });
+
+  it("warns and falls back when an ambiguous issue-events payload is malformed", async () => {
+    const warnMock = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "CHANGES_REQUESTED",
+              submitted_at: "2026-05-07T02:03:16Z",
+              user: { login: "alice", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              event: "review_requested",
+              created_at: 123,
+              requested_reviewer: { login: "alice", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+      pullMetadata: {
+        number: "42",
+        authorLogin: "author",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+      },
+    });
+
+    expect(summary.requestedUsers).toEqual([]);
+    expect(summary.completedReviews).toEqual([
+      { login: "alice", avatarUrl: null, state: "CHANGES_REQUESTED" },
+    ]);
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining("unexpected response shape"),
+      expect.any(Array),
+    );
+  });
+
   it("keeps DISMISSED when a later COMMENTED review is submitted by the same reviewer", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(


### PR DESCRIPTION
## Summary

- Resolve stale requested-reviewer overlaps by comparing review request event ordering before showing refresh/re-review state.
- Keep extra issue-event requests targeted to ambiguous requested + completed reviewer rows.
- Document the updated reviewer-state semantics and manual regression expectations.

## Why

GitHub can keep a reviewer in `requested_reviewers` even after that reviewer submits a completed non-comment review such as `CHANGES_REQUESTED`. The previous rendering treated that overlap as enough proof of a re-request, so stale data could show a refresh badge instead of the completed review state.

## Changes

- Add targeted `issues/{pull_number}/events` lookups only when a requested user also has a latest non-`COMMENTED` review state.
- Compare the latest `review_requested` event timestamp with the latest completed review timestamp to decide whether to keep the requested marker.
- Fall back to completed review state if the targeted event lookup fails, avoiding stale refresh/re-review labeling.
- Add regression coverage for stale requests, true re-requests, event pagination, lookup failure fallback, and non-ambiguous rows.
- Update implementation notes and manual Chrome testing guidance for the new ordering rule.

## Impact

- User-facing impact: stale requested reviewers now render as their completed state, such as `changes requested`, unless a later review request confirms re-review.
- API/schema impact: ambiguous rows may make an additional REST issue-events request; no storage or public API schema changes.
- Performance impact: rows without requested + completed reviewer overlap stay on the existing lower-request path.
- Operational or rollout impact: None.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (322 tests)
- `pnpm build`

## Breaking Changes

- None

## Related Issues

Resolves #78

Co-location checklist: reviewer UX behavior changed, so `docs/implementation-notes.md` and `docs/manual-chrome-testing.md` were updated.