### PR TITLE
chore(release): prepare v1.7.2

### DIFF
--- a/docs/chrome-web-store-submission.md
+++ b/docs/chrome-web-store-submission.md
@@ -111,5 +111,5 @@ link and the privacy fields aligned with the shipped behavior.
 Expected package path after `pnpm zip`:
 
 ```text
-.output/github-pulls-show-reviewers-1.7.1-chrome.zip
+.output/github-pulls-show-reviewers-1.7.2-chrome.zip
 ```

--- a/docs/releases/v1.7.2.md
+++ b/docs/releases/v1.7.2.md
@@ -1,0 +1,46 @@
+## v1.7.2
+
+Patch release for **GitHub Pulls Show Reviewers** focused on Chrome Web Store
+submission compliance, release packaging safety, and repository governance.
+The reviewer feature scope stays unchanged: requested reviewers, requested
+teams, and completed review state remain the only surfaced PR-list metadata.
+
+### Highlights
+
+- Chrome Web Store screenshots are now generated to comply with store sizing
+  requirements, unblocking listing updates.
+- The diagnostics page repository input is correctly labelled, making it
+  easier to file accurate reports.
+
+### Authentication
+
+- No permission, token-scope, storage-schema, or host-permission changes.
+- Public repositories still work without signing in when GitHub's
+  unauthenticated REST API allows it.
+- Private repositories continue to use the maintainer-owned GitHub App account
+  flow with `Pull requests: Read` access only.
+
+### Quality & Packaging
+
+- Release packaging now fails closed when the GitHub App build environment
+  variables are missing, preventing a package with disabled private-repository
+  sign-in from being published.
+- Playwright CI runs upload retry traces, making flaky end-to-end failures
+  easier to diagnose.
+- Chrome Web Store submission materials now reference the v1.7.2 package
+  name.
+
+### Governance & Documentation
+
+- Added an MIT `LICENSE` and a `SECURITY.md` policy to clarify reuse and
+  vulnerability reporting expectations.
+- Promoted the privacy policy to the canonical project policy document.
+
+### Scope Notes
+
+- Reviewer visibility on GitHub pull request list pages remains the only
+  product goal.
+- Checks, mergeability, labels, assignees, and general PR dashboard features
+  remain out of scope.
+
+**Full Changelog**: https://github.com/hon454/github-pulls-show-reviewers/compare/v1.7.1...v1.7.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-pulls-show-reviewers",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": true,
   "type": "module",
   "description": "Chrome extension focused on showing reviewers directly in GitHub pull request lists.",


### PR DESCRIPTION
## Summary
- Bump package version to 1.7.2
- Add release notes at `docs/releases/v1.7.2.md`
- Update CWS submission package name to v1.7.2

Once merged, tag `v1.7.2` on main to trigger the Release workflow.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] CI (`pnpm test:e2e`, `pnpm preflight:release`, `pnpm zip`) on tag push