### PR TITLE
test: add Playwright CI retry traces

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,8 +2,10 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/e2e",
+  retries: process.env.CI ? 1 : 0,
   use: {
     headless: true,
+    trace: "on-first-retry",
   },
   projects: [
     {

--- a/tests/playwright-config.test.ts
+++ b/tests/playwright-config.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+type PlaywrightConfig = {
+  retries?: number;
+  use?: {
+    trace?: string;
+  };
+};
+
+describe("Playwright config", () => {
+  it("does not retry e2e tests by default for local runs", async () => {
+    const config = await importPlaywrightConfigWithCi(undefined);
+
+    expect(config.retries).toBe(0);
+  });
+
+  it("retries e2e tests once in CI and records traces on first retry", async () => {
+    const config = await importPlaywrightConfigWithCi("true");
+
+    expect(config.retries).toBe(1);
+    expect(config.use?.trace).toBe("on-first-retry");
+  });
+});
+
+async function importPlaywrightConfigWithCi(
+  ci: string | undefined,
+): Promise<PlaywrightConfig> {
+  const previousCi = process.env.CI;
+
+  if (ci === undefined) {
+    delete process.env.CI;
+  } else {
+    process.env.CI = ci;
+  }
+  vi.resetModules();
+
+  try {
+    const module = (await import("../playwright.config")) as {
+      default: PlaywrightConfig;
+    };
+
+    return module.default;
+  } finally {
+    if (previousCi === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = previousCi;
+    }
+    vi.resetModules();
+  }
+}


### PR DESCRIPTION
## Summary
Add a CI-only retry and trace policy for the Playwright e2e suite.

## Why
Packaged MV3 extension tests can hit CI-only timing failures around Chromium extension startup and service worker readiness. Retrying once in CI and collecting a trace on that retry keeps local runs fast while preserving useful failure context.

## Changes
- Configure Playwright retries as `process.env.CI ? 1 : 0`.
- Enable `trace: "on-first-retry"` for e2e runs.
- Add Vitest coverage for local retry defaults and CI retry/trace behavior.

## Impact
Local Playwright runs do not retry by default. CI Playwright runs retry once and collect a trace on the first retry.

## Testing
- `pnpm exec vitest run tests/playwright-config.test.ts`
- `pnpm exec playwright test --list --project=default`
- `pnpm test:e2e`
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`

## Breaking Changes
None.

## Related Issues
Resolves #67
