### PR TITLE
fix(reviewers): ignore relative-time row mutations

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -54,7 +54,9 @@
    navigation. Same-repository navigation/render events mark visible row
    summaries stale instead of trusting the active page-session cache forever.
    Existing-row DOM mutations use a lightweight row fingerprint so unrelated
-   attribute changes do not trigger reviewer API requests.
+   attribute changes do not trigger reviewer API requests. The fingerprint
+   excludes extension-rendered reviewer nodes and GitHub's volatile relative
+   timestamp nodes, so automatic time text updates do not refetch reviewers.
 
 ## Current limitations
 

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -462,7 +462,14 @@ function readRowMetadataText(metaContainer: Element | null): string {
   if (metaContainer == null) return "";
   const clone = metaContainer.cloneNode(true);
   if (!(clone instanceof Element)) return "";
-  clone.querySelectorAll("[data-ghpsr-root]").forEach((node) => node.remove());
+  clone
+    .querySelectorAll(
+      [
+        "[data-ghpsr-root]",
+        ...githubSelectors.volatileMetadataSelectors,
+      ].join(", "),
+    )
+    .forEach((node) => node.remove());
   return (clone.textContent ?? "").replace(/\s+/g, " ").trim();
 }
 

--- a/src/github/selectors.ts
+++ b/src/github/selectors.ts
@@ -6,4 +6,5 @@ export const githubSelectors = {
     '[class*="ListItem-module__ListItemMetadataRow"]',
   ],
   inlineMetaRowSelectors: [".d-none.d-md-inline-flex"],
+  volatileMetadataSelectors: ["relative-time", "time-ago", ".js-timeago"],
 } as const;

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -588,6 +588,60 @@ describe("bootReviewerListPage", () => {
     clearReviewerCache();
   });
 
+  it("does not revalidate existing rows when GitHub relative-time text updates", async () => {
+    getPreferencesMock.mockResolvedValue({
+      version: 1,
+      showStateBadge: true,
+      showReviewerName: true,
+      openPullsOnly: true,
+    });
+    resolveAccountForRepoMock.mockResolvedValue(null);
+
+    const {
+      buildReviewerCacheKey,
+      clearReviewerCache,
+      setCachedReviewerSummary,
+    } = await import("../src/cache/reviewer-cache");
+    clearReviewerCache();
+    setCachedReviewerSummary(
+      buildReviewerCacheKey("cinev", "shotloom", "42"),
+      {
+        status: "ok",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+        completedReviews: [],
+      },
+      { fetchedAt: Date.now() },
+    );
+
+    const metadata = document.querySelector<HTMLElement>(
+      ".d-flex.mt-1.text-small.color-fg-muted",
+    )!;
+    metadata.innerHTML = `
+      <span class="issue-meta-section">
+        #42 opened <relative-time datetime="2026-05-08T02:00:00Z">30 minutes ago</relative-time> by mira
+      </span>
+    `;
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(document.body.textContent).toContain("@alice");
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(0);
+
+    document.querySelector("relative-time")!.textContent = "31 minutes ago";
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(0);
+
+    clearReviewerCache();
+  });
+
   it("revalidates mutated existing rows when metadata children are added", async () => {
     getPreferencesMock.mockResolvedValue({
       version: 1,


### PR DESCRIPTION
## Summary

- Prevent GitHub relative-time DOM updates from invalidating reviewer row caches.
- Keep meaningful row mutations, such as PR href or reviewer-relevant metadata changes, on the existing revalidation path.
- Document the row fingerprint behavior and add regression coverage for the rate-limit trigger.

## Why

Public repositories use the no-token reviewer path unless a saved GitHub App account covers the repository. The row fingerprint included GitHub's relative timestamp text, so idle PR list pages could refetch reviewers every time GitHub updated `opened N minutes ago` text and exhaust the unauthenticated 60/hr API limit.

## Changes

- Row fingerprints now strip extension-rendered reviewer nodes and known volatile GitHub timestamp nodes before reading metadata text.
- GitHub volatile metadata selectors are centralized with the other GitHub DOM selectors.
- Added a regression test proving `relative-time` text updates do not trigger `fetchPullReviewerSummary`.
- Updated implementation notes for the clarified fingerprint semantics.

## Impact

- User-facing impact: Fewer spurious unauthenticated rate-limit banners on public PR lists left open while idle.
- API/schema impact: None.
- Performance impact: Reduces unnecessary GitHub REST reviewer requests from volatile timestamp churn.
- Operational or rollout impact: None.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

### Test details

- RED: `pnpm test -- tests/reviewers.test.ts -t "relative-time text updates"` failed before the fix because one `fetchPullReviewerSummary` request was emitted.
- GREEN: `pnpm exec vitest run tests/reviewers.test.ts -t "relative-time text updates|mutated existing rows"` passed with 3 selected tests.
- `pnpm lint && pnpm typecheck && pnpm test` passed: 27 files, 330 tests.
- `pnpm build` passed for chrome-mv3.
- Manual Chrome extension testing not run.

## Breaking Changes

- None

## Related Issues

Resolves #93

Co-location note: `src/github/selectors.ts` changed, so reviewer regression coverage was added in `tests/reviewers.test.ts`; implementation behavior was also documented in `docs/implementation-notes.md`.
