### PR TITLE
docs: document browser and language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ Install the extension from the [Chrome Web Store](https://chromewebstore.google.
 
 After installation, open a GitHub repository's pull request list. Public repositories work without signing in. For private repositories, open the extension options page and add the GitHub account that can access the repository.
 
+## Browser and Language Support
+
+Chrome is the only browser this extension currently supports and tests. Other
+Chromium-family browsers such as Edge, Brave, and Arc may be able to run the
+same MV3 build, but they are not release targets today and are not covered by
+the manual Chrome verification flow. Firefox support is also out of scope until
+its MV3 behavior, extension packaging, and GitHub sign-in flow are tested
+explicitly.
+
+The extension is English-only today. Future localization would require
+extracting Chrome manifest strings, options-page copy, access-banner guidance,
+and injected pull-request-list labels into Chrome `_locales` resources or an
+equivalent localization layer.
+
 ## Public and Private Repositories
 
 - **Public repositories:** work without signing in whenever GitHub exposes enough public PR data.

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -68,6 +68,17 @@
 - Public-repository no-token access still depends on GitHub's unauthenticated REST availability and rate limits.
 - PAT-era single-token settings are not migrated; users must sign in again with
   the GitHub App account flow.
+- Browser support is intentionally limited to Chrome. The build and release
+  flow target Chrome MV3, manual verification runs in Chrome, and Chrome Web
+  Store packaging is the only distribution path. Edge, Brave, and Arc may run
+  the Chromium MV3 output, but they are compatibility expectations rather than
+  supported targets. Firefox support would need separate MV3 behavior checks,
+  packaging validation, store guidance, and private-repository sign-in testing.
+- User-facing copy is intentionally English-only. Adding localization later
+  would require extracting manifest text into Chrome `_locales`, moving
+  options-page React copy, access-banner guidance, and injected reviewer labels
+  behind a translation boundary, then adding fixture coverage to keep localized
+  pull-list rendering deterministic.
 
 ## Display preferences
 


### PR DESCRIPTION
## Summary

- Documents Chrome as the only currently supported and tested browser.
- Documents English-only as the current language policy.
- Records the expected future work for Chromium-family, Firefox, and localization support.

## Why

The maturity audit found that browser portability and localization expectations were implicit. This PR makes those policies explicit so users do not assume support for untested browsers or localization that has not been implemented.

## Changes

- Adds a README section covering Chrome-only support, Chromium-family compatibility expectations, Firefox scope, and English-only language support.
- Extends implementation notes with release-flow and maintenance details for future browser support and localization work.
- Keeps browser porting, i18n framework setup, and `_locales` implementation out of scope.

## Impact

- User-facing impact: Users and contributors can see the current browser and language support policy before installing or contributing.
- API/schema impact: None.
- Performance impact: None.
- Operational or rollout impact: None; documentation only.

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint`
- `git diff --check`
- Confirmed no `_locales` directory was added.

## Breaking Changes

- None

## Related Issues

Resolves #76
Resolves #77
