### PR TITLE
docs: tighten manual Chrome Web Store upload checklist

### DIFF
--- a/docs/chrome-web-store-submission.md
+++ b/docs/chrome-web-store-submission.md
@@ -93,7 +93,11 @@ link and the privacy fields aligned with the shipped behavior.
 
 ## Release and upload checklist
 
-1. Ensure the package version is the version you intend to submit. Tag names should follow `v<version>`, for example `v1.0.0`.
+1. Run the [version-alignment
+   preflight](./chrome-web-store.md#version-alignment-preflight) and
+   confirm `package.json`, the packaged zip filename, the Git tag, the
+   `docs/releases/v<version>.md` note, and the Chrome Web Store draft
+   version all resolve to the same `v<version>`.
 2. Run `pnpm preflight:release` in an environment with `WXT_GITHUB_APP_CLIENT_ID`, `WXT_GITHUB_APP_SLUG`, and `WXT_GITHUB_APP_NAME` populated. For local release builds, `pnpm build:release` and `pnpm zip:release` load these from GitHub Actions repository variables through `gh` and run the same preflight.
 3. Run `pnpm verify:release`.
 4. Run `pnpm cws:assets` if the submission screenshots need to reflect UI changes.
@@ -103,7 +107,7 @@ link and the privacy fields aligned with the shipped behavior.
 8. Paste the short description, detailed description, and privacy policy URL above.
 9. Fill in the privacy fields using the current values above, then reconcile every answer against the shipped permissions and network behavior.
 10. If you want review before launch, disable automatic publish and stage the release in the dashboard.
-11. After approval, publish the staged version and align the Git tag, GitHub Release, and store version.
+11. After approval, publish the staged version and re-run the version-alignment preflight against the now-published draft to confirm the Git tag, GitHub Release, and store version still match `v<version>`.
 12. Open the packaged extension's options page once before upload and confirm it never renders as a blank white screen. A missing GitHub App build config must surface the explicit configuration warning instead.
 
 ## Current package target

--- a/docs/chrome-web-store-submission.md
+++ b/docs/chrome-web-store-submission.md
@@ -93,22 +93,28 @@ link and the privacy fields aligned with the shipped behavior.
 
 ## Release and upload checklist
 
-1. Run the [version-alignment
+1. Run `pnpm preflight:release` in an environment with `WXT_GITHUB_APP_CLIENT_ID`, `WXT_GITHUB_APP_SLUG`, and `WXT_GITHUB_APP_NAME` populated. For local release builds, `pnpm build:release` and `pnpm zip:release` load these from GitHub Actions repository variables through `gh` and run the same preflight.
+2. Run `pnpm verify:release`.
+3. Run `pnpm cws:assets` if the submission screenshots need to reflect UI changes.
+4. Run `pnpm zip` only after the checks above pass.
+5. Run the [version-alignment
    preflight](./chrome-web-store.md#version-alignment-preflight) and
-   confirm `package.json`, the packaged zip filename, the Git tag, the
-   `docs/releases/v<version>.md` note, and the Chrome Web Store draft
-   version all resolve to the same `v<version>`.
-2. Run `pnpm preflight:release` in an environment with `WXT_GITHUB_APP_CLIENT_ID`, `WXT_GITHUB_APP_SLUG`, and `WXT_GITHUB_APP_NAME` populated. For local release builds, `pnpm build:release` and `pnpm zip:release` load these from GitHub Actions repository variables through `gh` and run the same preflight.
-3. Run `pnpm verify:release`.
-4. Run `pnpm cws:assets` if the submission screenshots need to reflect UI changes.
-5. Run `pnpm zip` only after the checks above pass.
-6. Upload `.output/*-chrome.zip` in the Chrome Web Store dashboard.
-7. Attach the three screenshots listed above, in order, with the dashboard captions from the screenshot inventory.
-8. Paste the short description, detailed description, and privacy policy URL above.
-9. Fill in the privacy fields using the current values above, then reconcile every answer against the shipped permissions and network behavior.
-10. If you want review before launch, disable automatic publish and stage the release in the dashboard.
-11. After approval, publish the staged version and re-run the version-alignment preflight against the now-published draft to confirm the Git tag, GitHub Release, and store version still match `v<version>`.
-12. Open the packaged extension's options page once before upload and confirm it never renders as a blank white screen. A missing GitHub App build config must surface the explicit configuration warning instead.
+   confirm `package.json`, the packaged zip filename, the `v<version>`
+   Git tag, and the `docs/releases/v<version>.md` note all use the same
+   bare `<version>` value.
+6. Open the packaged extension's options page once before upload and
+   confirm it never renders as a blank white screen. A missing GitHub App
+   build config must surface the explicit configuration warning instead.
+7. Upload `.output/*-chrome.zip` in the Chrome Web Store dashboard.
+8. Confirm the dashboard package version reads the same bare `<version>`
+   from the preflight before submitting for review or publishing.
+9. Attach the three screenshots listed above, in order, with the dashboard captions from the screenshot inventory.
+10. Paste the short description, detailed description, and privacy policy URL above.
+11. Fill in the privacy fields using the current values above, then reconcile every answer against the shipped permissions and network behavior.
+12. If you want review before launch, disable automatic publish and stage the release in the dashboard.
+13. After approval, publish the staged version and confirm the Git tag,
+    GitHub Release, release note, and now-published store version still
+    reference the same bare `<version>` value.
 
 ## Current package target
 

--- a/docs/chrome-web-store.md
+++ b/docs/chrome-web-store.md
@@ -68,23 +68,24 @@ Expected release gate behavior:
 
 ## Manual Chrome Web Store submission checklist
 
-Before uploading, complete the [version-alignment
-preflight](#version-alignment-preflight) below. Then:
-
 1. Run `pnpm icons:render` if the SVG icon changed.
 2. Run `pnpm verify:release`.
 3. Run `pnpm cws:assets` if screenshots need to be refreshed for this submission.
-4. Upload `.output/github-pulls-show-reviewers-<version>-chrome.zip` to the Chrome Web Store dashboard.
-5. Use the short and detailed descriptions above for the store listing.
-6. Refresh screenshots so they show reviewer chips on GitHub pull request lists only, using the generated fixture rather than live dummy PRs.
-7. Confirm the privacy disclosure matches the shipped behavior:
+4. Run `pnpm zip` after the checks above pass.
+5. Complete the [version-alignment
+   preflight](#version-alignment-preflight).
+6. Upload `.output/github-pulls-show-reviewers-<version>-chrome.zip` to the Chrome Web Store dashboard.
+7. Confirm the dashboard package version reads the same bare `<version>`
+   from the preflight before submitting for review or publishing.
+8. Use the short and detailed descriptions above for the store listing.
+9. Refresh screenshots so they show reviewer chips on GitHub pull request lists only, using the generated fixture rather than live dummy PRs.
+10. Confirm the privacy disclosure matches the shipped behavior:
    no sale of data, no advertising, no remote code, GitHub page access only,
    and locally stored GitHub App accounts plus a `preferences` record in
    `browser.storage.local` for private-repository access and reviewer display
    settings.
-8. Keep release tags aligned with the store package version, using `v<manifest-version>` tags such as `v1.0.0`.
-9. Confirm the reviewer-only scope in the listing copy still matches the extension and screenshots before submission.
-10. Open the packaged extension's options page once before submission and confirm it either renders the sign-in UI normally or shows the explicit GitHub App configuration warning, never a blank page.
+11. Confirm the reviewer-only scope in the listing copy still matches the extension and screenshots before submission.
+12. Open the packaged extension's options page once before submission and confirm it either renders the sign-in UI normally or shows the explicit GitHub App configuration warning, never a blank page.
 
 Concrete submission assets and current privacy-form values live in
 [chrome-web-store-submission.md](./chrome-web-store-submission.md). The
@@ -95,27 +96,29 @@ and is hosted publicly at
 ## Version-alignment preflight
 
 Run this preflight before every Chrome Web Store upload. It guards
-against `package.json` / zip / Git tag / release note / store draft
-drift, which is the most common manual-release failure mode for this
-repository.
+against `package.json` / zip / Git tag / release note drift before the
+package reaches the Chrome Web Store dashboard.
 
-Confirm every item below resolves to the same `v<version>` string:
+Start with the bare package version, such as `1.7.2`, and confirm every
+derived release artifact uses that same `<version>` value:
 
-1. `package.json` `version` field. Sanity check with
+1. `package.json` `version` field must be the bare `<version>`. Sanity check with
    `node -p "require('./package.json').version"`.
 2. The packaged zip filename. The release zip must be named
    `github-pulls-show-reviewers-<version>-chrome.zip` and live under
    `.output/`. Verify with
    `ls .output/github-pulls-show-reviewers-<version>-chrome.zip`.
-3. The Git tag. Verify with `git tag -l "v<version>"` and that the tag
+3. The Git tag must be `v<version>`. Verify with `git tag -l "v<version>"` and that the tag
    points at the commit you intend to ship
    (`git rev-parse v<version>`).
 4. The release note file. `docs/releases/v<version>.md` must exist and
    describe this version's changes.
-5. The Chrome Web Store draft version. The dashboard's package version
-   must read the same `<version>` after upload, before publish.
 
 If any of these disagree, stop and reconcile before continuing the
 upload. The maintainer pattern is to bump `package.json`, recreate the
 zip, retag, and refresh the release note rather than to publish a
 mismatched submission.
+
+After upload, the Chrome Web Store draft version becomes available in
+the dashboard. Confirm it reads the same bare `<version>` before
+submitting for review or publishing.

--- a/docs/chrome-web-store.md
+++ b/docs/chrome-web-store.md
@@ -68,6 +68,9 @@ Expected release gate behavior:
 
 ## Manual Chrome Web Store submission checklist
 
+Before uploading, complete the [version-alignment
+preflight](#version-alignment-preflight) below. Then:
+
 1. Run `pnpm icons:render` if the SVG icon changed.
 2. Run `pnpm verify:release`.
 3. Run `pnpm cws:assets` if screenshots need to be refreshed for this submission.
@@ -88,3 +91,31 @@ Concrete submission assets and current privacy-form values live in
 canonical published privacy policy lives in [privacy-policy.md](./privacy-policy.md)
 and is hosted publicly at
 <https://github.com/hon454/github-pulls-show-reviewers/blob/main/docs/privacy-policy.md>.
+
+## Version-alignment preflight
+
+Run this preflight before every Chrome Web Store upload. It guards
+against `package.json` / zip / Git tag / release note / store draft
+drift, which is the most common manual-release failure mode for this
+repository.
+
+Confirm every item below resolves to the same `v<version>` string:
+
+1. `package.json` `version` field. Sanity check with
+   `node -p "require('./package.json').version"`.
+2. The packaged zip filename. The release zip must be named
+   `github-pulls-show-reviewers-<version>-chrome.zip` and live under
+   `.output/`. Verify with
+   `ls .output/github-pulls-show-reviewers-<version>-chrome.zip`.
+3. The Git tag. Verify with `git tag -l "v<version>"` and that the tag
+   points at the commit you intend to ship
+   (`git rev-parse v<version>`).
+4. The release note file. `docs/releases/v<version>.md` must exist and
+   describe this version's changes.
+5. The Chrome Web Store draft version. The dashboard's package version
+   must read the same `<version>` after upload, before publish.
+
+If any of these disagree, stop and reconcile before continuing the
+upload. The maintainer pattern is to bump `package.json`, recreate the
+zip, retag, and refresh the release note rather than to publish a
+mismatched submission.


### PR DESCRIPTION
## Summary

- Tighten the manual Chrome Web Store upload checklist around version-drift checks.
- Add a version-alignment preflight that compares the package version, packaged zip filename, Git tag, and release note before upload.
- Add a post-upload dashboard check so the Chrome Web Store package version is confirmed before review or publish.

## Why

Manual Chrome Web Store upload remains acceptable for this repository, but release drift is still an operational risk. The checklist should make it hard to publish a package whose `package.json` version, zip filename, Git tag, release note, GitHub Release, or store version disagree.

## Changes

- Document a `Version-alignment preflight` for manual Chrome Web Store uploads.
- Anchor the preflight on the bare `<version>` value, with `v<version>` only for Git tags and release-note filenames.
- Move the Chrome Web Store dashboard version confirmation to the post-upload point where that value is available.
- Cross-link the preflight from the Chrome Web Store submission packet.

## Impact

- User-facing impact: None; docs-only release process change.
- API/schema impact: None.
- Performance impact: None.
- Operational or rollout impact: Maintainers get a clearer manual upload sequence for avoiding version/tag/release-note/store drift.

## Testing

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

### Test details

- GitHub CI `lint-and-test` succeeded on commit `21a16f7`.
- GitHub CI `e2e` succeeded on commit `21a16f7`.
- Ran `git diff --check HEAD^ HEAD` locally.
- Manually reviewed the checklist order so zip creation, pre-upload alignment checks, upload, and post-upload dashboard confirmation are sequentially possible.

## Breaking Changes

- None

## Related Issues

Resolves #70
