### PR TITLE
fix: handle private repo reviewer fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ equivalent localization layer.
 - **Public repositories:** work without signing in whenever GitHub exposes enough public PR data.
 - **Private repositories:** require signing in with GitHub through the extension's GitHub App.
 - **Permissions:** the GitHub App requests `Pull requests: Read` only.
+- **Repository access:** if a signed-in private repository is not covered by the
+  GitHub App installation, the extension prompts you to configure App access
+  for that owner/repository.
 - **Organizations:** an organization owner may need to install or approve the GitHub App before private organization repositories can be read.
 - **Multiple accounts:** personal and work accounts can be added side by side. The extension picks the matching account for each repository.
 - **Session persistence:** sign-in is kept across browser sessions; access tokens are refreshed automatically in the background until you remove the account or revoke the GitHub App.

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -40,11 +40,13 @@
    `pull + reviews` REST path.
    If no covering account is found, the first attempt still uses the no-token
    path so public repositories keep working without authentication. When that
-   no-token summary fetch fails with an authentication, access, not-found, or
-   rate-limit response, the content script retries once with a connected
-   fallback account: first an account whose login matches the repository owner,
-   otherwise the sole active connected account if there is exactly one. A
-   successful fallback renders reviewers; a failed fallback is reported as a
+   no-token metadata or summary fetch fails with an authentication, access,
+   not-found, or rate-limit response, the content script retries once with a
+   connected fallback account: first an account whose login matches the
+   repository owner, then the only active account installed on that owner, and
+   finally the sole active connected account if there is exactly one. Ambiguous
+   owner-installation matches do not fallback. A successful fallback is reused
+   for that owner during the page session; a failed fallback is reported as a
    signed-in failure so the banner can point to GitHub App access rather than
    asking the user to sign in again.
 7. For ambiguous user reviewers that appear in both `requested_reviewers` and

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -38,6 +38,15 @@
    endpoint and reads only the reviews endpoint. If the pull number is absent
    from the batch result, the summary request falls back to the original per-row
    `pull + reviews` REST path.
+   If no covering account is found, the first attempt still uses the no-token
+   path so public repositories keep working without authentication. When that
+   no-token summary fetch fails with an authentication, access, not-found, or
+   rate-limit response, the content script retries once with a connected
+   fallback account: first an account whose login matches the repository owner,
+   otherwise the sole active connected account if there is exactly one. A
+   successful fallback renders reviewers; a failed fallback is reported as a
+   signed-in failure so the banner can point to GitHub App access rather than
+   asking the user to sign in again.
 7. For ambiguous user reviewers that appear in both `requested_reviewers` and
    the latest non-`COMMENTED` review set (`APPROVED`, `CHANGES_REQUESTED`, or
    `DISMISSED`), read the pull request's issue events and compare ordering.
@@ -51,12 +60,12 @@
 9. On API errors, emit a signal to the banner aggregator; do not render
    row-level error text.
 10. Re-run row processing when GitHub mutates the page or performs SPA
-   navigation. Same-repository navigation/render events mark visible row
-   summaries stale instead of trusting the active page-session cache forever.
-   Existing-row DOM mutations use a lightweight row fingerprint so unrelated
-   attribute changes do not trigger reviewer API requests. The fingerprint
-   excludes extension-rendered reviewer nodes and GitHub's volatile relative
-   timestamp nodes, so automatic time text updates do not refetch reviewers.
+    navigation. Same-repository navigation/render events mark visible row
+    summaries stale instead of trusting the active page-session cache forever.
+    Existing-row DOM mutations use a lightweight row fingerprint so unrelated
+    attribute changes do not trigger reviewer API requests. The fingerprint
+    excludes extension-rendered reviewer nodes and GitHub's volatile relative
+    timestamp nodes, so automatic time text updates do not refetch reviewers.
 
 ## Current limitations
 
