### PR TITLE
chore(typescript): enable exact optional property types

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -49,7 +49,11 @@ export default defineContentScript({
               );
               return;
             }
-            aggregator.reportFailure(classified.kind, classified.info);
+            if (classified.info == null) {
+              aggregator.reportFailure(classified.kind);
+            } else {
+              aggregator.reportFailure(classified.kind, classified.info);
+            }
           },
         });
       }
@@ -93,13 +97,11 @@ function classifyRowFailure(
       }
       continue;
     }
-    best = {
-      kind,
-      info:
-        isRateLimitKind(kind)
-          ? { rateLimit: failure.rateLimit }
-          : undefined,
-    };
+    if (isRateLimitKind(kind) && failure.rateLimit != null) {
+      best = { kind, info: { rateLimit: failure.rateLimit } };
+    } else {
+      best = { kind };
+    }
   }
   return best;
 }

--- a/src/background/reviewer-fetch.ts
+++ b/src/background/reviewer-fetch.ts
@@ -76,8 +76,10 @@ export function createReviewerFetchService(input: {
             repo: message.repo,
             pullNumber: message.pullNumber,
             githubToken: token,
-            pullMetadata: message.pullMetadata,
             signal: controller.signal,
+            ...(message.pullMetadata == null
+              ? {}
+              : { pullMetadata: message.pullMetadata }),
           });
 
         try {

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -274,8 +274,8 @@ export function bootReviewerListPage(
           owner: route.owner,
           repo: route.repo,
           pullNumber,
-          pullMetadata,
           signal: controller.signal,
+          ...(pullMetadata == null ? {} : { pullMetadata }),
         });
         if (controller.signal.aborted) {
           return;

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { withOptionalSignal } from "./request-init";
+
 type GitHubAuthContext = {
   githubToken: string | null;
 };
@@ -285,10 +287,10 @@ export async function fetchPullReviewerSummary(input: {
   const reviewsFirstPageUrl = `https://api.github.com${reviewsEndpoint.path}?per_page=100`;
 
   if (input.pullMetadata != null) {
-    const reviewsFirstResponse = await fetch(reviewsFirstPageUrl, {
-      headers,
-      signal: input.signal,
-    });
+    const reviewsFirstResponse = await fetch(
+      reviewsFirstPageUrl,
+      withOptionalSignal({ headers }, input.signal),
+    );
 
     const failure = await createGitHubApiErrorFromResponse(
       reviewsFirstResponse,
@@ -302,7 +304,7 @@ export async function fetchPullReviewerSummary(input: {
       firstResponse: reviewsFirstResponse,
       endpoint: reviewsEndpoint,
       headers,
-      signal: input.signal,
+      ...(input.signal == null ? {} : { signal: input.signal }),
     });
 
     const latestReviewEvidence = collectLatestReviewEvidence(
@@ -317,7 +319,7 @@ export async function fetchPullReviewerSummary(input: {
         pullMetadata: input.pullMetadata,
         latestNonCommentByUser: latestReviewEvidence.latestNonCommentByUser,
         headers,
-        signal: input.signal,
+        ...(input.signal == null ? {} : { signal: input.signal }),
       });
 
     return buildPullReviewerSummary(
@@ -335,8 +337,8 @@ export async function fetchPullReviewerSummary(input: {
   const pullUrl = `https://api.github.com${pullEndpoint.path}`;
 
   const [pullResponse, reviewsFirstResponse] = await Promise.all([
-    fetch(pullUrl, { headers, signal: input.signal }),
-    fetch(reviewsFirstPageUrl, { headers, signal: input.signal }),
+    fetch(pullUrl, withOptionalSignal({ headers }, input.signal)),
+    fetch(reviewsFirstPageUrl, withOptionalSignal({ headers }, input.signal)),
   ]);
 
   const failures = (
@@ -359,7 +361,7 @@ export async function fetchPullReviewerSummary(input: {
     firstResponse: reviewsFirstResponse,
     endpoint: reviewsEndpoint,
     headers,
-    signal: input.signal,
+    ...(input.signal == null ? {} : { signal: input.signal }),
   });
 
   const pullMetadata = toPullReviewerMetadata(input.pullNumber, pullParsed.data);
@@ -372,7 +374,7 @@ export async function fetchPullReviewerSummary(input: {
       pullMetadata,
       latestNonCommentByUser: latestReviewEvidence.latestNonCommentByUser,
       headers,
-      signal: input.signal,
+      ...(input.signal == null ? {} : { signal: input.signal }),
     });
 
   return buildPullReviewerSummary(
@@ -390,10 +392,10 @@ export async function fetchPullReviewerMetadataBatch(input: {
 }): Promise<PullReviewerMetadata[]> {
   const headers = createGitHubHeaders(input.githubToken);
   const endpoint = buildPullsMetadataEndpoint(input.owner, input.repo);
-  const response = await fetch(`https://api.github.com${endpoint.path}`, {
-    headers,
-    signal: input.signal,
-  });
+  const response = await fetch(
+    `https://api.github.com${endpoint.path}`,
+    withOptionalSignal({ headers }, input.signal),
+  );
 
   const failure = await createGitHubApiErrorFromResponse(response, endpoint);
   if (failure != null) {
@@ -528,10 +530,10 @@ async function fetchLatestReviewRequestEventsForAmbiguousReviewers(params: {
   const firstPageUrl = `https://api.github.com${endpoint.path}?per_page=100`;
 
   try {
-    const firstResponse = await fetch(firstPageUrl, {
-      headers: params.headers,
-      signal: params.signal,
-    });
+    const firstResponse = await fetch(
+      firstPageUrl,
+      withOptionalSignal({ headers: params.headers }, params.signal),
+    );
 
     const failure = await createGitHubApiErrorFromResponse(firstResponse, endpoint);
     if (failure != null) {
@@ -542,7 +544,7 @@ async function fetchLatestReviewRequestEventsForAmbiguousReviewers(params: {
       firstResponse,
       endpoint,
       headers: params.headers,
-      signal: params.signal,
+      ...(params.signal == null ? {} : { signal: params.signal }),
     });
 
     return selectLatestReviewRequestByLogin(events, new Set(ambiguousLogins));
@@ -847,10 +849,10 @@ async function collectReviewsAcrossPages(params: {
       return collected;
     }
 
-    response = await fetch(nextUrl, {
-      headers: params.headers,
-      signal: params.signal,
-    });
+    response = await fetch(
+      nextUrl,
+      withOptionalSignal({ headers: params.headers }, params.signal),
+    );
 
     const error = await createGitHubApiErrorFromResponse(
       response,
@@ -883,10 +885,10 @@ async function collectReviewRequestEventsAcrossPages(params: {
       return collected;
     }
 
-    response = await fetch(nextUrl, {
-      headers: params.headers,
-      signal: params.signal,
-    });
+    response = await fetch(
+      nextUrl,
+      withOptionalSignal({ headers: params.headers }, params.signal),
+    );
 
     const error = await createGitHubApiErrorFromResponse(
       response,

--- a/src/github/auth.ts
+++ b/src/github/auth.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { withOptionalSignal } from "./request-init";
+
 export type DeviceFlowErrorCode =
   | "expired_token"
   | "access_denied"
@@ -51,15 +53,20 @@ export async function initiateDeviceFlow(input: {
   clientId: string;
   signal?: AbortSignal;
 }): Promise<DeviceFlowInit> {
-  const response = await fetch("https://github.com/login/device/code", {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: new URLSearchParams({ client_id: input.clientId }).toString(),
-    signal: input.signal,
-  });
+  const response = await fetch(
+    "https://github.com/login/device/code",
+    withOptionalSignal(
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({ client_id: input.clientId }).toString(),
+      },
+      input.signal,
+    ),
+  );
   if (!response.ok) {
     throw new DeviceFlowError(
       "network_error",
@@ -128,19 +135,24 @@ export async function pollForAccessToken(input: {
   deviceCode: string;
   signal?: AbortSignal;
 }): Promise<AccessTokenPollResult> {
-  const response = await fetch("https://github.com/login/oauth/access_token", {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: new URLSearchParams({
-      client_id: input.clientId,
-      device_code: input.deviceCode,
-      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-    }).toString(),
-    signal: input.signal,
-  });
+  const response = await fetch(
+    "https://github.com/login/oauth/access_token",
+    withOptionalSignal(
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({
+          client_id: input.clientId,
+          device_code: input.deviceCode,
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }).toString(),
+      },
+      input.signal,
+    ),
+  );
   if (!response.ok) {
     throw new DeviceFlowError(
       "network_error",
@@ -230,19 +242,24 @@ export async function refreshAccessToken(input: {
 }): Promise<RefreshTokenResult> {
   let response: Response;
   try {
-    response = await fetch("https://github.com/login/oauth/access_token", {
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: new URLSearchParams({
-        client_id: input.clientId,
-        grant_type: "refresh_token",
-        refresh_token: input.refreshToken,
-      }).toString(),
-      signal: input.signal,
-    });
+    response = await fetch(
+      "https://github.com/login/oauth/access_token",
+      withOptionalSignal(
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: new URLSearchParams({
+            client_id: input.clientId,
+            grant_type: "refresh_token",
+            refresh_token: input.refreshToken,
+          }).toString(),
+        },
+        input.signal,
+      ),
+    );
   } catch (cause) {
     throw new RefreshTokenError(
       "transient",
@@ -351,10 +368,10 @@ export async function fetchAuthenticatedUser(input: {
   token: string;
   signal?: AbortSignal;
 }): Promise<AuthenticatedUser> {
-  const response = await fetch("https://api.github.com/user", {
-    headers: createAuthHeaders(input.token),
-    signal: input.signal,
-  });
+  const response = await fetch(
+    "https://api.github.com/user",
+    withOptionalSignal({ headers: createAuthHeaders(input.token) }, input.signal),
+  );
   if (!response.ok) {
     throw new Error(`GET /user failed with status ${response.status}.`);
   }
@@ -405,10 +422,10 @@ export async function fetchUserInstallations(input: {
   let url: string | null =
     "https://api.github.com/user/installations?per_page=100";
   for (let page = 0; page < MAX_INSTALLATION_PAGES && url != null; page++) {
-    const response = await fetch(url, {
-      headers: createAuthHeaders(input.token),
-      signal: input.signal,
-    });
+    const response = await fetch(
+      url,
+      withOptionalSignal({ headers: createAuthHeaders(input.token) }, input.signal),
+    );
     if (!response.ok) {
       throw new Error(
         `GET /user/installations failed with status ${response.status}.`,
@@ -453,10 +470,10 @@ export async function fetchInstallationRepositories(input: {
   const results: string[] = [];
   let url: string | null = `https://api.github.com/user/installations/${input.installationId}/repositories?per_page=100`;
   for (let page = 0; page < MAX_INSTALLATION_PAGES && url != null; page++) {
-    const response = await fetch(url, {
-      headers: createAuthHeaders(input.token),
-      signal: input.signal,
-    });
+    const response = await fetch(
+      url,
+      withOptionalSignal({ headers: createAuthHeaders(input.token) }, input.signal),
+    );
     if (!response.ok) {
       throw new Error(
         `GET /user/installations/${input.installationId}/repositories failed with status ${response.status}.`,

--- a/src/github/request-init.ts
+++ b/src/github/request-init.ts
@@ -1,0 +1,6 @@
+export function withOptionalSignal(
+  init: Omit<RequestInit, "signal">,
+  signal?: AbortSignal,
+): RequestInit {
+  return signal == null ? init : { ...init, signal };
+}

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -137,10 +137,7 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(401)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith(
-        "auth-expired",
-        undefined,
-      );
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-expired");
     });
 
     it("emits app-uncovered for account + 404 (no rate-limit signal)", async () => {
@@ -157,10 +154,7 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(404)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith(
-        "app-uncovered",
-        undefined,
-      );
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("app-uncovered");
     });
 
     it("emits app-uncovered for account + 403 without rate-limit signal", async () => {
@@ -179,10 +173,7 @@ describe("content entrypoint", () => {
         ]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith(
-        "app-uncovered",
-        undefined,
-      );
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("app-uncovered");
     });
 
     it("emits auth-rate-limit with the response snapshot for account + 403 + rate-limit headers", async () => {
@@ -230,9 +221,7 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(429)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit", {
-        rateLimit: undefined,
-      });
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("auth-rate-limit");
     });
 
     it("backfills rate-limit details from a later same-kind failure", async () => {
@@ -315,10 +304,7 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(403)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith(
-        "signin-required",
-        undefined,
-      );
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("signin-required");
     });
 
     it("emits signin-required for no account + 401", async () => {
@@ -335,10 +321,7 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(401)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith(
-        "signin-required",
-        undefined,
-      );
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("signin-required");
     });
 
     it("emits unauth-rate-limit without a snapshot for no account + 429 with no headers", async () => {
@@ -357,7 +340,6 @@ describe("content entrypoint", () => {
 
       expect(aggregator.reportFailure).toHaveBeenCalledWith(
         "unauth-rate-limit",
-        { rateLimit: undefined },
       );
     });
 
@@ -375,10 +357,7 @@ describe("content entrypoint", () => {
         error: new GitHubPullRequestEndpointsError([new GitHubApiError(404)]),
       });
 
-      expect(aggregator.reportFailure).toHaveBeenCalledWith(
-        "signin-required",
-        undefined,
-      );
+      expect(aggregator.reportFailure).toHaveBeenCalledWith("signin-required");
     });
 
     it("picks the highest-priority kind across mixed failures (auth-expired wins over app-uncovered)", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./.wxt/tsconfig.json",
   "compilerOptions": {
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "jsx": "react-jsx"
   },
   "include": [


### PR DESCRIPTION
## Summary

- Enables `exactOptionalPropertyTypes` as the first incremental stronger TypeScript safety flag.
- Tightens optional request data and banner failure handling so absent values are omitted instead of written as `undefined` properties.

## Why

Issue #72 tracks maturity-audit finding F-001: the extension parses unstable GitHub API and DOM data, so stronger compiler checks should catch unsafe optional-value handling earlier. Starting with `exactOptionalPropertyTypes` keeps the first step focused while preserving the existing reviewer-list behavior.

## Changes

- Added a GitHub request-init helper that only includes `signal` when an abort signal exists, matching DOM `RequestInit` optional-property semantics.
- Updated reviewer summary and metadata fetch paths to omit optional `pullMetadata` when unavailable.
- Adjusted access-banner failure reporting and content tests so optional rate-limit info is only present when there is a snapshot.

## Impact

- User-facing impact: None; reviewer display behavior is unchanged.
- API/schema impact: None; no GitHub API payload or storage schema changes.
- Performance impact: None expected.
- Operational or rollout impact: TypeScript now enforces exact optional property handling during `pnpm typecheck`.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (338 tests passed)

## Breaking Changes

- None

## Related Issues

Resolves #72
