### PR TITLE
refactor(runtime): back messages with zod schemas

### DIFF
--- a/src/runtime/installation-refresh.ts
+++ b/src/runtime/installation-refresh.ts
@@ -1,9 +1,19 @@
+import { z } from "zod";
+
 import type { InstallationRefreshOutcome } from "../background/installation-refresh";
 
-export type RefreshAccountInstallationsMessage = {
-  type: "refreshAccountInstallations";
-  accountId: string;
-};
+const nonEmptyStringSchema = z
+  .string()
+  .refine((value) => value.trim().length > 0);
+
+export const refreshAccountInstallationsMessageSchema = z.object({
+  type: z.literal("refreshAccountInstallations"),
+  accountId: nonEmptyStringSchema,
+});
+
+export type RefreshAccountInstallationsMessage = z.infer<
+  typeof refreshAccountInstallationsMessageSchema
+>;
 
 export type RefreshAccountInstallationsResponse =
   | InstallationRefreshOutcome
@@ -12,11 +22,5 @@ export type RefreshAccountInstallationsResponse =
 export function isRefreshAccountInstallationsMessage(
   value: unknown,
 ): value is RefreshAccountInstallationsMessage {
-  return (
-    value != null &&
-    typeof value === "object" &&
-    (value as { type?: unknown }).type === "refreshAccountInstallations" &&
-    typeof (value as { accountId?: unknown }).accountId === "string" &&
-    ((value as { accountId: string }).accountId.trim().length > 0)
-  );
+  return refreshAccountInstallationsMessageSchema.safeParse(value).success;
 }

