### PR TITLE
fix: map user-facing schema parse failures to typed diagnostics

### DIFF
--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -630,25 +630,38 @@ export async function validateAccountToken(
       message: "No account provided — sign in with GitHub from the options page.",
     };
   }
+  const rateLimitEndpoint: GitHubEndpointDescriptor = {
+    name: "pulls-list",
+    method: "GET",
+    path: "/rate_limit",
+  };
   const response = await fetch("https://api.github.com/rate_limit", {
     headers: createGitHubHeaders(account.token),
   });
   if (!response.ok) {
-    const error = await createGitHubApiError(response, {
-      name: "pulls-list",
-      method: "GET",
-      path: "/rate_limit",
-    });
+    const error = await createGitHubApiError(response, rateLimitEndpoint);
     return {
       ok: false,
       message: describeGitHubApiError(error, { githubToken: account.token }),
     };
   }
-  const payload = rateLimitSchema.parse(await response.json());
+  const parsed = rateLimitSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    const schemaError = new GitHubApiSchemaError(
+      rateLimitEndpoint,
+      parsed.error.issues,
+    );
+    return {
+      ok: false,
+      message: describeGitHubApiError(schemaError, {
+        githubToken: account.token,
+      }),
+    };
+  }
   return {
     ok: true,
-    limit: payload.rate.limit,
-    remaining: payload.rate.remaining,
+    limit: parsed.data.rate.limit,
+    remaining: parsed.data.rate.remaining,
   };
 }
 
@@ -689,7 +702,21 @@ export async function validateGitHubRepositoryAccess(
     };
   }
 
-  const pulls = pullListSchema.parse(await response.json());
+  const parsedPulls = pullListSchema.safeParse(await response.json());
+  if (!parsedPulls.success) {
+    const schemaError = new GitHubApiSchemaError(
+      listEndpoint,
+      parsedPulls.error.issues,
+    );
+    return {
+      ok: false,
+      authMode,
+      outcome: classifyRepositoryValidationOutcome(schemaError, auth),
+      fullName,
+      message: describeRepositoryValidationError(schemaError, fullName, auth),
+    };
+  }
+  const pulls = parsedPulls.data;
   const firstPull = pulls[0];
   if (firstPull == null) {
     return {

--- a/src/github/auth.ts
+++ b/src/github/auth.ts
@@ -20,6 +20,16 @@ export class DeviceFlowError extends Error {
   }
 }
 
+export class GitHubAuthSchemaError extends Error {
+  constructor(
+    public readonly endpoint: string,
+    public readonly issues?: unknown,
+  ) {
+    super(`GitHub returned an unexpected response shape for ${endpoint}.`);
+    this.name = "GitHubAuthSchemaError";
+  }
+}
+
 const deviceCodeInitSchema = z.object({
   device_code: z.string(),
   user_code: z.string(),
@@ -348,10 +358,13 @@ export async function fetchAuthenticatedUser(input: {
   if (!response.ok) {
     throw new Error(`GET /user failed with status ${response.status}.`);
   }
-  const payload = githubUserSchema.parse(await response.json());
+  const parsed = githubUserSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new GitHubAuthSchemaError("GET /user", parsed.error.issues);
+  }
   return {
-    login: payload.login,
-    avatarUrl: payload.avatar_url ?? null,
+    login: parsed.data.login,
+    avatarUrl: parsed.data.avatar_url ?? null,
   };
 }
 
@@ -401,8 +414,14 @@ export async function fetchUserInstallations(input: {
         `GET /user/installations failed with status ${response.status}.`,
       );
     }
-    const payload = userInstallationsSchema.parse(await response.json());
-    for (const installation of payload.installations) {
+    const parsed = userInstallationsSchema.safeParse(await response.json());
+    if (!parsed.success) {
+      throw new GitHubAuthSchemaError(
+        "GET /user/installations",
+        parsed.error.issues,
+      );
+    }
+    for (const installation of parsed.data.installations) {
       if (installation.account.type === "Bot") {
         continue;
       }
@@ -443,10 +462,16 @@ export async function fetchInstallationRepositories(input: {
         `GET /user/installations/${input.installationId}/repositories failed with status ${response.status}.`,
       );
     }
-    const payload = installationRepositoriesSchema.parse(
+    const parsed = installationRepositoriesSchema.safeParse(
       await response.json(),
     );
-    for (const repository of payload.repositories) {
+    if (!parsed.success) {
+      throw new GitHubAuthSchemaError(
+        `GET /user/installations/${input.installationId}/repositories`,
+        parsed.error.issues,
+      );
+    }
+    for (const repository of parsed.data.repositories) {
       results.push(repository.full_name);
     }
     url = parseNextLink(response.headers.get("link"));

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -10,6 +10,7 @@ import {
   describeGitHubApiError,
   isRateLimitError,
   parseRepositoryReference,
+  validateAccountToken,
   validateGitHubRepositoryAccess,
 } from "../src/github/api";
 
@@ -1341,4 +1342,54 @@ describe("validateGitHubRepositoryAccess", () => {
       }
     });
   }
+
+  it("returns a typed diagnostic when /pulls returns a malformed body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify([{ not_a_number: "oops" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await validateGitHubRepositoryAccess(
+      { token: "ghu_example" },
+      "hon454/github-pulls-show-reviewers",
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.outcome).toBe("unknown-error");
+    expect(result.message).toContain("unexpected response shape");
+    expect(result.message).not.toMatch(/ZodError/);
+  });
+});
+
+describe("validateAccountToken", () => {
+  it("returns ok with limit and remaining for a healthy rate-limit body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ rate: { limit: 5000, remaining: 4999 } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await validateAccountToken({ token: "ghu_example" });
+    expect(result).toEqual({ ok: true, limit: 5000, remaining: 4999 });
+  });
+
+  it("returns a typed diagnostic when /rate_limit returns a malformed body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ unexpected: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await validateAccountToken({ token: "ghu_example" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain("unexpected response shape");
+    expect(result.message).toContain("/rate_limit");
+    expect(result.message).not.toMatch(/ZodError/);
+  });
 });

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   DeviceFlowError,
+  GitHubAuthSchemaError,
   fetchAuthenticatedUser,
   fetchInstallationRepositories,
   fetchUserInstallations,