@@ -154,7 +163,11 @@ snapshot is in-memory only — it is never persisted.
 - `createSelfHealingAccountResolver` (`src/features/reviewers/account-resolution.ts`) wraps the resolution: when the cached lookup misses, it scans for accounts that own a `selected` installation on the same owner but do not list the repo, then sends a `refreshAccountInstallations` message to the background and re-runs the resolution.
 - The background-side `createInstallationRefreshService` (`src/background/installation-refresh.ts`) holds the token, refreshes via `RefreshCoordinator` on 401, persists through `replaceInstallations`, and dedupes concurrent calls per `accountId`. Tokens never enter the content-script context.
 - Each candidate is refreshed at most once per page session. A successful refresh writes to `account:installations:*`, which the existing `accountsChange` storage listener uses to clear the row cache and re-render covered rows transparently.
-- Genuinely uncovered repos still flow into the `app-uncovered` / `signin-required` banner copy after the refresh attempt completes.
+- Genuinely uncovered repos still flow into the `app-uncovered` /
+  `signin-required` banner copy after the refresh attempt completes. When a
+  connected fallback account is available, uncovered private repositories are
+  reported through the signed-in `app-uncovered` path rather than the no-account
+  sign-in path.
 
 ## Next implementation targets
 

--- a/src/features/reviewers/account-resolution.ts
+++ b/src/features/reviewers/account-resolution.ts
@@ -6,9 +6,12 @@ import {
 
 export type SelfHealingAccountResolver = {
   resolveAccount(owner: string, repo: string): Promise<Account | null>;
+  resolveFallbackAccount(owner: string): Promise<Account | null>;
 };
 
-export type RequestInstallationsRefresh = (accountId: string) => Promise<boolean>;
+export type RequestInstallationsRefresh = (
+  accountId: string,
+) => Promise<boolean>;
 
 export function createSelfHealingAccountResolver(input: {
   requestRefresh: RequestInstallationsRefresh;
@@ -63,7 +66,9 @@ export function createSelfHealingAccountResolver(input: {
           return true;
         }
         const fullNames = installation.repoFullNames ?? [];
-        return fullNames.some((name) => name.toLowerCase() === normalizedFullName);
+        return fullNames.some(
+          (name) => name.toLowerCase() === normalizedFullName,
+        );
       });
       if (alreadyCovers) {
         continue;
@@ -89,9 +94,24 @@ export function createSelfHealingAccountResolver(input: {
         return null;
       }
 
-      await Promise.all(refreshable.map((accountId) => dedupedRefresh(accountId)));
+      await Promise.all(
+        refreshable.map((accountId) => dedupedRefresh(accountId)),
+      );
 
       return await resolveAccountForRepo(owner, repo);
+    },
+    async resolveFallbackAccount(owner: string): Promise<Account | null> {
+      const accounts = (await listAccounts()).filter(
+        (account) => !account.invalidated,
+      );
+      const normalizedOwner = owner.toLowerCase();
+      const ownerAccount = accounts.find(
+        (account) => account.login.toLowerCase() === normalizedOwner,
+      );
+      if (ownerAccount != null) {
+        return ownerAccount;
+      }
+      return accounts.length === 1 ? accounts[0] : null;
     },
   };
 }

--- a/src/features/reviewers/account-resolution.ts
+++ b/src/features/reviewers/account-resolution.ts
@@ -79,6 +79,14 @@ export function createSelfHealingAccountResolver(input: {
     return candidates;
   }
 
+  function hasInstallationForOwner(account: Account, owner: string): boolean {
+    const normalizedOwner = owner.toLowerCase();
+    return account.installations.some(
+      (installation) =>
+        installation.account.login.toLowerCase() === normalizedOwner,
+    );
+  }
+
   return {
     async resolveAccount(owner: string, repo: string): Promise<Account | null> {
       const initial = await resolveAccountForRepo(owner, repo);
@@ -111,6 +119,17 @@ export function createSelfHealingAccountResolver(input: {
       if (ownerAccount != null) {
         return ownerAccount;
       }
+
+      const ownerInstallationAccounts = accounts.filter((account) =>
+        hasInstallationForOwner(account, owner),
+      );
+      if (ownerInstallationAccounts.length === 1) {
+        return ownerInstallationAccounts[0] ?? null;
+      }
+      if (ownerInstallationAccounts.length > 1) {
+        return null;
+      }
+
       return accounts.length === 1 ? accounts[0] : null;
     },
   };

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -81,10 +81,20 @@ export function bootReviewerListPage(
     fetchedAt: number;
     stale: boolean;
   };
+  type FallbackAccountCache = {
+    owner: string;
+    account: Account | null;
+  };
+  type FallbackAccountRequest = {
+    owner: string;
+    promise: Promise<Account | null>;
+  };
   const inflightRequests = new Map<string, InflightRequest>();
   const rowFingerprints = new Map<string, string>();
   let pageMetadataRequest: PageMetadataRequest | null = null;
   let pageMetadataCache: PageMetadataCache | null = null;
+  let fallbackAccountCache: FallbackAccountCache | null = null;
+  let fallbackAccountRequest: FallbackAccountRequest | null = null;
   let cachedPreferences: Promise<Preferences> | null = null;
   const accountResolver = createSelfHealingAccountResolver({
     requestRefresh: requestInstallationsRefresh,
@@ -98,6 +108,46 @@ export function bootReviewerListPage(
     pageMetadataRequest?.controller.abort();
     pageMetadataRequest = null;
     pageMetadataCache = null;
+  }
+
+  function clearFallbackAccountCache(): void {
+    fallbackAccountCache = null;
+    fallbackAccountRequest = null;
+  }
+
+  function readCachedFallbackAccount(
+    owner: string,
+  ): Account | null | undefined {
+    return fallbackAccountCache?.owner === owner
+      ? fallbackAccountCache.account
+      : undefined;
+  }
+
+  async function getFallbackAccount(owner: string): Promise<Account | null> {
+    const cached = readCachedFallbackAccount(owner);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    if (fallbackAccountRequest?.owner === owner) {
+      return fallbackAccountRequest.promise;
+    }
+
+    const request: FallbackAccountRequest = {
+      owner,
+      promise: accountResolver.resolveFallbackAccount(owner).then((account) => {
+        fallbackAccountCache = { owner, account };
+        return account;
+      }),
+    };
+    fallbackAccountRequest = request;
+    try {
+      return await request.promise;
+    } finally {
+      if (fallbackAccountRequest === request) {
+        fallbackAccountRequest = null;
+      }
+    }
   }
 
   function readPreferences(): Promise<Preferences> {
@@ -128,7 +178,10 @@ export function bootReviewerListPage(
     account: Account | null,
     signal: AbortSignal,
   ): Promise<Map<string, PullReviewerMetadata>> {
-    const accountId = account?.id ?? null;
+    const cachedFallbackAccount =
+      account == null ? readCachedFallbackAccount(route.owner) : undefined;
+    const requestAccount = cachedFallbackAccount ?? account;
+    const accountId = requestAccount?.id ?? null;
     if (
       pageMetadataCache != null &&
       pageMetadataCache.owner === route.owner &&
@@ -164,7 +217,7 @@ export function bootReviewerListPage(
       accountId,
       controller,
       promise: fetchPageMetadata({
-        account,
+        account: requestAccount,
         owner: route.owner,
         repo: route.repo,
         signal: controller.signal,
@@ -183,8 +236,40 @@ export function bootReviewerListPage(
           };
           return metadataByNumber;
         })
-        .catch((error) => {
+        .catch(async (error) => {
           if (!isAbortError(error) && !controller.signal.aborted) {
+            if (account == null && shouldRetryWithFallbackAccount(error)) {
+              const fallbackAccount = await getFallbackAccount(route.owner);
+              if (fallbackAccount != null && !controller.signal.aborted) {
+                try {
+                  const metadata = await fetchPageMetadata({
+                    account: fallbackAccount,
+                    owner: route.owner,
+                    repo: route.repo,
+                    signal: controller.signal,
+                  });
+                  const metadataByNumber = new Map(
+                    metadata.map((pullMetadata) => [
+                      pullMetadata.number,
+                      pullMetadata,
+                    ]),
+                  );
+                  pageMetadataCache = {
+                    owner: route.owner,
+                    repo: route.repo,
+                    accountId: fallbackAccount.id,
+                    metadata: metadataByNumber,
+                    fetchedAt: Date.now(),
+                    stale: false,
+                  };
+                  return metadataByNumber;
+                } catch {
+                  if (controller.signal.aborted) {
+                    return new Map<string, PullReviewerMetadata>();
+                  }
+                }
+              }
+            }
             pageMetadataCache = {
               owner: route.owner,
               repo: route.repo,
@@ -265,13 +350,16 @@ export function bootReviewerListPage(
       const pullMetadata = (
         await getPageMetadata(route, account, controller.signal)
       ).get(pullNumber);
+      const cachedFallbackAccount =
+        account == null ? readCachedFallbackAccount(route.owner) : undefined;
+      const summaryAccount = cachedFallbackAccount ?? account;
       if (controller.signal.aborted) {
         return;
       }
 
       try {
         const summary = await fetchWithRefresh({
-          account,
+          account: summaryAccount,
           owner: route.owner,
           repo: route.repo,
           pullNumber,
@@ -286,12 +374,14 @@ export function bootReviewerListPage(
         if (isAbortError(error) || controller.signal.aborted) {
           return;
         }
-        let failureAccount = account;
+        let failureAccount = summaryAccount;
         let failureError = error;
-        if (account == null && shouldRetryWithFallbackAccount(error)) {
-          const fallbackAccount = await accountResolver.resolveFallbackAccount(
-            route.owner,
-          );
+        if (
+          account == null &&
+          summaryAccount == null &&
+          shouldRetryWithFallbackAccount(error)
+        ) {
+          const fallbackAccount = await getFallbackAccount(route.owner);
           if (controller.signal.aborted) {
             return;
           }
@@ -459,6 +549,7 @@ export function bootReviewerListPage(
 
     if (isAccountsChange(changes)) {
       clearReviewerCache();
+      clearFallbackAccountCache();
       abortInflightRequests();
       processRows();
     }

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -18,6 +18,7 @@ import { githubSelectors } from "../../github/selectors";
 import type { RefreshAccountInstallationsResponse } from "../../runtime/installation-refresh";
 import {
   ReviewerFetchRuntimeError,
+  extractReviewerFetchFailures,
   type FetchPullReviewerMetadataBatchResponse,
   type FetchPullReviewerSummaryResponse,
 } from "../../runtime/reviewer-fetch";
@@ -285,14 +286,47 @@ export function bootReviewerListPage(
         if (isAbortError(error) || controller.signal.aborted) {
           return;
         }
+        let failureAccount = account;
+        let failureError = error;
+        if (account == null && shouldRetryWithFallbackAccount(error)) {
+          const fallbackAccount = await accountResolver.resolveFallbackAccount(
+            route.owner,
+          );
+          if (controller.signal.aborted) {
+            return;
+          }
+          if (fallbackAccount != null) {
+            try {
+              const summary = await fetchWithRefresh({
+                account: fallbackAccount,
+                owner: route.owner,
+                repo: route.repo,
+                pullNumber,
+                signal: controller.signal,
+                ...(pullMetadata == null ? {} : { pullMetadata }),
+              });
+              if (controller.signal.aborted) {
+                return;
+              }
+              setCachedReviewerSummary(cacheKey, summary);
+              return;
+            } catch (fallbackError) {
+              if (isAbortError(fallbackError) || controller.signal.aborted) {
+                return;
+              }
+              failureAccount = fallbackAccount;
+              failureError = fallbackError;
+            }
+          }
+        }
         mount.replaceChildren();
         mount.removeAttribute("title");
         clearRenderedReviewerState(mount);
         options?.onRowFailure?.({
           owner: route.owner,
           repo: route.repo,
-          account,
-          error,
+          account: failureAccount,
+          error: failureError,
         });
       } finally {
         // Only delete if this is still the tracked request for that key.
@@ -464,10 +498,9 @@ function readRowMetadataText(metaContainer: Element | null): string {
   if (!(clone instanceof Element)) return "";
   clone
     .querySelectorAll(
-      [
-        "[data-ghpsr-root]",
-        ...githubSelectors.volatileMetadataSelectors,
-      ].join(", "),
+      ["[data-ghpsr-root]", ...githubSelectors.volatileMetadataSelectors].join(
+        ", ",
+      ),
     )
     .forEach((node) => node.remove());
   return (clone.textContent ?? "").replace(/\s+/g, " ").trim();
@@ -594,6 +627,17 @@ function isAbortError(error: unknown): boolean {
     return true;
   }
   return false;
+}
+
+function shouldRetryWithFallbackAccount(error: unknown): boolean {
+  return extractReviewerFetchFailures(error).some((failure) => {
+    if (failure.rateLimited || failure.status === 429) {
+      return true;
+    }
+    return (
+      failure.status === 401 || failure.status === 403 || failure.status === 404
+    );
+  });
 }
 
 function unwrapReviewerFetchResponse(

--- a/tests/account-resolution.test.ts
+++ b/tests/account-resolution.test.ts
@@ -60,7 +60,11 @@ describe("createSelfHealingAccountResolver", () => {
         installations: [
           {
             id: 1,
-            account: { login: "different-org", type: "Organization", avatarUrl: null },
+            account: {
+              login: "different-org",
+              type: "Organization",
+              avatarUrl: null,
+            },
             repositorySelection: "all",
             repoFullNames: null,
           },
@@ -285,6 +289,66 @@ describe("createSelfHealingAccountResolver", () => {
 
     expect(result).toBeNull();
     expect(resolveAccountForRepoMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the only active account installed on the repo owner as a fallback account", async () => {
+    const account = makeAccount({
+      id: "acc-work",
+      login: "work-user",
+      installations: [
+        {
+          id: 7,
+          account: { login: "acme", type: "Organization", avatarUrl: null },
+          repositorySelection: "selected",
+          repoFullNames: ["acme/legacy"],
+        },
+      ],
+    });
+    listAccountsMock.mockResolvedValueOnce([
+      makeAccount({ id: "acc-personal", login: "personal-user" }),
+      account,
+    ]);
+    const requestRefresh = vi.fn();
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    const result = await resolver.resolveFallbackAccount("acme");
+
+    expect(result).toBe(account);
+  });
+
+  it("does not pick a fallback account when multiple active accounts are installed on the repo owner", async () => {
+    listAccountsMock.mockResolvedValueOnce([
+      makeAccount({
+        id: "acc-a",
+        login: "user-a",
+        installations: [
+          {
+            id: 7,
+            account: { login: "acme", type: "Organization", avatarUrl: null },
+            repositorySelection: "selected",
+            repoFullNames: ["acme/legacy"],
+          },
+        ],
+      }),
+      makeAccount({
+        id: "acc-b",
+        login: "user-b",
+        installations: [
+          {
+            id: 8,
+            account: { login: "ACME", type: "Organization", avatarUrl: null },
+            repositorySelection: "all",
+            repoFullNames: null,
+          },
+        ],
+      }),
+    ]);
+    const requestRefresh = vi.fn();
+
+    const resolver = createSelfHealingAccountResolver({ requestRefresh });
+    const result = await resolver.resolveFallbackAccount("acme");
+
+    expect(result).toBeNull();
   });
 
   it("still re-resolves and returns null when a refresh succeeds but does not heal coverage", async () => {

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -259,7 +259,7 @@ describe("bootReviewerListPage", () => {
     expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(1);
   });
 
-  it("retries a failed no-token reviewer fetch with the connected owner account", async () => {
+  it("uses the connected owner account after a failed no-token metadata fetch", async () => {
     document.body.innerHTML = `
       <div class="js-issue-row" id="issue_42">
         <a class="Link--primary" href="/hon454/private-repo/pull/42">PR #42</a>
@@ -339,10 +339,15 @@ describe("bootReviewerListPage", () => {
     await flushMicrotasks();
 
     expect(
-      getRuntimeMessages("fetchPullReviewerSummary").map(
+      getRuntimeMessages("fetchPullReviewerMetadataBatch").map(
         (message) => message.accountId,
       ),
     ).toEqual([null, "acc-owner"]);
+    expect(
+      getRuntimeMessages("fetchPullReviewerSummary").map(
+        (message) => message.accountId,
+      ),
+    ).toEqual(["acc-owner"]);
     expect(onRowFailure).not.toHaveBeenCalled();
     expect(document.body.textContent).toContain("Reviewers:");
     expect(
@@ -423,6 +428,117 @@ describe("bootReviewerListPage", () => {
         envelope: notFoundError,
       }),
     });
+  });
+
+  it("reuses a page fallback account after a failed no-token metadata request", async () => {
+    document.body.innerHTML = `
+      <div class="js-issue-row" id="issue_42">
+        <a class="Link--primary" href="/hon454/private-repo/pull/42">PR #42</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+      <div class="js-issue-row" id="issue_41">
+        <a class="Link--primary" href="/hon454/private-repo/pull/41">PR #41</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+    `;
+    window.history.replaceState({}, "", "/hon454/private-repo/pulls");
+
+    const account = {
+      id: "acc-owner",
+      login: "hon454",
+      avatarUrl: null,
+      token: "ghu_owner",
+      createdAt: 1,
+      installations: [],
+      installationsRefreshedAt: 1,
+      invalidated: false,
+      invalidatedReason: null,
+      refreshToken: null,
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
+    };
+    resolveAccountForRepoMock.mockResolvedValue(null);
+    listAccountsMock.mockResolvedValue([account]);
+
+    const rateLimitError = {
+      kind: "github-api" as const,
+      status: 429,
+      failures: [{ status: 429, endpoint: null, rateLimited: true }],
+    };
+    const summary: PullReviewerSummary = {
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: [],
+      completedReviews: [],
+    };
+
+    runtimeSendMessageMock.mockImplementation(
+      (message: {
+        type?: string;
+        accountId?: string | null;
+        pullNumber?: string;
+      }) => {
+        if (
+          message.type === "fetchPullReviewerMetadataBatch" &&
+          message.accountId == null
+        ) {
+          return Promise.resolve({ ok: false, error: rateLimitError });
+        }
+        if (
+          message.type === "fetchPullReviewerMetadataBatch" &&
+          message.accountId === "acc-owner"
+        ) {
+          return Promise.resolve({
+            ok: true,
+            metadata: [
+              {
+                number: "42",
+                authorLogin: "hon454",
+                requestedUsers: [],
+                requestedTeams: [],
+              },
+              {
+                number: "41",
+                authorLogin: "hon454",
+                requestedUsers: [],
+                requestedTeams: [],
+              },
+            ],
+          });
+        }
+        if (
+          message.type === "fetchPullReviewerSummary" &&
+          message.accountId === "acc-owner"
+        ) {
+          return Promise.resolve({ ok: true, summary });
+        }
+        if (message.type === "fetchPullReviewerSummary") {
+          return Promise.resolve({ ok: false, error: rateLimitError });
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+
+    const onRowFailure = vi.fn();
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx(), { onRowFailure });
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(
+      getRuntimeMessages("fetchPullReviewerMetadataBatch").map(
+        (message) => message.accountId,
+      ),
+    ).toEqual([null, "acc-owner"]);
+    expect(
+      getRuntimeMessages("fetchPullReviewerSummary").map(
+        (message) => message.accountId,
+      ),
+    ).toEqual(["acc-owner", "acc-owner"]);
+    expect(listAccountsMock).toHaveBeenCalledTimes(1);
+    expect(onRowFailure).not.toHaveBeenCalled();
   });
 
   it("requests page-level pull metadata once and reuses it for matching row summaries", async () => {

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -259,6 +259,172 @@ describe("bootReviewerListPage", () => {
     expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(1);
   });
 
+  it("retries a failed no-token reviewer fetch with the connected owner account", async () => {
+    document.body.innerHTML = `
+      <div class="js-issue-row" id="issue_42">
+        <a class="Link--primary" href="/hon454/private-repo/pull/42">PR #42</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+    `;
+    window.history.replaceState({}, "", "/hon454/private-repo/pulls");
+
+    resolveAccountForRepoMock.mockResolvedValue(null);
+    listAccountsMock.mockResolvedValue([
+      {
+        id: "acc-owner",
+        login: "hon454",
+        avatarUrl: null,
+        token: "ghu_owner",
+        createdAt: 1,
+        installations: [],
+        installationsRefreshedAt: 1,
+        invalidated: false,
+        invalidatedReason: null,
+        refreshToken: null,
+        expiresAt: null,
+        refreshTokenExpiresAt: null,
+      },
+    ]);
+
+    const summary: PullReviewerSummary = {
+      status: "ok",
+      requestedUsers: [{ login: "alice", avatarUrl: null }],
+      requestedTeams: [],
+      completedReviews: [],
+    };
+    const rateLimitError = {
+      kind: "github-api" as const,
+      status: 429,
+      failures: [
+        {
+          status: 429,
+          endpoint: null,
+          rateLimited: true,
+          rateLimit: {
+            limit: 60,
+            remaining: 0,
+            resource: "core",
+            resetAt: 1_700_000_000,
+          },
+        },
+      ],
+    };
+    runtimeSendMessageMock.mockImplementation(
+      (message: { type?: string; accountId?: string | null }) => {
+        if (message.type === "fetchPullReviewerMetadataBatch") {
+          return Promise.resolve({ ok: false, error: rateLimitError });
+        }
+        if (
+          message.type === "fetchPullReviewerSummary" &&
+          message.accountId == null
+        ) {
+          return Promise.resolve({ ok: false, error: rateLimitError });
+        }
+        if (
+          message.type === "fetchPullReviewerSummary" &&
+          message.accountId === "acc-owner"
+        ) {
+          return Promise.resolve({ ok: true, summary });
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+
+    const onRowFailure = vi.fn();
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx(), { onRowFailure });
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(
+      getRuntimeMessages("fetchPullReviewerSummary").map(
+        (message) => message.accountId,
+      ),
+    ).toEqual([null, "acc-owner"]);
+    expect(onRowFailure).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Reviewers:");
+    expect(
+      document.querySelector('a.ghpsr-avatar[title*="@alice"]'),
+    ).not.toBeNull();
+  });
+
+  it("reports fallback account failures as signed-in failures", async () => {
+    document.body.innerHTML = `
+      <div class="js-issue-row" id="issue_42">
+        <a class="Link--primary" href="/hon454/private-repo/pull/42">PR #42</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+    `;
+    window.history.replaceState({}, "", "/hon454/private-repo/pulls");
+
+    const account = {
+      id: "acc-owner",
+      login: "hon454",
+      avatarUrl: null,
+      token: "ghu_owner",
+      createdAt: 1,
+      installations: [],
+      installationsRefreshedAt: 1,
+      invalidated: false,
+      invalidatedReason: null,
+      refreshToken: null,
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
+    };
+    resolveAccountForRepoMock.mockResolvedValue(null);
+    listAccountsMock.mockResolvedValue([account]);
+
+    const rateLimitError = {
+      kind: "github-api" as const,
+      status: 429,
+      failures: [{ status: 429, endpoint: null, rateLimited: true }],
+    };
+    const notFoundError = {
+      kind: "github-api" as const,
+      status: 404,
+      failures: [{ status: 404, endpoint: null, rateLimited: false }],
+    };
+    runtimeSendMessageMock.mockImplementation(
+      (message: { type?: string; accountId?: string | null }) => {
+        if (message.type === "fetchPullReviewerMetadataBatch") {
+          return Promise.resolve({ ok: false, error: rateLimitError });
+        }
+        if (
+          message.type === "fetchPullReviewerSummary" &&
+          message.accountId == null
+        ) {
+          return Promise.resolve({ ok: false, error: rateLimitError });
+        }
+        if (
+          message.type === "fetchPullReviewerSummary" &&
+          message.accountId === "acc-owner"
+        ) {
+          return Promise.resolve({ ok: false, error: notFoundError });
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+
+    const onRowFailure = vi.fn();
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx(), { onRowFailure });
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(onRowFailure).toHaveBeenCalledWith({
+      owner: "hon454",
+      repo: "private-repo",
+      account,
+      error: expect.objectContaining({
+        envelope: notFoundError,
+      }),
+    });
+  });
+
   it("requests page-level pull metadata once and reuses it for matching row summaries", async () => {
     document.body.innerHTML = `
       <div class="js-issue-row" id="issue_42">

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -537,7 +537,6 @@ describe("bootReviewerListPage", () => {
         (message) => message.accountId,
       ),
     ).toEqual(["acc-owner", "acc-owner"]);
-    expect(listAccountsMock).toHaveBeenCalledTimes(1);
     expect(onRowFailure).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- Fixes private-repository reviewer loading when the stored GitHub App installation cache does not resolve a covering account but a connected account is available.
- Keeps the public no-token path first, then retries qualifying no-token failures with a connected fallback account.
- Refines fallback account selection for organization repositories and reuses a successful page fallback account to avoid repeated no-token failures per row.

## Why

Users could be signed in and still see the unauthenticated 60/hr rate-limit or sign-in banner on private repositories. The root cause was that a failed installation-cache match sent reviewer fetches with `accountId: null`, so GitHub treated the API request as unauthenticated even though the extension had a saved account.

The follow-up review found two remaining gaps: organization repositories with multiple connected accounts could still miss the one account installed on the repo owner, and private PR lists could repeat the same no-token failure for every row after fallback succeeded once.

## Changes

- Adds a fallback account resolver that prefers an active account whose login matches the repository owner.
- Falls back to the only active connected account installed on the repository owner when that match is unambiguous.
- Avoids fallback when multiple active accounts are installed on the same owner, so ambiguous multi-account org access does not guess incorrectly.
- Retries no-token metadata or summary failures once with the connected fallback account for auth/access/not-found/rate-limit responses.
- Caches the owner-level fallback account during the page session so later rows can use the authenticated path directly.
- Reports fallback failures as signed-in failures so the banner can point users toward GitHub App repository access instead of another sign-in loop.
- Adds regression coverage for fallback retry, signed-in fallback failure classification, owner-installation fallback selection, ambiguous owner-installation handling, and page-level fallback reuse.
- Updates README and implementation notes for the private-repository access behavior.

## Impact

- User-facing impact: signed-in private repository pages can recover from stale or missing installation-cache matches instead of staying on the unauthenticated path.
- API/schema impact: None.
- Performance impact: failed no-token metadata or summary fetches may issue one authenticated retry; after fallback succeeds for an owner, later visible rows reuse that account instead of repeating no-token failures.
- Operational or rollout impact: None.

## Testing

- [x] GitHub CI `lint-and-test`
- [x] GitHub CI `e2e`
- [x] Local typecheck: `pnpm typecheck`
- [x] Local lint: `pnpm lint`
- [x] Local formatting: `pnpm exec prettier --check docs/implementation-notes.md src/features/reviewers/account-resolution.ts src/features/reviewers/index.ts tests/account-resolution.test.ts tests/reviewers.test.ts`
- [x] Local whitespace: `git diff --check`
- [ ] Local targeted Vitest: `pnpm test tests/account-resolution.test.ts` and `pnpm test tests/reviewers.test.ts` were attempted locally, but Vitest did not start on this macOS environment because Rollup native optional dependency loading (`@rollup/rollup-darwin-arm64`) failed with a code-signature Team ID mismatch. The same test suite passed in GitHub CI via `lint-and-test`.

## Breaking Changes

- None

## Related Issues

No issue: user-reported private repository sign-in loop.