### PR TITLE
chore(release): prepare v1.8.1

### DIFF
--- a/docs/chrome-web-store-submission.md
+++ b/docs/chrome-web-store-submission.md
@@ -121,5 +121,5 @@ link and the privacy fields aligned with the shipped behavior.
 Expected package path after `pnpm zip`:
 
 ```text
-.output/github-pulls-show-reviewers-1.8.0-chrome.zip
+.output/github-pulls-show-reviewers-1.8.1-chrome.zip
 ```

--- a/docs/releases/v1.8.1.md
+++ b/docs/releases/v1.8.1.md
@@ -1,0 +1,50 @@
+## v1.8.1
+
+Patch release for **GitHub Pulls Show Reviewers** focused on private-repository
+reviewer loading. This release keeps the product scope unchanged: requested
+reviewers, requested teams, and completed review state remain the only
+pull-list metadata surfaced by the extension.
+
+### Highlights
+
+- Signed-in private repository pages can now recover when the saved GitHub App
+  installation cache does not identify the account that should cover the
+  repository.
+- Reviewer fetches still try the public no-token path first when appropriate,
+  then retry qualifying auth, access, not-found, or rate-limit failures with a
+  connected fallback account.
+- Successful fallback account selection is reused during the page session, so
+  later visible pull request rows avoid repeating the same unauthenticated
+  failure.
+
+### Authentication
+
+- No permission, token-scope, storage-schema, or host-permission changes.
+- Public repositories still work without signing in when GitHub's
+  unauthenticated REST API allows it.
+- Private repositories continue to use the maintainer-owned GitHub App account
+  flow with `Pull requests: Read` access only.
+- Organization repositories now prefer a connected account whose login matches
+  the repository owner, or the only active connected account installed on that
+  owner when the choice is unambiguous.
+- Ambiguous multi-account organization access is left unresolved instead of
+  guessing the wrong account.
+
+### Quality & Packaging
+
+- Adds regression coverage for fallback retry behavior, signed-in fallback
+  failure classification, owner-installation fallback selection, ambiguous
+  owner-installation handling, and page-level fallback reuse.
+- GitHub CI passed `lint-and-test` and `e2e` for PR #105 before this release.
+- Release packaging behavior is unchanged: GitHub Actions still runs the
+  release preflight, `pnpm verify:release`, and Chrome zip creation before
+  attaching the package to the GitHub Release.
+
+### Scope Notes
+
+- Reviewer visibility on GitHub pull request list pages remains the only
+  product goal.
+- Checks, mergeability, labels, assignees, and general PR dashboard features
+  remain out of scope.
+
+**Full Changelog**: https://github.com/hon454/github-pulls-show-reviewers/compare/v1.8.0...v1.8.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-pulls-show-reviewers",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": true,
   "type": "module",
   "description": "Chrome extension focused on showing reviewers directly in GitHub pull request lists.",


### PR DESCRIPTION
## Summary

- Bump the extension package version to 1.8.1.
- Add v1.8.1 release notes centered on PR #105 private repository reviewer fallback behavior.
- Update the Chrome Web Store expected package path for the 1.8.1 zip.

## Why

PR #105 fixed signed-in private repository reviewer loading when installation-cache matching fails but a connected GitHub App account is available. A patch release is needed so that fix can be packaged and published.

## Changes

- Updates `package.json` from 1.8.0 to 1.8.1.
- Adds `docs/releases/v1.8.1.md` with release notes, auth notes, quality notes, scope notes, and the full changelog compare link.
- Updates `docs/chrome-web-store-submission.md` to expect `.output/github-pulls-show-reviewers-1.8.1-chrome.zip`.

## Impact

- User-facing impact: prepares a patch release for the private repository reviewer fallback fix from PR #105.
- API/schema impact: None.
- Performance impact: None beyond PR #105 behavior already merged.
- Operational or rollout impact: release workflow will package v1.8.1 after the tag is pushed.

## Testing

- [x] `pnpm exec prettier --check package.json docs/chrome-web-store-submission.md docs/releases/v1.8.1.md`
- [x] `pnpm lint`
- [x] `git diff --check`
- [ ] `pnpm install --frozen-lockfile` completed dependency linking but failed during `wxt prepare` because the local macOS environment rejected the Rolldown native binding with a Team ID code-signature mismatch.
- [ ] `pnpm typecheck` could not complete because `.wxt/tsconfig.json` was not generated after the local `wxt prepare` failure.
- [ ] Vitest could not start locally because the Rollup native optional dependency failed with the same local macOS code-signature mismatch class.

## Breaking Changes

- None

## Related Issues

No issue: release packaging for PR #105.