### PR TITLE
docs: add security policy and MIT license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ without asking follow-up questions:
 - Repository type (public or private)
 - DOM / selector evidence when the issue is visual
 
+Do not report security vulnerabilities through public GitHub Issues.
+Use GitHub Private Vulnerability Reporting instead, as described in
+[`SECURITY.md`](./SECURITY.md).
+
 ## Suggesting enhancements
 
 Use GitHub Issues and pick the **Feature Request** template.
@@ -120,6 +124,11 @@ packaging) only after the checks above are green.
 
 This project follows the
 [Contributor Covenant](./CODE_OF_CONDUCT.md).
+
+## License
+
+By contributing, you agree that your contributions are licensed under
+the repository's [MIT license](./LICENSE).
 
 ## Scope boundary
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jihoon Jeon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -100,3 +100,6 @@ For repository workflow, branch naming, commit style, and pull request requireme
 - [Chrome Web Store notes](./docs/chrome-web-store.md)
 - [Chrome Web Store submission draft](./docs/chrome-web-store-submission.md)
 - [Privacy policy draft](./docs/privacy-policy.md)
+- [Security policy](./SECURITY.md)
+- [Release notes](./docs/releases/)
+- [MIT license](./LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes target the latest published Chrome Web Store release and the
+current `main` branch. Older extension versions are not supported separately;
+users should update to the latest Chrome Web Store version to receive security
+fixes.
+
+## Reporting a Vulnerability
+
+Report suspected vulnerabilities through GitHub Private Vulnerability Reporting:
+
+https://github.com/hon454/github-pulls-show-reviewers/security/advisories/new
+
+Do not disclose security vulnerabilities through public GitHub issues,
+discussions, pull requests, or other public channels. Public issues are for
+non-sensitive bugs and feature requests only.
+
+When reporting, include as much of the following as you can:
+
+- Affected extension version or commit.
+- Chrome version and operating system.
+- Whether the affected repository is public or private.
+- Steps to reproduce and expected impact.
+- Any relevant logs, screenshots, or proof-of-concept details that can be
+  shared privately.
+
+The maintainer will acknowledge private reports as soon as practical, triage
+the issue, and coordinate any fix and disclosure through the private advisory
+thread.


### PR DESCRIPTION
## Summary

- Add a root security policy for private vulnerability reporting.
- Add an explicit MIT license for repository use and contribution clarity.
- Link security, license, and release-note guidance from contributor-facing docs.

## Why

A Chrome extension that stores GitHub access and refresh tokens needs an obvious private vulnerability reporting path. The repository also lacked explicit license metadata, which creates ambiguity for contributors and reuse.

## Changes

- Added `SECURITY.md` with supported-version guidance and GitHub Private Vulnerability Reporting as the disclosure channel.
- Added a root `LICENSE` using the MIT license.
- Updated `README.md` and `CONTRIBUTING.md` to point contributors to the security policy, license, and existing release notes under `docs/releases/`.
- Preserved `docs/releases/` as the release-history source of truth and did not add a top-level changelog.

## Impact

- User-facing impact: None.
- API/schema impact: None.
- Performance impact: None.
- Operational or rollout impact: Security reports now have a documented private intake path; license metadata is explicit.

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

### Test details

- `ls -la LICENSE SECURITY.md docs/releases && test ! -e CHANGELOG.md`
- `rg -n "GitHub Private Vulnerability Reporting|Do not disclose security vulnerabilities through public GitHub issues|MIT License|Release notes|docs/releases|SECURITY.md|LICENSE" SECURITY.md LICENSE README.md CONTRIBUTING.md docs/releases/README.md`
- `git diff --check`

## Breaking Changes

- None

## Related Issues

Resolves #65
