### PR TITLE
fix: label diagnostics repository input

### DIFF
--- a/entrypoints/options/components/DiagnosticsPanel.tsx
+++ b/entrypoints/options/components/DiagnosticsPanel.tsx
@@ -86,7 +86,11 @@ export function DiagnosticsPanel() {
   return (
     <section style={styles.section}>
       <h2 style={styles.heading}>Diagnostics</h2>
+      <label htmlFor="diagnostics-repository" style={styles.visuallyHidden}>
+        Repository in owner/name format
+      </label>
       <input
+        id="diagnostics-repository"
         type="text"
         value={repository}
         placeholder="owner/name"
@@ -146,6 +150,17 @@ function toneColor(tone: "neutral" | "success" | "error"): string {
 const styles: Record<string, CSSProperties> = {
   section: { marginTop: 32 },
   heading: { margin: 0, fontSize: 18 },
+  visuallyHidden: {
+    position: "absolute",
+    width: 1,
+    height: 1,
+    padding: 0,
+    margin: -1,
+    overflow: "hidden",
+    clip: "rect(0, 0, 0, 0)",
+    whiteSpace: "nowrap",
+    border: 0,
+  },
   input: {
     width: "100%",
     boxSizing: "border-box",

--- a/tests/options-page.test.ts
+++ b/tests/options-page.test.ts
@@ -199,6 +199,19 @@ describe("OptionsPage", () => {
     ).not.toBeNull();
   });
 
+  it("gives the diagnostics repository input an associated label", async () => {
+    await renderOptionsPage();
+
+    const input = document.querySelector<HTMLInputElement>(
+      '[data-testid="diagnostics-repo"]',
+    );
+
+    expect(input).not.toBeNull();
+    expect(input!.labels).toHaveLength(1);
+    expect(input!.labels![0]?.textContent).toContain("Repository");
+    expect(input!.labels![0]?.textContent).toContain("owner/name");
+  });
+
   it("renders account cards when accounts are present", async () => {
     listAccountsMock.mockResolvedValue([
       {


### PR DESCRIPTION
## Summary
Add an associated label to the options-page diagnostics repository input.

## Why
Placeholder text is not a reliable accessible name, so screen reader users need a stable label that communicates the expected `owner/name` format.

## Changes
- Added a visually hidden `label` tied to the diagnostics repository input with `htmlFor`/`id`.
- Added focused options-page coverage asserting the input has an associated label describing the repository format.

## Impact
Improves accessibility for the diagnostics repository field while preserving the compact options-page layout.

## Testing
- `pnpm exec vitest run tests/options-page.test.ts -t "associated label"` (verified red before implementation, then green after implementation)
- `pnpm exec vitest run tests/options-page.test.ts`
- `pnpm typecheck`

## Breaking Changes
None.

## Related Issues
Resolves #66
