### PR TITLE
ops: add weekly pnpm audit workflow

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,28 @@
+name: Dependency audit
+
+on:
+  schedule:
+    # Run weekly on Monday 09:00 UTC.
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Fail only on moderate-or-higher advisories so transitive low-severity
+      # noise does not page the maintainer. The job runs on a schedule and
+      # surfaces failures via GitHub Actions notifications, with no automated
+      # PRs.
+      - name: pnpm audit (moderate+)
+        run: pnpm audit --audit-level moderate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,25 @@ packaging) only after the checks above are green.
   [`AGENTS.md`](./AGENTS.md#implementation-guidelines) for patterns
   specific to this codebase.
 
+## Dependency audits
+
+The
+[`dependency-audit`](./.github/workflows/dependency-audit.yml) workflow
+runs `pnpm audit --audit-level moderate` on a weekly schedule (Mondays
+09:00 UTC) and on demand via `workflow_dispatch`. The job fails when a
+moderate-or-higher advisory appears, surfacing a notification to the
+maintainer. There is no automated dependency PR bot; the workflow is
+intentionally noise-light.
+
+When the workflow fails:
+
+1. Investigate the advisory locally with `pnpm audit`.
+2. Bump the affected dependency or transitive override.
+3. Run `pnpm verify:release` before pushing the fix.
+
+If a finding is a known false positive, document the rationale in the
+fix commit instead of suppressing the workflow.
+
 ## Code of Conduct
 
 This project follows the


### PR DESCRIPTION
## Summary

- Add a scheduled dependency audit workflow that runs `pnpm audit --audit-level moderate` weekly and on demand.
- Document the audit cadence and maintainer follow-up steps in `CONTRIBUTING.md`.
- Keep the approach notification-based without automated dependency PRs.

## Why

Release-time dependency security checks should not depend on maintainer memory. Issue #69 asks for a lightweight, repeatable cadence that catches moderate-or-higher advisories without creating unnecessary maintenance noise.

## Changes

- Add a `Dependency audit` GitHub Actions workflow triggered every Monday at 09:00 UTC and through `workflow_dispatch`.
- Install dependencies with the repository lockfile and run `pnpm audit --audit-level moderate`.
- Document how maintainers should investigate and fix audit failures.

## Impact

- User-facing impact: None.
- API/schema impact: None.
- Performance impact: None.
- Operational or rollout impact: Adds a weekly scheduled GitHub Actions job that fails on moderate-or-higher dependency advisories and relies on Actions notifications.

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

### Test details

- `pnpm audit --audit-level moderate`

## Breaking Changes

- None

## Related Issues

Resolves #69