### PR TITLE
fix: define focus-visible styles for injected reviewer UI

### DIFF
--- a/src/features/access-banner/dom.ts
+++ b/src/features/access-banner/dom.ts
@@ -2,6 +2,24 @@ import type { BannerKind, BannerState } from "./aggregator";
 import { formatBannerMessage } from "./aggregator";
 
 const BANNER_ATTRIBUTE = "data-ghpsr-banner";
+const BANNER_STYLE_ATTRIBUTE = "data-ghpsr-banner-style";
+
+function ensureBannerStyles(): void {
+  if (document.head.querySelector(`[${BANNER_STYLE_ATTRIBUTE}]`)) {
+    return;
+  }
+  const style = document.createElement("style");
+  style.setAttribute(BANNER_STYLE_ATTRIBUTE, "true");
+  style.textContent = `
+    .ghpsr-banner-cta:focus-visible,
+    .ghpsr-banner-dismiss:focus-visible {
+      outline: 2px solid var(--fgColor-accent, #0969da);
+      outline-offset: 2px;
+      border-radius: 4px;
+    }
+  `;
+  document.head.append(style);
+}
 
 export type BannerMount = {
   update(state: BannerState): void;
@@ -45,6 +63,8 @@ export function mountBanner(input: {
       return;
     }
 
+    ensureBannerStyles();
+
     if (element == null) {
       element = document.createElement("div");
       element.setAttribute(BANNER_ATTRIBUTE, "true");
@@ -75,12 +95,14 @@ export function mountBanner(input: {
       link.target = "_blank";
       link.rel = "noreferrer";
       link.textContent = cta.label;
+      link.className = "ghpsr-banner-cta";
       element.append(link);
     }
 
     const dismissBtn = document.createElement("button");
     dismissBtn.type = "button";
     dismissBtn.textContent = "Dismiss";
+    dismissBtn.className = "ghpsr-banner-dismiss";
     dismissBtn.addEventListener("click", () => input.onDismiss());
     element.append(dismissBtn);
   }

--- a/src/features/reviewers/dom.ts
+++ b/src/features/reviewers/dom.ts
@@ -154,6 +154,7 @@ export function ensureReviewerStyles(): void {
     }
     .ghpsr-chip:hover { text-decoration: none; filter: brightness(0.98); }
 
+    .ghpsr-avatar:focus-visible,
     .ghpsr-pill:focus-visible,
     .ghpsr-chip:focus-visible {
       outline: 2px solid var(--fgColor-accent, #0969da);

--- a/src/features/reviewers/dom.ts
+++ b/src/features/reviewers/dom.ts
@@ -153,6 +153,14 @@ export function ensureReviewerStyles(): void {
       border: 1px solid transparent;
     }
     .ghpsr-chip:hover { text-decoration: none; filter: brightness(0.98); }
+
+    .ghpsr-pill:focus-visible,
+    .ghpsr-chip:focus-visible {
+      outline: 2px solid var(--fgColor-accent, #0969da);
+      outline-offset: 2px;
+      border-radius: 999px;
+    }
+
     .ghpsr-chip--team {
       color: var(--fgColor-attention, #9a6700);
       background: color-mix(in srgb, var(--bgColor-attention-muted, #fff8c5) 80%, white);

--- a/tests/access-banner.test.ts
+++ b/tests/access-banner.test.ts
@@ -466,6 +466,21 @@ describe("banner DOM", () => {
     expect(el.querySelector("button")?.textContent).toBe("Dismiss");
   });
 
+  it("attaches focus-visible classes on the CTA link and dismiss button", () => {
+    const banner = setup();
+    banner.update({
+      current: "app-uncovered",
+      dismissed: false,
+      repo: TEST_REPO,
+    });
+    const link = document.querySelector("[data-ghpsr-banner] a");
+    const dismiss = document.querySelector("[data-ghpsr-banner] button");
+    expect(link?.classList.contains("ghpsr-banner-cta")).toBe(true);
+    expect(dismiss?.classList.contains("ghpsr-banner-dismiss")).toBe(true);
+    const styleEl = document.querySelector("[data-ghpsr-banner-style]");
+    expect(styleEl?.textContent).toContain(":focus-visible");
+  });
+
   it("removes the banner when dismissed", () => {
     const banner = setup();
     banner.update({

--- a/tests/reviewer-dom.test.ts
+++ b/tests/reviewer-dom.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   ensureReviewerMount,
+  ensureReviewerStyles,
   extractPullNumber,
   renderReviewers,
 } from "../src/features/reviewers/dom";
@@ -255,6 +256,15 @@ describe("renderReviewers", () => {
     const row = document.querySelector(".js-issue-row");
     expect(ensureReviewerMount(row!)).not.toBeNull();
     expect(row?.querySelector(".d-none.d-md-inline-flex")).not.toBeNull();
+  });
+
+  it("declares :focus-visible styles for reviewer pills and team chips", () => {
+    ensureReviewerStyles();
+    const styleEl = document.querySelector("[data-ghpsr-style]");
+    const css = styleEl?.textContent ?? "";
+    expect(css).toContain(".ghpsr-pill:focus-visible");
+    expect(css).toContain(".ghpsr-chip:focus-visible");
+    expect(css).toContain("outline:");
   });
 });
 

--- a/tests/reviewer-dom.test.ts
+++ b/tests/reviewer-dom.test.ts
@@ -258,10 +258,11 @@ describe("renderReviewers", () => {
     expect(row?.querySelector(".d-none.d-md-inline-flex")).not.toBeNull();
   });
 
-  it("declares :focus-visible styles for reviewer pills and team chips", () => {
+  it("declares :focus-visible styles for reviewer avatars, pills, and team chips", () => {
     ensureReviewerStyles();
     const styleEl = document.querySelector("[data-ghpsr-style]");
     const css = styleEl?.textContent ?? "";
+    expect(css).toContain(".ghpsr-avatar:focus-visible");
     expect(css).toContain(".ghpsr-pill:focus-visible");
     expect(css).toContain(".ghpsr-chip:focus-visible");
     expect(css).toContain("outline:");


### PR DESCRIPTION
## Summary

- Pin visible `:focus-visible` indicators on injected reviewer links, including avatar-only reviewers, named reviewer pills, and team chips.
- Pin visible focus indicators on the access-banner CTA link and Dismiss button.
- Add focused DOM regression coverage for the reviewer and access-banner stylesheets.

## Why

Keyboard users need a predictable focus indicator when tabbing through injected reviewer UI and access-banner controls. Relying on browser or GitHub defaults leaves this behavior vulnerable to upstream style changes, especially for extension-owned links and buttons.

## Changes

- Reviewer UI: add explicit `:focus-visible` outline styling for `.ghpsr-avatar`, `.ghpsr-pill`, and `.ghpsr-chip`.
- Access banner: inject a dedicated banner stylesheet and assign stable classes to the CTA link and Dismiss button.
- Test coverage: assert that both injected stylesheets declare the expected focus-visible selectors.

## Impact

- User-facing impact: keyboard users get a consistent visible focus ring on injected reviewer and banner controls.
- API/schema impact: None.
- Performance impact: None; the stylesheets are inserted once and reused.
- Operational or rollout impact: None.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Breaking Changes

- None

## Related Issues

Resolves #71

<!-- Co-location note: reviewer UI focus styling changed, but reviewer display semantics, copy, supported states, permissions, storage, auth, release artifacts, and Chrome Web Store copy did not change. -->