--- a/src/runtime/reviewer-fetch.ts
+++ b/src/runtime/reviewer-fetch.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import {
   GitHubApiError,
   GitHubApiSchemaError,
@@ -8,28 +10,56 @@ import {
   type PullReviewerSummary,
 } from "../github/api";
 
-export type FetchPullReviewerSummaryMessage = {
-  type: "fetchPullReviewerSummary";
-  requestId: string;
-  owner: string;
-  repo: string;
-  pullNumber: string;
-  accountId: string | null;
-  pullMetadata?: PullReviewerMetadata;
-};
+const nonEmptyStringSchema = z
+  .string()
+  .refine((value) => value.trim().length > 0);
 
-export type CancelPullReviewerSummaryMessage = {
-  type: "cancelPullReviewerSummary";
-  requestId: string;
-};
+const reviewerUserMessageSchema = z.object({
+  login: nonEmptyStringSchema,
+  avatarUrl: z.string().nullable(),
+}) satisfies z.ZodType<PullReviewerMetadata["requestedUsers"][number]>;
 
-export type FetchPullReviewerMetadataBatchMessage = {
-  type: "fetchPullReviewerMetadataBatch";
-  requestId: string;
-  owner: string;
-  repo: string;
-  accountId: string | null;
-};
+const pullReviewerMetadataMessageSchema = z.object({
+  number: nonEmptyStringSchema,
+  authorLogin: nonEmptyStringSchema,
+  requestedUsers: z.array(reviewerUserMessageSchema),
+  requestedTeams: z.array(z.string()),
+}) satisfies z.ZodType<PullReviewerMetadata>;
+
+export const fetchPullReviewerSummaryMessageSchema = z.object({
+  type: z.literal("fetchPullReviewerSummary"),
+  requestId: nonEmptyStringSchema,
+  owner: nonEmptyStringSchema,
+  repo: nonEmptyStringSchema,
+  pullNumber: nonEmptyStringSchema,
+  accountId: z.string().nullable(),
+  pullMetadata: pullReviewerMetadataMessageSchema.optional(),
+});
+
+export type FetchPullReviewerSummaryMessage = z.infer<
+  typeof fetchPullReviewerSummaryMessageSchema
+>;
+
+export const cancelPullReviewerSummaryMessageSchema = z.object({
+  type: z.literal("cancelPullReviewerSummary"),
+  requestId: nonEmptyStringSchema,
+});
+
+export type CancelPullReviewerSummaryMessage = z.infer<
+  typeof cancelPullReviewerSummaryMessageSchema
+>;
+
+export const fetchPullReviewerMetadataBatchMessageSchema = z.object({
+  type: z.literal("fetchPullReviewerMetadataBatch"),
+  requestId: nonEmptyStringSchema,
+  owner: nonEmptyStringSchema,
+  repo: nonEmptyStringSchema,
+  accountId: z.string().nullable(),
+});
+
+export type FetchPullReviewerMetadataBatchMessage = z.infer<
+  typeof fetchPullReviewerMetadataBatchMessageSchema
+>;
 
 export type ReviewerFetchRateLimitSnapshot = {
   limit: number | null;
@@ -82,46 +112,19 @@ export class ReviewerFetchRuntimeError extends Error {
 export function isFetchPullReviewerSummaryMessage(
   value: unknown,
 ): value is FetchPullReviewerSummaryMessage {
-  return (
-    value != null &&
-    typeof value === "object" &&
-    (value as { type?: unknown }).type === "fetchPullReviewerSummary" &&
-    hasNonEmptyString((value as { requestId?: unknown }).requestId) &&
-    hasNonEmptyString((value as { owner?: unknown }).owner) &&
-    hasNonEmptyString((value as { repo?: unknown }).repo) &&
-    hasNonEmptyString((value as { pullNumber?: unknown }).pullNumber) &&
-    (((value as { accountId?: unknown }).accountId === null) ||
-      typeof (value as { accountId?: unknown }).accountId === "string") &&
-    (!("pullMetadata" in value) ||
-      (value as { pullMetadata?: unknown }).pullMetadata === undefined ||
-      isPullReviewerMetadata((value as { pullMetadata?: unknown }).pullMetadata))
-  );
+  return fetchPullReviewerSummaryMessageSchema.safeParse(value).success;
 }
 
 export function isCancelPullReviewerSummaryMessage(
   value: unknown,
 ): value is CancelPullReviewerSummaryMessage {
-  return (
-    value != null &&
-    typeof value === "object" &&
-    (value as { type?: unknown }).type === "cancelPullReviewerSummary" &&
-    hasNonEmptyString((value as { requestId?: unknown }).requestId)
-  );
+  return cancelPullReviewerSummaryMessageSchema.safeParse(value).success;
 }
 
 export function isFetchPullReviewerMetadataBatchMessage(
   value: unknown,
 ): value is FetchPullReviewerMetadataBatchMessage {
-  return (
-    value != null &&
-    typeof value === "object" &&
-    (value as { type?: unknown }).type === "fetchPullReviewerMetadataBatch" &&
-    hasNonEmptyString((value as { requestId?: unknown }).requestId) &&
-    hasNonEmptyString((value as { owner?: unknown }).owner) &&
-    hasNonEmptyString((value as { repo?: unknown }).repo) &&
-    (((value as { accountId?: unknown }).accountId === null) ||
-      typeof (value as { accountId?: unknown }).accountId === "string")
-  );
+  return fetchPullReviewerMetadataBatchMessageSchema.safeParse(value).success;
 }
 
 export function serializeReviewerFetchError(
@@ -291,34 +294,4 @@ function parseRateLimitSnapshot(
     return undefined;
   }
   return candidate;
-}
-
-function hasNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-function isPullReviewerMetadata(value: unknown): value is PullReviewerMetadata {
-  if (value == null || typeof value !== "object") {
-    return false;
-  }
-  const record = value as Record<string, unknown>;
-  return (
-    hasNonEmptyString(record.number) &&
-    hasNonEmptyString(record.authorLogin) &&
-    Array.isArray(record.requestedUsers) &&
-    record.requestedUsers.every(isReviewerUser) &&
-    Array.isArray(record.requestedTeams) &&
-    record.requestedTeams.every((team) => typeof team === "string")
-  );
-}
-
-function isReviewerUser(value: unknown): value is PullReviewerMetadata["requestedUsers"][number] {
-  if (value == null || typeof value !== "object") {
-    return false;
-  }
-  const record = value as Record<string, unknown>;
-  return (
-    hasNonEmptyString(record.login) &&
-    (record.avatarUrl === null || typeof record.avatarUrl === "string")
-  );
 }

--- a/tests/runtime-messages.test.ts
+++ b/tests/runtime-messages.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cancelPullReviewerSummaryMessageSchema,
+  fetchPullReviewerMetadataBatchMessageSchema,
+  fetchPullReviewerSummaryMessageSchema,
+  isCancelPullReviewerSummaryMessage,
+  isFetchPullReviewerMetadataBatchMessage,
+  isFetchPullReviewerSummaryMessage,
+} from "../src/runtime/reviewer-fetch";
+import {
+  isRefreshAccountInstallationsMessage,
+  refreshAccountInstallationsMessageSchema,
+} from "../src/runtime/installation-refresh";
+
+describe("reviewer fetch runtime message schemas", () => {
+  it("accepts valid fetch-summary messages through the schema-backed guard", () => {
+    const message = {
+      type: "fetchPullReviewerSummary",
+      requestId: "req-1",
+      owner: "cinev",
+      repo: "shotloom",
+      pullNumber: "42",
+      accountId: null,
+      pullMetadata: {
+        number: "42",
+        authorLogin: "octocat",
+        requestedUsers: [{ login: "hubot", avatarUrl: null }],
+        requestedTeams: ["reviewers"],
+      },
+    };
+
+    expect(
+      fetchPullReviewerSummaryMessageSchema.safeParse(message).success,
+    ).toBe(true);
+    expect(isFetchPullReviewerSummaryMessage(message)).toBe(true);
+  });
+
+  it("rejects malformed nested pull metadata through the fetch-summary guard", () => {
+    const message = {
+      type: "fetchPullReviewerSummary",
+      requestId: "req-1",
+      owner: "cinev",
+      repo: "shotloom",
+      pullNumber: "42",
+      accountId: null,
+      pullMetadata: {
+        number: "42",
+        authorLogin: "octocat",
+        requestedUsers: [{ login: "", avatarUrl: null }],
+        requestedTeams: ["reviewers"],
+      },
+    };
+
+    expect(
+      fetchPullReviewerSummaryMessageSchema.safeParse(message).success,
+    ).toBe(false);
+    expect(isFetchPullReviewerSummaryMessage(message)).toBe(false);
+  });
+
+  it("accepts cancel and metadata-batch messages through their schema-backed guards", () => {
+    const cancelMessage = {
+      type: "cancelPullReviewerSummary",
+      requestId: "req-1",
+    };
+    const batchMessage = {
+      type: "fetchPullReviewerMetadataBatch",
+      requestId: "req-2",
+      owner: "cinev",
+      repo: "shotloom",
+      accountId: "acc-1",
+    };
+
+    expect(
+      cancelPullReviewerSummaryMessageSchema.safeParse(cancelMessage).success,
+    ).toBe(true);
+    expect(isCancelPullReviewerSummaryMessage(cancelMessage)).toBe(true);
+    expect(
+      fetchPullReviewerMetadataBatchMessageSchema.safeParse(batchMessage)
+        .success,
+    ).toBe(true);
+    expect(isFetchPullReviewerMetadataBatchMessage(batchMessage)).toBe(true);
+  });
+});
+
+describe("installation refresh runtime message schema", () => {
+  it("accepts valid refresh-installations messages through the schema-backed guard", () => {
+    const message = {
+      type: "refreshAccountInstallations",
+      accountId: "acc-1",
+    };
+
+    expect(
+      refreshAccountInstallationsMessageSchema.safeParse(message).success,
+    ).toBe(true);
+    expect(isRefreshAccountInstallationsMessage(message)).toBe(true);
+  });
+
+  it("rejects blank account ids through the schema-backed guard", () => {
+    const message = {
+      type: "refreshAccountInstallations",
+      accountId: " ",
+    };
+
+    expect(
+      refreshAccountInstallationsMessageSchema.safeParse(message).success,
+    ).toBe(false);
+    expect(isRefreshAccountInstallationsMessage(message)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Back reviewer-fetch and installation-refresh runtime request messages with zod schemas.
- Infer exported runtime message types from those schemas while preserving the existing `is...Message` guard APIs.
- Add focused unit coverage for valid and malformed schema-backed message guards.

## Why

Runtime messaging crosses the Chrome extension background/content boundary. Keeping exported TypeScript message types and runtime guards derived from the same zod schemas reduces drift as those payloads evolve.

## Changes

- Runtime contracts: define zod schemas for fetch-summary, cancel-summary, metadata-batch, and installation-refresh request messages.
- Type safety: infer the exported message types from the schemas and route all message guards through `safeParse`.
- Test coverage: add schema-backed guard tests for valid reviewer/installation messages and malformed nested reviewer metadata.

## Impact

- User-facing impact: None; this preserves current reviewer rendering and background dispatch behavior.
- API/schema impact: Internal runtime request message contracts are now zod schema-backed.
- Performance impact: Negligible; validation remains limited to incoming extension messages.
- Operational or rollout impact: None. Co-location checklist: no reviewer UX, selector, permission, storage persistence, auth flow, release, or CWS copy changes.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (28 files, 343 tests)

## Breaking Changes

- None

## Related Issues

Resolves #73
