### PR TITLE
docs: promote privacy policy to canonical policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ The extension is built around the minimum access needed to show reviewer informa
 - Removing an account from the options page deletes the locally stored token for that account.
 - To revoke the GitHub App itself, remove it from GitHub's Applications settings.
 
-See the [privacy policy draft](./docs/privacy-policy.md) for the full policy text.
+See the
+[public privacy policy](https://github.com/hon454/github-pulls-show-reviewers/blob/main/docs/privacy-policy.md)
+for the full policy text.
 
 ## For Contributors
 
@@ -98,8 +100,8 @@ For repository workflow, branch naming, commit style, and pull request requireme
 - [Implementation notes](./docs/implementation-notes.md)
 - [Manual Chrome testing](./docs/manual-chrome-testing.md)
 - [Chrome Web Store notes](./docs/chrome-web-store.md)
-- [Chrome Web Store submission draft](./docs/chrome-web-store-submission.md)
-- [Privacy policy draft](./docs/privacy-policy.md)
+- [Chrome Web Store submission packet](./docs/chrome-web-store-submission.md)
+- [Privacy policy](./docs/privacy-policy.md)
 - [Security policy](./SECURITY.md)
 - [Release notes](./docs/releases/)
 - [MIT license](./LICENSE)

--- a/docs/chrome-web-store-submission.md
+++ b/docs/chrome-web-store-submission.md
@@ -43,14 +43,14 @@ Regenerate them with:
 pnpm cws:assets
 ```
 
-## Privacy practices draft
+## Current privacy practices
 
 Use the current shipped behavior, not aspirational behavior.
 
 Single purpose:
 `Show requested reviewers, requested teams, and completed review state inside GitHub pull request list pages.`
 
-Permission justification draft:
+Permission justification:
 
 - `storage`: stores locally the GitHub App accounts (user-to-server access token, refresh token, and token-expiry timestamps per account) so the user can access private repositories. It also stores the review-chip display preferences (`showStateBadge`, `showReviewerName`, and `openPullsOnly`) under the local `preferences` key.
 - `alarms`: schedules a recurring 15-minute background task that refreshes GitHub App access tokens ahead of expiry. Without this, every eight-hour token lifetime would force the user to sign in again even while actively using the extension, and reviewer lookups on private repositories would stall until the next sign-in.
@@ -60,7 +60,7 @@ Permission justification draft:
 Remote code:
 `No, this extension does not execute remote code.`
 
-Conservative data usage draft:
+Conservative data usage:
 
 - Authentication information: `Yes`
   Reason: the user may sign in with GitHub via the GitHub App, and the resulting user-to-server token is stored locally for private repository access.
@@ -70,21 +70,26 @@ Conservative data usage draft:
   Reason: the extension detects when the user is on a GitHub repository pull request list page in order to activate.
 - Personal communications, health information, financial/payment information, location, web history outside GitHub, and advertising identifiers: `No`
 
-Certification draft:
+Certification:
 
 - Data is used only for the extension's reviewer-visibility feature.
 - Data is not sold.
 - Data is not used for creditworthiness or lending decisions.
 - Data is not used or transferred for unrelated advertising or marketing.
 
-Sharing draft:
+Sharing:
 
 - Requests needed for reviewer lookups go directly to GitHub.
 - No extension-operated backend receives user data.
 - No data is shared with advertisers or data brokers.
 
 Privacy policy URL:
-Host [privacy-policy.md](./privacy-policy.md) at a stable public URL before submission. The Chrome Web Store requires the privacy policy link and the privacy fields to match the shipped behavior.
+`https://github.com/hon454/github-pulls-show-reviewers/blob/main/docs/privacy-policy.md`
+
+Earlier submission preparation tracked the need to host
+[privacy-policy.md](./privacy-policy.md) at a stable public URL. The published
+Chrome Web Store listing now uses the GitHub-hosted policy URL above. Keep that
+link and the privacy fields aligned with the shipped behavior.
 
 ## Release and upload checklist
 
@@ -94,8 +99,8 @@ Host [privacy-policy.md](./privacy-policy.md) at a stable public URL before subm
 4. Run `pnpm zip` only after the checks above pass.
 5. Upload `.output/*-chrome.zip` in the Chrome Web Store dashboard.
 6. Attach the three screenshots listed above, in order, with the dashboard captions from the screenshot inventory.
-7. Paste the short description, detailed description, and privacy policy URL.
-8. Fill in the privacy fields using the draft above, then reconcile every answer against the shipped permissions and network behavior.
+7. Paste the short description, detailed description, and privacy policy URL above.
+8. Fill in the privacy fields using the current values above, then reconcile every answer against the shipped permissions and network behavior.
 9. If you want review before launch, disable automatic publish and stage the release in the dashboard.
 10. After approval, publish the staged version and align the Git tag, GitHub Release, and store version.
 11. Open the packaged extension's options page once before upload and confirm it never renders as a blank white screen. A missing GitHub App build config must surface the explicit configuration warning instead.

--- a/docs/chrome-web-store.md
+++ b/docs/chrome-web-store.md
@@ -83,4 +83,8 @@ Expected release gate behavior:
 9. Confirm the reviewer-only scope in the listing copy still matches the extension and screenshots before submission.
 10. Open the packaged extension's options page once before submission and confirm it either renders the sign-in UI normally or shows the explicit GitHub App configuration warning, never a blank page.
 
-Concrete submission assets and privacy-form draft live in [chrome-web-store-submission.md](./chrome-web-store-submission.md). The publishable privacy policy draft lives in [privacy-policy.md](./privacy-policy.md).
+Concrete submission assets and current privacy-form values live in
+[chrome-web-store-submission.md](./chrome-web-store-submission.md). The
+canonical published privacy policy lives in [privacy-policy.md](./privacy-policy.md)
+and is hosted publicly at
+<https://github.com/hon454/github-pulls-show-reviewers/blob/main/docs/privacy-policy.md>.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -2,6 +2,10 @@
 
 Last updated: 2026-04-24
 
+This is the canonical published privacy policy for the Chrome Web Store listing.
+The public policy URL is
+<https://github.com/hon454/github-pulls-show-reviewers/blob/main/docs/privacy-policy.md>.
+
 `GitHub Pulls Show Reviewers` is a Chrome extension that shows requested reviewers, requested teams, and completed review state directly inside GitHub pull request list pages.
 
 ## What the extension accesses


### PR DESCRIPTION
## Summary
Promote the repository privacy policy from draft wording to the canonical published policy source.

## Why
Chrome Web Store privacy disclosures should point to a stable public policy URL and avoid draft language now that the extension is deployed.

## Changes
- Updated README privacy references to remove draft wording and link to the GitHub-hosted public policy URL.
- Marked docs/privacy-policy.md as the canonical published policy source.
- Updated Chrome Web Store submission and release notes to use current privacy values and the hosted policy URL.

## Impact
Documentation only. No permission, storage, auth, runtime, or packaged-extension behavior changes.

## Testing
- `rg -n "privacy policy draft|Privacy policy draft|publishable privacy policy draft|Privacy practices draft|Permission justification draft|Conservative data usage draft|Certification draft|Sharing draft|Host \[privacy-policy\.md\].*before submission|privacy-form draft|submission draft" README.md docs .github -g '*.md'` returned no matches.
- `rg -n "https://github.com/hon454/github-pulls-show-reviewers/blob/main/docs/privacy-policy.md" README.md docs/privacy-policy.md docs/chrome-web-store-submission.md docs/chrome-web-store.md` confirmed the canonical URL appears in the expected docs.
- `pnpm exec prettier --check README.md docs/privacy-policy.md docs/chrome-web-store-submission.md docs/chrome-web-store.md` passed.

## Breaking Changes
None.

## Related Issues
Resolves #64