### PR TITLE
feat(reviewers): improve metadata batching resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 - Shows requested team reviewers on GitHub pull request list rows.
 - Shows each reviewer's latest completed review state: `approved`, `changes requested`, `commented`, or `dismissed`.
 - Links reviewer chips to GitHub PR searches.
+- Reuses page-level reviewer metadata across visible rows, including searched
+  or paginated pull request lists when GitHub's REST pagination exposes those
+  rows.
 - Keeps working as GitHub updates the page during normal navigation.
 
 ## Why Use It

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -24,20 +24,25 @@
 3. Extract the pull request number from the row id or primary pull request link.
 4. Resolve the covering account for `owner/repo` via `resolveAccountForRepo`.
 5. Send one `fetchPullReviewerMetadataBatch` message per page/account when the
-   page-level metadata cache is cold or stale. The background reads the first
-   REST pull-list page with the matched account token (or no token if none
-   matches), returning requested user reviewers, requested teams, and author
-   logins that can be reused across visible rows. Page metadata has a shorter
-   freshness window than row summaries because re-review requests primarily
-   change `requested_reviewers` / `requested_teams`.
+   page-level metadata cache is cold or stale. The content script includes the
+   visible pull numbers in that message. The background reads the first REST
+   pull-list page with the matched account token (or no token if none matches)
+   and follows `Link: rel="next"` until those visible numbers are covered or
+   pagination ends, returning requested user reviewers, requested teams, and
+   author logins that can be reused across visible rows. Page metadata has a
+   shorter freshness window than row summaries because re-review requests
+   primarily change `requested_reviewers` / `requested_teams`.
 6. Send a `fetchPullReviewerSummary` message for each uncached or stale row.
    Fresh cache hits render without refetching. Stale cache hits render the
    cached chips immediately, then revalidate in the background and rerender only
    the affected row when fresh data arrives. When the page-level metadata
    contains that pull request number, the background skips the per-row pull
    endpoint and reads only the reviews endpoint. If the pull number is absent
-   from the batch result, the summary request falls back to the original per-row
-   `pull + reviews` REST path.
+   from a successful batch result, the summary request falls back to the
+   original per-row `pull + reviews` REST path. If the page-level metadata batch
+   finally fails with an authentication, access, not-found, or rate-limit
+   failure after eligible fallback-account retry, same-page row fallback is
+   suppressed and the existing page banner receives that failure once.
    If no covering account is found, the first attempt still uses the no-token
    path so public repositories keep working without authentication. When that
    no-token metadata or summary fetch fails with an authentication, access,
@@ -72,10 +77,11 @@
 ## Current limitations
 
 - The extension still depends on GitHub metadata DOM structure.
-- Cold rows on a typical first PR-list page use one pull-list metadata request
-  plus one reviews request per uncached row. Filtered, searched, or older pages
-  can still fall back to one pull request plus one reviews request for rows that
-  are not present in the first REST pull-list page.
+- Cold rows use one pull-list metadata request, additional pull-list pages only
+  when visible pull numbers are not covered by the first REST page, and one
+  reviews request per uncached row. Very old filtered or searched pages can
+  still fall back to one pull request plus one reviews request for visible rows
+  if pagination ends before matching metadata is found.
 - Public-repository no-token access still depends on GitHub's unauthenticated REST availability and rate limits.
 - PAT-era single-token settings are not migrated; users must sign in again with
   the GitHub App account flow.
@@ -113,9 +119,11 @@
 ## Request volume decision
 
 - ADR: [0001 - Keep No-Token Support For Public Repositories](./adr/0001-keep-no-token-support-for-public-repositories.md)
-- The current implementation keeps the REST-only public path and uses
+- The current implementation keeps the REST-only public path and starts with
   `GET /repos/{owner}/{repo}/pulls?per_page=100&state=all` as a page-level
-  metadata hint before row summaries.
+  metadata hint before row summaries. For searched, filtered, and paginated
+  GitHub list pages, the content script sends visible pull numbers so the
+  background can follow REST pagination until those numbers are covered.
 - The content script de-duplicates in-flight row fetches, caches each pull
   request summary for the active page session with freshness metadata, and
   caches the page-level metadata result per `owner/repo/account` with a shorter
@@ -125,7 +133,7 @@
   non-`COMMENTED` review keep the lower-volume pull metadata plus reviews path.
 - A GraphQL-first rewrite is not the next step because it would push the product away from the current no-token public-repository path and add a second transport model to maintain.
 - If request volume remains the next bottleneck, the preferred follow-up is to
-  make the REST batch smarter for filtered and paginated GitHub list pages
+  bound or tune the REST pagination strategy with fixture-backed evidence
   before considering a broader API migration.
 
 ## Access banner classification
@@ -173,8 +181,6 @@ snapshot is in-memory only — it is never persisted.
 
 ## Next implementation targets
 
-- Extend the REST metadata batch to better cover searched, filtered, and older
-  paginated GitHub PR list pages.
 - Add more fixture-backed extension boot coverage for GitHub DOM variants.
 
 ## End-to-end banner coverage

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -27,11 +27,13 @@
    page-level metadata cache is cold or stale. The content script includes the
    visible pull numbers in that message. The background reads the first REST
    pull-list page with the matched account token (or no token if none matches)
-   and follows `Link: rel="next"` until those visible numbers are covered or
-   pagination ends, returning requested user reviewers, requested teams, and
-   author logins that can be reused across visible rows. Page metadata has a
-   shorter freshness window than row summaries because re-review requests
-   primarily change `requested_reviewers` / `requested_teams`.
+   and follows validated `Link: rel="next"` pagination for up to three REST
+   pages total, stopping earlier when those visible numbers are covered or
+   pagination ends. The response returns requested user reviewers, requested
+   teams, and author logins that can be reused across visible rows. Page
+   metadata has a shorter freshness window than row summaries because
+   re-review requests primarily change `requested_reviewers` /
+   `requested_teams`.
 6. Send a `fetchPullReviewerSummary` message for each uncached or stale row.
    Fresh cache hits render without refetching. Stale cache hits render the
    cached chips immediately, then revalidate in the background and rerender only
@@ -123,18 +125,19 @@
   `GET /repos/{owner}/{repo}/pulls?per_page=100&state=all` as a page-level
   metadata hint before row summaries. For searched, filtered, and paginated
   GitHub list pages, the content script sends visible pull numbers so the