@@ -229,5 +230,34 @@ describe("fetchInstallationRepositories", () => {
     await expect(
       fetchInstallationRepositories({ token: "ghu_abc", installationId: 1 }),
     ).rejects.toThrow();
+  });
+});
+
+describe("auth schema diagnostics", () => {
+  it("throws GitHubAuthSchemaError when /user payload is malformed", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ unexpected: true }),
+    );
+    await expect(
+      fetchAuthenticatedUser({ token: "ghu_abc" }),
+    ).rejects.toBeInstanceOf(GitHubAuthSchemaError);
+  });
+
+  it("throws GitHubAuthSchemaError when /user/installations payload is malformed", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ installations: "not-an-array" }),
+    );
+    await expect(
+      fetchUserInstallations({ token: "ghu_abc" }),
+    ).rejects.toBeInstanceOf(GitHubAuthSchemaError);
+  });
+
+  it("throws GitHubAuthSchemaError when installation repositories payload is malformed", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ repositories: [{ wrong: "shape" }] }),
+    );
+    await expect(
+      fetchInstallationRepositories({ token: "ghu_abc", installationId: 1 }),
+    ).rejects.toBeInstanceOf(GitHubAuthSchemaError);
   });
 });


### PR DESCRIPTION
## Summary

- Convert `validateAccountToken` and `validateGitHubRepositoryAccess` to `safeParse`, returning a typed diagnostic via `describeGitHubApiError(GitHubApiSchemaError, …)` when GitHub responds with an unexpected shape.
- Introduce `GitHubAuthSchemaError` and convert the three direct `parse()` calls in `fetchAuthenticatedUser`, `fetchUserInstallations`, and `fetchInstallationRepositories`.
- Add focused regression tests for malformed `/rate_limit`, `/pulls`, `/user`, `/user/installations`, and installation-repositories payloads.

## Test plan

- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm test

Resolves #68