-  background can follow REST pagination until those numbers are covered.
+  background can follow REST pagination until those numbers are covered, bounded
+  to three REST pages total.
 - The content script de-duplicates in-flight row fetches, caches each pull
   request summary for the active page session with freshness metadata, and
-  caches the page-level metadata result per `owner/repo/account` with a shorter
-  freshness window.
+  caches the page-level metadata result per `owner/repo/account` and visible
+  pull-number set with a shorter freshness window.
 - Issue-event requests are targeted to ambiguous requested+completed reviewer
   overlaps only. Rows whose requested users do not overlap a latest
   non-`COMMENTED` review keep the lower-volume pull metadata plus reviews path.
 - A GraphQL-first rewrite is not the next step because it would push the product away from the current no-token public-repository path and add a second transport model to maintain.
 - If request volume remains the next bottleneck, the preferred follow-up is to
-  bound or tune the REST pagination strategy with fixture-backed evidence
-  before considering a broader API migration.
+  tune the three-page REST pagination bound with fixture-backed evidence before
+  considering a broader API migration.
 
 ## Access banner classification
 

--- a/src/background/reviewer-fetch.ts
+++ b/src/background/reviewer-fetch.ts
@@ -149,6 +149,9 @@ export function createReviewerFetchService(input: {
             repo: message.repo,
             githubToken: token,
             signal: controller.signal,
+            ...(message.targetPullNumbers == null
+              ? {}
+              : { targetPullNumbers: message.targetPullNumbers }),
           });
 
         try {

--- a/src/features/reviewers/dom.ts
+++ b/src/features/reviewers/dom.ts
@@ -189,10 +189,10 @@ export function extractPullNumber(row: Element): string | null {
 }
 
 export function ensureReviewerMount(row: Element): HTMLElement | null {
-  const metaContainer = findFirst<HTMLElement>(row, githubSelectors.metaContainers);
-  if (metaContainer == null) {
-    return null;
-  }
+  const metaContainer =
+    findFirst<HTMLElement>(row, githubSelectors.metaContainers) ??
+    createFallbackMetaContainer(row);
+  if (metaContainer == null) return null;
 
   let inlineMetaRow = findFirst<HTMLElement>(
     metaContainer,
@@ -213,6 +213,17 @@ export function ensureReviewerMount(row: Element): HTMLElement | null {
   }
 
   return mount;
+}
+
+function createFallbackMetaContainer(row: Element): HTMLElement | null {
+  const link = row.querySelector<HTMLAnchorElement>(githubSelectors.primaryLink);
+  if (link == null) return null;
+
+  const container = document.createElement("span");
+  container.className = "d-none d-md-inline-flex";
+  container.setAttribute("data-ghpsr-fallback-meta", "true");
+  link.insertAdjacentElement("afterend", container);
+  return container;
 }
 
 export function renderLoading(mount: HTMLElement): void {

--- a/src/features/reviewers/dom.ts
+++ b/src/features/reviewers/dom.ts
@@ -191,6 +191,7 @@ export function extractPullNumber(row: Element): string | null {
 export function ensureReviewerMount(row: Element): HTMLElement | null {
   const metaContainer =
     findFirst<HTMLElement>(row, githubSelectors.metaContainers) ??
+    row.querySelector<HTMLElement>(githubSelectors.fallbackMetaContainer) ??
     createFallbackMetaContainer(row);
   if (metaContainer == null) return null;
 

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -71,6 +71,7 @@ export function bootReviewerListPage(
     repo: string;
     accountId: string | null;
     targetPullNumbersKey: string;
+    sequence: number;
     promise: Promise<PageMetadataResult>;
     controller: AbortController;
   };
@@ -88,9 +89,11 @@ export function bootReviewerListPage(
     owner: string;
     repo: string;
     accountId: string | null;
+    targetPullNumbers: string[];
     targetPullNumbersKey: string;
     metadata: Map<string, PullReviewerMetadata>;
     fetchedAt: number;
+    sequence: number;
     stale: boolean;
     failure: PageMetadataFailure | null;
   };
@@ -106,6 +109,7 @@ export function bootReviewerListPage(
   const rowFingerprints = new Map<string, string>();
   let pageMetadataRequest: PageMetadataRequest | null = null;
   let pageMetadataCache: PageMetadataCache | null = null;
+  let pageMetadataSequence = 0;
   let fallbackAccountCache: FallbackAccountCache | null = null;
   let fallbackAccountRequest: FallbackAccountRequest | null = null;
   let cachedPreferences: Promise<Preferences> | null = null;
@@ -186,6 +190,79 @@ export function bootReviewerListPage(
     });
   }
 
+  function pageMetadataCacheIsFresh(cache: PageMetadataCache): boolean {
+    return (
+      !cache.stale &&
+      Date.now() - cache.fetchedAt <= PAGE_METADATA_FRESH_MS
+    );
+  }
+
+  function readExactPageMetadataCache(args: {
+    route: NonNullable<typeof currentRoute>;
+    accountId: string | null;
+    targetPullNumbersKey: string;
+  }): PageMetadataCache | null {
+    const { route, accountId, targetPullNumbersKey } = args;
+    if (
+      pageMetadataCache == null ||
+      pageMetadataCache.owner !== route.owner ||
+      pageMetadataCache.repo !== route.repo ||
+      pageMetadataCache.accountId !== accountId ||
+      pageMetadataCache.targetPullNumbersKey !== targetPullNumbersKey ||
+      !pageMetadataCacheIsFresh(pageMetadataCache)
+    ) {
+      return null;
+    }
+    return pageMetadataCache;
+  }
+
+  function readCoveringPageMetadataCache(args: {
+    route: NonNullable<typeof currentRoute>;
+    accountId: string | null;
+    targetPullNumbers: string[];
+  }): PageMetadataCache | null {
+    const { route, accountId, targetPullNumbers } = args;
+    if (
+      pageMetadataCache == null ||
+      pageMetadataCache.owner !== route.owner ||
+      pageMetadataCache.repo !== route.repo ||
+      pageMetadataCache.accountId !== accountId ||
+      pageMetadataCache.failure != null ||
+      !pageMetadataCacheIsFresh(pageMetadataCache)
+    ) {
+      return null;
+    }
+
+    const cache = pageMetadataCache;
+    return targetPullNumbers.every((pullNumber) =>
+      cache.metadata.has(pullNumber),
+    )
+      ? cache
+      : null;
+  }
+
+  function pageMetadataResultFromCache(
+    cache: PageMetadataCache,
+  ): PageMetadataResult {
+    return {
+      metadata: cache.metadata,
+      failure: cache.failure,
+    };
+  }
+
+  function writePageMetadataCache(
+    nextCache: PageMetadataCache,
+  ): PageMetadataCache {
+    if (
+      pageMetadataCache != null &&
+      pageMetadataCache.sequence > nextCache.sequence
+    ) {
+      return pageMetadataCache;
+    }
+    pageMetadataCache = nextCache;
+    return pageMetadataCache;
+  }
+
   async function getPageMetadata(
     route: NonNullable<typeof currentRoute>,
     account: Account | null,
@@ -197,19 +274,13 @@ export function bootReviewerListPage(
     const accountId = requestAccount?.id ?? null;
     const targetPullNumbers = collectVisiblePullNumbers();
     const targetPullNumbersKey = targetPullNumbers.join(",");
-    if (
-      pageMetadataCache != null &&
-      pageMetadataCache.owner === route.owner &&
-      pageMetadataCache.repo === route.repo &&
-      pageMetadataCache.accountId === accountId &&
-      pageMetadataCache.targetPullNumbersKey === targetPullNumbersKey &&
-      !pageMetadataCache.stale &&
-      Date.now() - pageMetadataCache.fetchedAt <= PAGE_METADATA_FRESH_MS
-    ) {
-      return {
-        metadata: pageMetadataCache.metadata,
-        failure: pageMetadataCache.failure,
-      };
+    const cachedPageMetadata = readExactPageMetadataCache({
+      route,
+      accountId,
+      targetPullNumbersKey,
+    });
+    if (cachedPageMetadata != null) {
+      return pageMetadataResultFromCache(cachedPageMetadata);
     }
 
     if (
@@ -231,11 +302,14 @@ export function bootReviewerListPage(
       { once: true },
     );
 
+    const requestSequence = pageMetadataSequence + 1;
+    pageMetadataSequence = requestSequence;
     const request: PageMetadataRequest = {
       owner: route.owner,
       repo: route.repo,
       accountId,
       targetPullNumbersKey,
+      sequence: requestSequence,
       controller,
       promise: fetchPageMetadata({
         account: requestAccount,
@@ -248,17 +322,19 @@ export function bootReviewerListPage(
           const metadataByNumber = new Map(
             metadata.map((pullMetadata) => [pullMetadata.number, pullMetadata]),
           );
-          pageMetadataCache = {
+          const cache = writePageMetadataCache({
             owner: route.owner,
             repo: route.repo,
             accountId,
+            targetPullNumbers,
             targetPullNumbersKey,
             metadata: metadataByNumber,
             fetchedAt: Date.now(),
+            sequence: request.sequence,
             stale: false,
             failure: null,
-          };
-          return { metadata: metadataByNumber, failure: null };
+          });
+          return pageMetadataResultFromCache(cache);
         })
         .catch(async (error) => {
           if (!isAbortError(error) && !controller.signal.aborted) {
@@ -267,6 +343,9 @@ export function bootReviewerListPage(
             if (account == null && shouldRetryWithFallbackAccount(error)) {
               const fallbackAccount = await getFallbackAccount(route.owner);
               if (fallbackAccount != null && !controller.signal.aborted) {
+                if (pageMetadataRequest === request) {
+                  request.accountId = fallbackAccount.id;
+                }
                 try {
                   const metadata = await fetchPageMetadata({
                     account: fallbackAccount,
@@ -281,17 +360,19 @@ export function bootReviewerListPage(
                       pullMetadata,
                     ]),
                   );
-                  pageMetadataCache = {
+                  const cache = writePageMetadataCache({
                     owner: route.owner,
                     repo: route.repo,
                     accountId: fallbackAccount.id,
+                    targetPullNumbers,
                     targetPullNumbersKey,
                     metadata: metadataByNumber,
                     fetchedAt: Date.now(),
+                    sequence: request.sequence,
                     stale: false,
                     failure: null,
-                  };
-                  return { metadata: metadataByNumber, failure: null };
+                  });
+                  return pageMetadataResultFromCache(cache);
                 } catch (fallbackError) {
                   if (controller.signal.aborted) {
                     return {
@@ -304,6 +385,17 @@ export function bootReviewerListPage(
                 }
               }
             }
+            const coveringCache = readCoveringPageMetadataCache({
+              route,
+              accountId: failureAccount?.id ?? accountId,
+              targetPullNumbers,
+            });
+            if (
+              coveringCache != null &&
+              coveringCache.sequence > request.sequence
+            ) {
+              return pageMetadataResultFromCache(coveringCache);
+            }
             const failure = shouldSuppressRowFallbackAfterPageMetadataFailure(
               failureError,
             )
@@ -314,19 +406,21 @@ export function bootReviewerListPage(
                   suppressRowFallback: true,
                 }
               : null;
-            pageMetadataCache = {
+            const cache = writePageMetadataCache({
               owner: route.owner,
               repo: route.repo,
               accountId: failureAccount?.id ?? accountId,
+              targetPullNumbers,
               targetPullNumbersKey,
               metadata: new Map(),
               fetchedAt: Date.now(),
+              sequence: request.sequence,
               stale: false,
               failure,
-            };
+            });
             return {
-              metadata: pageMetadataCache.metadata,
-              failure,
+              metadata: cache.metadata,
+              failure: cache.failure,
             };
           }
           return {

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -70,16 +70,29 @@ export function bootReviewerListPage(
     owner: string;
     repo: string;
     accountId: string | null;
-    promise: Promise<Map<string, PullReviewerMetadata>>;
+    targetPullNumbersKey: string;
+    promise: Promise<PageMetadataResult>;
     controller: AbortController;
+  };
+  type PageMetadataFailure = {
+    account: Account | null;
+    error: unknown;
+    reported: boolean;
+    suppressRowFallback: boolean;
+  };
+  type PageMetadataResult = {
+    metadata: Map<string, PullReviewerMetadata>;
+    failure: PageMetadataFailure | null;
   };
   type PageMetadataCache = {
     owner: string;
     repo: string;
     accountId: string | null;
+    targetPullNumbersKey: string;
     metadata: Map<string, PullReviewerMetadata>;
     fetchedAt: number;
     stale: boolean;
+    failure: PageMetadataFailure | null;
   };
   type FallbackAccountCache = {
     owner: string;
@@ -177,27 +190,34 @@ export function bootReviewerListPage(
     route: NonNullable<typeof currentRoute>,
     account: Account | null,
     signal: AbortSignal,
-  ): Promise<Map<string, PullReviewerMetadata>> {
+  ): Promise<PageMetadataResult> {
     const cachedFallbackAccount =
       account == null ? readCachedFallbackAccount(route.owner) : undefined;
     const requestAccount = cachedFallbackAccount ?? account;
     const accountId = requestAccount?.id ?? null;
+    const targetPullNumbers = collectVisiblePullNumbers();
+    const targetPullNumbersKey = targetPullNumbers.join(",");
     if (
       pageMetadataCache != null &&
       pageMetadataCache.owner === route.owner &&
       pageMetadataCache.repo === route.repo &&
       pageMetadataCache.accountId === accountId &&
+      pageMetadataCache.targetPullNumbersKey === targetPullNumbersKey &&
       !pageMetadataCache.stale &&
       Date.now() - pageMetadataCache.fetchedAt <= PAGE_METADATA_FRESH_MS
     ) {
-      return pageMetadataCache.metadata;
+      return {
+        metadata: pageMetadataCache.metadata,
+        failure: pageMetadataCache.failure,
+      };
     }
 
     if (
       pageMetadataRequest != null &&
       pageMetadataRequest.owner === route.owner &&
       pageMetadataRequest.repo === route.repo &&
-      pageMetadataRequest.accountId === accountId
+      pageMetadataRequest.accountId === accountId &&
+      pageMetadataRequest.targetPullNumbersKey === targetPullNumbersKey
     ) {
       return pageMetadataRequest.promise;
     }
@@ -215,11 +235,13 @@ export function bootReviewerListPage(
       owner: route.owner,
       repo: route.repo,
       accountId,
+      targetPullNumbersKey,
       controller,
       promise: fetchPageMetadata({
         account: requestAccount,
         owner: route.owner,
         repo: route.repo,
+        targetPullNumbers,
         signal: controller.signal,
       })
         .then((metadata) => {
@@ -230,14 +252,18 @@ export function bootReviewerListPage(
             owner: route.owner,
             repo: route.repo,
             accountId,
+            targetPullNumbersKey,
             metadata: metadataByNumber,
             fetchedAt: Date.now(),
             stale: false,
+            failure: null,
           };
-          return metadataByNumber;
+          return { metadata: metadataByNumber, failure: null };
         })
         .catch(async (error) => {
           if (!isAbortError(error) && !controller.signal.aborted) {
+            let failureAccount = requestAccount;
+            let failureError = error;
             if (account == null && shouldRetryWithFallbackAccount(error)) {
               const fallbackAccount = await getFallbackAccount(route.owner);
               if (fallbackAccount != null && !controller.signal.aborted) {
@@ -247,6 +273,7 @@ export function bootReviewerListPage(
                     owner: route.owner,
                     repo: route.repo,
                     signal: controller.signal,
+                    targetPullNumbers,
                   });
                   const metadataByNumber = new Map(
                     metadata.map((pullMetadata) => [
@@ -258,28 +285,54 @@ export function bootReviewerListPage(
                     owner: route.owner,
                     repo: route.repo,
                     accountId: fallbackAccount.id,
+                    targetPullNumbersKey,
                     metadata: metadataByNumber,
                     fetchedAt: Date.now(),
                     stale: false,
+                    failure: null,
                   };
-                  return metadataByNumber;
-                } catch {
+                  return { metadata: metadataByNumber, failure: null };
+                } catch (fallbackError) {
                   if (controller.signal.aborted) {
-                    return new Map<string, PullReviewerMetadata>();
+                    return {
+                      metadata: new Map<string, PullReviewerMetadata>(),
+                      failure: null,
+                    };
                   }
+                  failureAccount = fallbackAccount;
+                  failureError = fallbackError;
                 }
               }
             }
+            const failure = shouldSuppressRowFallbackAfterPageMetadataFailure(
+              failureError,
+            )
+              ? {
+                  account: failureAccount,
+                  error: failureError,
+                  reported: false,
+                  suppressRowFallback: true,
+                }
+              : null;
             pageMetadataCache = {
               owner: route.owner,
               repo: route.repo,
-              accountId,
+              accountId: failureAccount?.id ?? accountId,
+              targetPullNumbersKey,
               metadata: new Map(),
               fetchedAt: Date.now(),
               stale: false,
+              failure,
+            };
+            return {
+              metadata: pageMetadataCache.metadata,
+              failure,
             };
           }
-          return new Map<string, PullReviewerMetadata>();
+          return {
+            metadata: new Map<string, PullReviewerMetadata>(),
+            failure: null,
+          };
         })
         .finally(() => {
           if (pageMetadataRequest === request) {
@@ -289,6 +342,22 @@ export function bootReviewerListPage(
     };
     pageMetadataRequest = request;
     return request.promise;
+  }
+
+  function reportPageMetadataFailure(
+    route: NonNullable<typeof currentRoute>,
+    failure: PageMetadataFailure,
+  ): void {
+    if (failure.reported) {
+      return;
+    }
+    failure.reported = true;
+    options?.onRowFailure?.({
+      owner: route.owner,
+      repo: route.repo,
+      account: failure.account,
+      error: failure.error,
+    });
   }
 
   async function processRow(row: Element): Promise<void> {
@@ -347,9 +416,19 @@ export function bootReviewerListPage(
         route.owner,
         route.repo,
       );
-      const pullMetadata = (
-        await getPageMetadata(route, account, controller.signal)
-      ).get(pullNumber);
+      const pageMetadata = await getPageMetadata(
+        route,
+        account,
+        controller.signal,
+      );
+      if (pageMetadata.failure?.suppressRowFallback) {
+        reportPageMetadataFailure(route, pageMetadata.failure);
+        mount.replaceChildren();
+        mount.removeAttribute("title");
+        clearRenderedReviewerState(mount);
+        return;
+      }
+      const pullMetadata = pageMetadata.metadata.get(pullNumber);
       const cachedFallbackAccount =
         account == null ? readCachedFallbackAccount(route.owner) : undefined;
       const summaryAccount = cachedFallbackAccount ?? account;
@@ -597,6 +676,20 @@ function readRowMetadataText(metaContainer: Element | null): string {
   return (clone.textContent ?? "").replace(/\s+/g, " ").trim();
 }
 
+function collectVisiblePullNumbers(): string[] {
+  const pullNumbers: string[] = [];
+  const seen = new Set<string>();
+  document.querySelectorAll(githubSelectors.row).forEach((row) => {
+    const pullNumber = extractPullNumber(row);
+    if (pullNumber == null || seen.has(pullNumber)) {
+      return;
+    }
+    seen.add(pullNumber);
+    pullNumbers.push(pullNumber);
+  });
+  return pullNumbers;
+}
+
 async function fetchWithRefresh(args: {
   account: Account | null;
   owner: string;
@@ -657,9 +750,10 @@ async function fetchPageMetadata(args: {
   account: Account | null;
   owner: string;
   repo: string;
+  targetPullNumbers: string[];
   signal: AbortSignal;
 }): Promise<PullReviewerMetadata[]> {
-  const { account, owner, repo, signal } = args;
+  const { account, owner, repo, signal, targetPullNumbers } = args;
 
   if (signal.aborted) {
     throw createAbortError();
@@ -672,6 +766,7 @@ async function fetchPageMetadata(args: {
     owner,
     repo,
     accountId: account?.id ?? null,
+    targetPullNumbers,
   }) as Promise<FetchPullReviewerMetadataBatchResponse | undefined>;
 
   const abortListenerController = new AbortController();
@@ -729,6 +824,12 @@ function shouldRetryWithFallbackAccount(error: unknown): boolean {
       failure.status === 401 || failure.status === 403 || failure.status === 404
     );
   });
+}
+
+function shouldSuppressRowFallbackAfterPageMetadataFailure(
+  error: unknown,
+): boolean {
+  return shouldRetryWithFallbackAccount(error);
 }
 
 function unwrapReviewerFetchResponse(

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -388,6 +388,7 @@ export async function fetchPullReviewerMetadataBatch(input: {
   owner: string;
   repo: string;
   githubToken: string | null;
+  targetPullNumbers?: string[];
   signal?: AbortSignal;
 }): Promise<PullReviewerMetadata[]> {
   const headers = createGitHubHeaders(input.githubToken);
@@ -402,12 +403,15 @@ export async function fetchPullReviewerMetadataBatch(input: {
     throw failure;
   }
 
-  const parsed = pullReviewerMetadataListSchema.safeParse(await response.json());
-  if (!parsed.success) {
-    throw new GitHubApiSchemaError(endpoint, parsed.error.issues);
-  }
+  const pulls = await collectPullMetadataAcrossPages({
+    firstResponse: response,
+    endpoint,
+    headers,
+    targetPullNumbers: input.targetPullNumbers ?? [],
+    ...(input.signal == null ? {} : { signal: input.signal }),
+  });
 
-  return parsed.data.map((pull) => toPullReviewerMetadata(String(pull.number), pull));
+  return pulls.map((pull) => toPullReviewerMetadata(String(pull.number), pull));
 }
 
 function buildPullReviewerSummary(
@@ -898,6 +902,63 @@ async function collectReviewRequestEventsAcrossPages(params: {
       throw new GitHubPullRequestEndpointsError([error]);
     }
   }
+}
+
+async function collectPullMetadataAcrossPages(params: {
+  firstResponse: Response;
+  endpoint: GitHubEndpointDescriptor;
+  headers: Headers;
+  targetPullNumbers: string[];
+  signal?: AbortSignal;
+}): Promise<z.infer<typeof pullReviewerMetadataListSchema>> {
+  const collected: z.infer<typeof pullReviewerMetadataListSchema> = [];
+  const targets = new Set(params.targetPullNumbers);
+
+  let response = params.firstResponse;
+  while (true) {
+    const parsed = pullReviewerMetadataListSchema.safeParse(
+      await response.json(),
+    );
+    if (!parsed.success) {
+      throw new GitHubApiSchemaError(params.endpoint, parsed.error.issues);
+    }
+    collected.push(...parsed.data);
+
+    if (targets.size === 0 || hasAllTargetPulls(collected, targets)) {
+      return collected;
+    }
+
+    const nextUrl = parseNextPageUrl(response.headers.get("Link"));
+    if (nextUrl == null) {
+      return collected;
+    }
+
+    response = await fetch(
+      nextUrl,
+      withOptionalSignal({ headers: params.headers }, params.signal),
+    );
+
+    const error = await createGitHubApiErrorFromResponse(
+      response,
+      params.endpoint,
+    );
+    if (error != null) {
+      throw error;
+    }
+  }
+}
+
+function hasAllTargetPulls(
+  pulls: z.infer<typeof pullReviewerMetadataListSchema>,
+  targets: Set<string>,
+): boolean {
+  const pullNumbers = new Set(pulls.map((pull) => String(pull.number)));
+  for (const target of targets) {
+    if (!pullNumbers.has(target)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function parseNextPageUrl(linkHeader: string | null): string | null {

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -38,6 +38,7 @@ const pullReviewerMetadataSchema = pullSchema.extend({
 });
 
 const pullReviewerMetadataListSchema = z.array(pullReviewerMetadataSchema);
+const MAX_PULL_METADATA_BATCH_PAGES = 3;
 
 const pullListSchema = z.array(
   z.object({
@@ -913,8 +914,10 @@ async function collectPullMetadataAcrossPages(params: {
 }): Promise<z.infer<typeof pullReviewerMetadataListSchema>> {
   const collected: z.infer<typeof pullReviewerMetadataListSchema> = [];
   const targets = new Set(params.targetPullNumbers);
+  const expectedPathname = params.endpoint.path.split("?")[0];
 
   let response = params.firstResponse;
+  let pageCount = 0;
   while (true) {
     const parsed = pullReviewerMetadataListSchema.safeParse(
       await response.json(),
@@ -923,12 +926,20 @@ async function collectPullMetadataAcrossPages(params: {
       throw new GitHubApiSchemaError(params.endpoint, parsed.error.issues);
     }
     collected.push(...parsed.data);
+    pageCount += 1;
 
-    if (targets.size === 0 || hasAllTargetPulls(collected, targets)) {
+    if (
+      targets.size === 0 ||
+      hasAllTargetPulls(collected, targets) ||
+      pageCount >= MAX_PULL_METADATA_BATCH_PAGES
+    ) {
       return collected;
     }
 
-    const nextUrl = parseNextPageUrl(response.headers.get("Link"));
+    const nextUrl = parseNextPageUrl(
+      response.headers.get("Link"),
+      expectedPathname,
+    );
     if (nextUrl == null) {
       return collected;
     }
@@ -961,7 +972,10 @@ function hasAllTargetPulls(
   return true;
 }
 
-function parseNextPageUrl(linkHeader: string | null): string | null {
+function parseNextPageUrl(
+  linkHeader: string | null,
+  expectedPathname?: string,
+): string | null {
   if (linkHeader == null) {
     return null;
   }
@@ -973,11 +987,30 @@ function parseNextPageUrl(linkHeader: string | null): string | null {
     }
     const rels = match[2].split(/\s+/);
     if (rels.includes("next")) {
+      if (
+        expectedPathname != null &&
+        !isExpectedGitHubApiUrl(match[1], expectedPathname)
+      ) {
+        return null;
+      }
       return match[1];
     }
   }
 
   return null;
+}
+
+function isExpectedGitHubApiUrl(url: string, expectedPathname: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === "https:" &&
+      parsed.hostname === "api.github.com" &&
+      parsed.pathname === expectedPathname
+    );
+  } catch {
+    return false;
+  }
 }
 
 function normalizeReviewState(state: string): ReviewState | null {

--- a/src/github/selectors.ts
+++ b/src/github/selectors.ts
@@ -5,6 +5,7 @@ export const githubSelectors = {
     ".d-flex.mt-1.text-small.color-fg-muted",
     '[class*="ListItem-module__ListItemMetadataRow"]',
   ],
+  fallbackMetaContainer: "[data-ghpsr-fallback-meta]",
   inlineMetaRowSelectors: [".d-none.d-md-inline-flex"],
   volatileMetadataSelectors: ["relative-time", "time-ago", ".js-timeago"],
 } as const;

--- a/src/runtime/reviewer-fetch.ts
+++ b/src/runtime/reviewer-fetch.ts
@@ -55,6 +55,7 @@ export const fetchPullReviewerMetadataBatchMessageSchema = z.object({
   owner: nonEmptyStringSchema,
   repo: nonEmptyStringSchema,
   accountId: z.string().nullable(),
+  targetPullNumbers: z.array(nonEmptyStringSchema).optional(),
 });
 
 export type FetchPullReviewerMetadataBatchMessage = z.infer<

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1343,6 +1343,118 @@ describe("fetchPullReviewerMetadataBatch", () => {
       requestedTeams: ["platform"],
     });
   });
+
+  it("stops pull-list pagination after a bounded number of pages", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              number: 300,
+              user: { login: "hon454" },
+              requested_reviewers: [],
+              requested_teams: [],
+            },
+          ]),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              Link: '<https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls?per_page=100&state=all&page=2>; rel="next"',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              number: 250,
+              user: { login: "octocat" },
+              requested_reviewers: [],
+              requested_teams: [],
+            },
+          ]),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              Link: '<https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls?per_page=100&state=all&page=3>; rel="next"',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              number: 200,
+              user: { login: "alice" },
+              requested_reviewers: [],
+              requested_teams: [],
+            },
+          ]),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              Link: '<https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls?per_page=100&state=all&page=4>; rel="next"',
+            },
+          },
+        ),
+      );
+
+    const metadata = await fetchPullReviewerMetadataBatch({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      githubToken: null,
+      targetPullNumbers: ["150"],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(metadata.map((pull) => pull.number)).toEqual(["300", "250", "200"]);
+  });
+
+  it("does not follow pull-list pagination links outside the expected GitHub endpoint", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              number: 200,
+              user: { login: "hon454" },
+              requested_reviewers: [],
+              requested_teams: [],
+            },
+          ]),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              Link: '<https://example.test/repos/hon454/github-pulls-show-reviewers/pulls?per_page=100&state=all&page=2>; rel="next"',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const metadata = await fetchPullReviewerMetadataBatch({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      githubToken: "ghu_example",
+      targetPullNumbers: ["150"],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(metadata.map((pull) => pull.number)).toEqual(["200"]);
+  });
 });
 
 describe("validateGitHubRepositoryAccess", () => {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1288,6 +1288,61 @@ describe("fetchPullReviewerMetadataBatch", () => {
     expect(headers).toBeInstanceOf(Headers);
     expect((headers as Headers).get("Authorization")).toBeNull();
   });
+
+  it("follows pull-list pagination until visible target pull numbers are covered", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              number: 200,
+              user: { login: "hon454" },
+              requested_reviewers: [],
+              requested_teams: [],
+            },
+          ]),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              Link: '<https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls?per_page=100&state=all&page=2>; rel="next"',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              number: 150,
+              user: { login: "octocat" },
+              requested_reviewers: [{ login: "alice", avatar_url: null }],
+              requested_teams: [{ slug: "platform" }],
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const metadata = await fetchPullReviewerMetadataBatch({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      githubToken: null,
+      targetPullNumbers: ["150"],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls?per_page=100&state=all&page=2",
+    );
+    expect(metadata.find((pull) => pull.number === "150")).toEqual({
+      number: "150",
+      authorLogin: "octocat",
+      requestedUsers: [{ login: "alice", avatarUrl: null }],
+      requestedTeams: ["platform"],
+    });
+  });
 });
 
 describe("validateGitHubRepositoryAccess", () => {

--- a/tests/fixtures/github-pulls-title-only-metadata.html
+++ b/tests/fixtures/github-pulls-title-only-metadata.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>GitHub Pulls Fixture Title Only Metadata</title>
+  </head>
+  <body>
+    <div class="js-navigation-container js-active-navigation-container">
+      <div class="js-issue-row" id="issue_203">
+        <div class="ListItem-module__ListItemContent--Y7CtA">
+          <div class="ListItem-module__TitleArea--abc12">
+            <span class="ListItem-module__TitleWrapper--def34">
+              <a
+                class="Link--primary"
+                href="/hon454/github-pulls-show-reviewers/pull/203"
+              >
+                Metadata container omitted by GitHub list variant
+              </a>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/reviewer-dom.test.ts
+++ b/tests/reviewer-dom.test.ts
@@ -262,8 +262,11 @@ describe("renderReviewers", () => {
     await loadFixture("github-pulls-title-only-metadata.html");
     const row = document.querySelector(".js-issue-row");
     const mountNode = ensureReviewerMount(row!);
+    const repeatedMountNode = ensureReviewerMount(row!);
     expect(mountNode).not.toBeNull();
-    expect(row?.querySelector("[data-ghpsr-fallback-meta]")).not.toBeNull();
+    expect(repeatedMountNode).toBe(mountNode);
+    expect(row?.querySelectorAll("[data-ghpsr-fallback-meta]")).toHaveLength(1);
+    expect(row?.querySelectorAll("[data-ghpsr-root]")).toHaveLength(1);
     expect(extractPullNumber(row!)).toBe("203");
   });
 

--- a/tests/reviewer-dom.test.ts
+++ b/tests/reviewer-dom.test.ts
@@ -258,6 +258,15 @@ describe("renderReviewers", () => {
     expect(row?.querySelector(".d-none.d-md-inline-flex")).not.toBeNull();
   });
 
+  it("creates a deterministic fallback mount when GitHub omits the metadata container", async () => {
+    await loadFixture("github-pulls-title-only-metadata.html");
+    const row = document.querySelector(".js-issue-row");
+    const mountNode = ensureReviewerMount(row!);
+    expect(mountNode).not.toBeNull();
+    expect(row?.querySelector("[data-ghpsr-fallback-meta]")).not.toBeNull();
+    expect(extractPullNumber(row!)).toBe("203");
+  });
+
   it("declares :focus-visible styles for reviewer avatars, pills, and team chips", () => {
     ensureReviewerStyles();
     const styleEl = document.querySelector("[data-ghpsr-style]");

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -744,6 +744,134 @@ describe("bootReviewerListPage", () => {
     });
   });
 
+  it("does not let an older fallback metadata failure overwrite a newer success", async () => {
+    document.body.innerHTML = `
+      <div class="js-issue-row" id="issue_42">
+        <a class="Link--primary" href="/hon454/private-repo/pull/42">PR #42</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+    `;
+    window.history.replaceState({}, "", "/hon454/private-repo/pulls");
+
+    const account = {
+      id: "acc-owner",
+      login: "hon454",
+      avatarUrl: null,
+      token: "ghu_owner",
+      createdAt: 1,
+      installations: [],
+      installationsRefreshedAt: 1,
+      invalidated: false,
+      invalidatedReason: null,
+      refreshToken: null,
+      expiresAt: null,
+      refreshTokenExpiresAt: null,
+    };
+    resolveAccountForRepoMock.mockResolvedValue(null);
+    listAccountsMock.mockResolvedValue([account]);
+
+    const rateLimitError = {
+      kind: "github-api" as const,
+      status: 429,
+      failures: [{ status: 429, endpoint: null, rateLimited: true }],
+    };
+    const summary: PullReviewerSummary = {
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: [],
+      completedReviews: [],
+    };
+
+    let fallbackMetadataCalls = 0;
+    let resolveFirstFallbackMetadata:
+      | ((response: Record<string, unknown>) => void)
+      | null = null;
+    let resolveSecondFallbackMetadata:
+      | ((response: Record<string, unknown>) => void)
+      | null = null;
+
+    runtimeSendMessageMock.mockImplementation(
+      (message: { type?: string; accountId?: string | null }) => {
+        if (
+          message.type === "fetchPullReviewerMetadataBatch" &&
+          message.accountId == null
+        ) {
+          return Promise.resolve({ ok: false, error: rateLimitError });
+        }
+        if (
+          message.type === "fetchPullReviewerMetadataBatch" &&
+          message.accountId === "acc-owner"
+        ) {
+          fallbackMetadataCalls += 1;
+          if (fallbackMetadataCalls === 1) {
+            return new Promise<Record<string, unknown>>((resolve) => {
+              resolveFirstFallbackMetadata = resolve;
+            });
+          }
+          return new Promise<Record<string, unknown>>((resolve) => {
+            resolveSecondFallbackMetadata = resolve;
+          });
+        }
+        if (message.type === "fetchPullReviewerSummary") {
+          return Promise.resolve({ ok: true, summary });
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+
+    const onRowFailure = vi.fn();
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx(), { onRowFailure });
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+    expect(fallbackMetadataCalls).toBe(1);
+
+    document.body.insertAdjacentHTML(
+      "beforeend",
+      `
+        <div class="js-issue-row" id="issue_41">
+          <a class="Link--primary" href="/hon454/private-repo/pull/41">PR #41</a>
+          <div class="d-flex mt-1 text-small color-fg-muted"></div>
+        </div>
+      `,
+    );
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+    expect(fallbackMetadataCalls).toBe(2);
+
+    resolveSecondFallbackMetadata!({
+      ok: true,
+      metadata: [
+        {
+          number: "42",
+          authorLogin: "hon454",
+          requestedUsers: [],
+          requestedTeams: [],
+        },
+        {
+          number: "41",
+          authorLogin: "hon454",
+          requestedUsers: [],
+          requestedTeams: [],
+        },
+      ],
+    });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    resolveFirstFallbackMetadata!({ ok: false, error: rateLimitError });
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(onRowFailure).not.toHaveBeenCalled();
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(2);
+  });
+
   it("does not flash loading text on a cache-hit re-render", async () => {
     resolveAccountForRepoMock.mockResolvedValue(null);
     const summary: PullReviewerSummary = {

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -311,8 +311,17 @@ describe("bootReviewerListPage", () => {
     };
     runtimeSendMessageMock.mockImplementation(
       (message: { type?: string; accountId?: string | null }) => {
-        if (message.type === "fetchPullReviewerMetadataBatch") {
+        if (
+          message.type === "fetchPullReviewerMetadataBatch" &&
+          message.accountId == null
+        ) {
           return Promise.resolve({ ok: false, error: rateLimitError });
+        }
+        if (
+          message.type === "fetchPullReviewerMetadataBatch" &&
+          message.accountId === "acc-owner"
+        ) {
+          return Promise.resolve({ ok: true, metadata: [] });
         }
         if (
           message.type === "fetchPullReviewerSummary" &&
@@ -393,8 +402,17 @@ describe("bootReviewerListPage", () => {
     };
     runtimeSendMessageMock.mockImplementation(
       (message: { type?: string; accountId?: string | null }) => {
-        if (message.type === "fetchPullReviewerMetadataBatch") {
+        if (
+          message.type === "fetchPullReviewerMetadataBatch" &&
+          message.accountId == null
+        ) {
           return Promise.resolve({ ok: false, error: rateLimitError });
+        }
+        if (
+          message.type === "fetchPullReviewerMetadataBatch" &&
+          message.accountId === "acc-owner"
+        ) {
+          return Promise.resolve({ ok: true, metadata: [] });
         }
         if (
           message.type === "fetchPullReviewerSummary" &&
@@ -610,6 +628,120 @@ describe("bootReviewerListPage", () => {
     expect(
       summaryCalls.find((message) => message.pullNumber === "41"),
     ).not.toHaveProperty("pullMetadata");
+  });
+
+  it("passes visible pull numbers to the page-level metadata request", async () => {
+    document.body.innerHTML = `
+      <div class="js-issue-row" id="issue_150">
+        <a class="Link--primary" href="/cinev/shotloom/pull/150">PR #150</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+      <div class="js-issue-row" id="issue_149">
+        <a class="Link--primary" href="/cinev/shotloom/pull/149">PR #149</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+    `;
+    resolveAccountForRepoMock.mockResolvedValue(null);
+    const summary: PullReviewerSummary = {
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: [],
+      completedReviews: [],
+    };
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({
+          ok: true,
+          metadata: [
+            {
+              number: "150",
+              authorLogin: "cinev",
+              requestedUsers: [],
+              requestedTeams: [],
+            },
+            {
+              number: "149",
+              authorLogin: "cinev",
+              requestedUsers: [],
+              requestedTeams: [],
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ ok: true, summary });
+    });
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(
+      getRuntimeMessages("fetchPullReviewerMetadataBatch")[0],
+    ).toMatchObject({
+      targetPullNumbers: ["150", "149"],
+    });
+  });
+
+  it("short-circuits same-page row fallback after a final page metadata rate-limit failure", async () => {
+    document.body.innerHTML = `
+      <div class="js-issue-row" id="issue_42">
+        <a class="Link--primary" href="/cinev/shotloom/pull/42">PR #42</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+      <div class="js-issue-row" id="issue_41">
+        <a class="Link--primary" href="/cinev/shotloom/pull/41">PR #41</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+    `;
+    resolveAccountForRepoMock.mockResolvedValue(null);
+    listAccountsMock.mockResolvedValue([]);
+
+    const rateLimitError = {
+      kind: "github-api" as const,
+      status: 429,
+      failures: [
+        {
+          status: 429,
+          endpoint: "/repos/cinev/shotloom/pulls",
+          rateLimited: true,
+          rateLimit: {
+            limit: 60,
+            remaining: 0,
+            resource: "core",
+            resetAt: 1_700_000_000,
+          },
+        },
+      ],
+    };
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({ ok: false, error: rateLimitError });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const onRowFailure = vi.fn();
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx(), { onRowFailure });
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(getRuntimeMessages("fetchPullReviewerMetadataBatch")).toHaveLength(1);
+    expect(getRuntimeMessages("fetchPullReviewerSummary")).toHaveLength(0);
+    expect(onRowFailure).toHaveBeenCalledTimes(1);
+    expect(onRowFailure).toHaveBeenCalledWith({
+      owner: "cinev",
+      repo: "shotloom",
+      account: null,
+      error: expect.objectContaining({
+        envelope: rateLimitError,
+      }),
+    });
   });
 
   it("does not flash loading text on a cache-hit re-render", async () => {

--- a/tests/runtime-messages.test.ts
+++ b/tests/runtime-messages.test.ts
@@ -69,6 +69,7 @@ describe("reviewer fetch runtime message schemas", () => {
       owner: "cinev",
       repo: "shotloom",
       accountId: "acc-1",
+      targetPullNumbers: ["42", "41"],
     };
 
     expect(


### PR DESCRIPTION
## Summary

- Improves page-level reviewer metadata reuse for searched, filtered, and paginated pull request lists.
- Adds bounded, validated page-level metadata pagination and guards fallback-account race conditions.
- Adds fixture-backed coverage for a GitHub PR-list DOM variant without the usual metadata container.

## Why

v1.9.0 focuses on reviewer-list performance and DOM resilience. The previous metadata batch path only covered the first REST pull-list page, so older or filtered GitHub lists could fall back to one pull request call plus one reviews call per visible row. When the page-level batch failed for auth, access, or rate-limit reasons, row fallback could amplify the same failure across every row before the banner state settled.

## Changes

- Sends visible pull numbers through the metadata batch runtime contract and follows validated REST pagination for up to three pages until those rows are covered or pagination ends.
- Stops following unexpected pagination links so authenticated requests stay on the expected GitHub pulls endpoint.
- Caches final page-level metadata failures and suppresses same-page row fallback for auth/access/not-found/rate-limit failures after fallback-account retry is exhausted.
- Guards fallback-account metadata cache writes so older failures cannot overwrite newer successful page metadata results.
- Adds an idempotent reviewer mount fallback when GitHub omits the expected metadata container.
- Updates README and implementation notes for the new batching, failure, and DOM behavior.

## Impact

- User-facing impact: reviewer chips should appear more consistently on searched, filtered, paginated, and variant PR list pages; page-level access banners should appear without row-level request cascades.
- API/schema impact: extends the internal reviewer metadata batch runtime message with optional `targetPullNumbers`; no external API or storage schema change.
- Performance impact: reduces avoidable per-row pull fallback on older/filtered pages while bounding page-level batch pagination to avoid large-list request cascades.
- Operational or rollout impact: None.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

### Test details

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 355 tests passed
- `pnpm exec vitest run tests/api.test.ts tests/reviewer-dom.test.ts tests/reviewers.test.ts tests/runtime-messages.test.ts` — 94 tests passed
- `WXT_GITHUB_APP_CLIENT_ID=TESTING_CLIENT_ID WXT_GITHUB_APP_SLUG=test-app pnpm build`

## Breaking Changes

- None

## Related Issues

Resolves #100, #101, #102