### PR TITLE
refactor(runtime): share reviewer fetch retry handling

### DIFF
--- a/src/background/reviewer-fetch.ts
+++ b/src/background/reviewer-fetch.ts
@@ -11,6 +11,7 @@ import {
   type FetchPullReviewerMetadataBatchResponse,
   type FetchPullReviewerSummaryMessage,
   type FetchPullReviewerSummaryResponse,
+  type ReviewerFetchErrorEnvelope,
 } from "../runtime/reviewer-fetch";
 
 export const CANCELED_REQUEST_TTL_MS = 60_000;
@@ -25,6 +26,16 @@ export type ReviewerFetchService = {
   ): Promise<FetchPullReviewerMetadataBatchResponse>;
 };
 
+type ReviewerFetchMessage = {
+  requestId: string;
+  accountId: string | null;
+};
+
+type ReviewerFetchFailureResponse = {
+  ok: false;
+  error: ReviewerFetchErrorEnvelope;
+};
+
 export function createReviewerFetchService(input: {
   refreshCoordinator: RefreshCoordinator;
 }): ReviewerFetchService {
@@ -37,6 +48,81 @@ export function createReviewerFetchService(input: {
       if (now - createdAt > CANCELED_REQUEST_TTL_MS) {
         canceledRequestIds.delete(requestId);
       }
+    }
+  }
+
+  function createController(requestId: string): AbortController {
+    // Prune on both cancel and fetch entry so the TTL applies symmetrically
+    // even when a cancel's matching fetch never arrives.
+    pruneCanceledRequestIds(Date.now());
+
+    const controller = new AbortController();
+    inFlightControllers.set(requestId, controller);
+
+    if (canceledRequestIds.delete(requestId)) {
+      controller.abort();
+    }
+
+    return controller;
+  }
+
+  async function runWithRefreshRetry<Result, SuccessResponse extends { ok: true }>(
+    message: ReviewerFetchMessage,
+    execute: (token: string | null, signal: AbortSignal) => Promise<Result>,
+    toSuccessResponse: (result: Result) => SuccessResponse,
+  ): Promise<SuccessResponse | ReviewerFetchFailureResponse> {
+    const controller = createController(message.requestId);
+
+    try {
+      const account =
+        message.accountId == null ? null : await getAccountById(message.accountId);
+
+      try {
+        const result = await execute(account?.token ?? null, controller.signal);
+        return toSuccessResponse(result);
+      } catch (error) {
+        if (extractGitHubApiStatus(error) !== 401 || account == null) {
+          return {
+            ok: false,
+            error: serializeReviewerFetchError(error),
+          };
+        }
+
+        if (account.refreshToken == null) {
+          await markAccountInvalidated(account.id, "revoked");
+          return {
+            ok: false,
+            error: serializeReviewerFetchError(error),
+          };
+        }
+
+        const outcome = await refreshCoordinator.refreshAccountToken(account.id);
+        if (outcome.ok !== true) {
+          return {
+            ok: false,
+            error: serializeReviewerFetchError(error),
+          };
+        }
+
+        const refreshed = await getAccountById(account.id);
+        try {
+          const result = await execute(
+            refreshed?.token ?? outcome.token,
+            controller.signal,
+          );
+          return toSuccessResponse(result);
+        } catch (retryError) {
+          if (extractGitHubApiStatus(retryError) === 401) {
+            await markAccountInvalidated(account.id, "revoked");
+          }
+          return {
+            ok: false,
+            error: serializeReviewerFetchError(retryError),
+          };
+        }
+      }
+    } finally {
+      inFlightControllers.delete(message.requestId);
     }
   }
 
@@ -55,149 +141,39 @@ export function createReviewerFetchService(input: {
     async handleFetchMessage(
       message: FetchPullReviewerSummaryMessage,
     ): Promise<FetchPullReviewerSummaryResponse> {
-      // Prune on both cancel and fetch entry so the TTL applies symmetrically
-      // even when a cancel's matching fetch never arrives.
-      pruneCanceledRequestIds(Date.now());
-
-      const controller = new AbortController();
-      inFlightControllers.set(message.requestId, controller);
-
-      if (canceledRequestIds.delete(message.requestId)) {
-        controller.abort();
-      }
-
-      try {
-        const account =
-          message.accountId == null ? null : await getAccountById(message.accountId);
-
-        const execute = (token: string | null) =>
+      return runWithRefreshRetry(
+        message,
+        (token, signal) =>
           fetchPullReviewerSummary({
             owner: message.owner,
             repo: message.repo,
             pullNumber: message.pullNumber,
             githubToken: token,
-            signal: controller.signal,
+            signal,
             ...(message.pullMetadata == null
               ? {}
               : { pullMetadata: message.pullMetadata }),
-          });
-
-        try {
-          const summary = await execute(account?.token ?? null);
-          return { ok: true, summary };
-        } catch (error) {
-          if (extractGitHubApiStatus(error) !== 401 || account == null) {
-            return {
-              ok: false,
-              error: serializeReviewerFetchError(error),
-            };
-          }
-
-          if (account.refreshToken == null) {
-            await markAccountInvalidated(account.id, "revoked");
-            return {
-              ok: false,
-              error: serializeReviewerFetchError(error),
-            };
-          }
-
-          const outcome = await refreshCoordinator.refreshAccountToken(account.id);
-          if (outcome.ok !== true) {
-            return {
-              ok: false,
-              error: serializeReviewerFetchError(error),
-            };
-          }
-
-          const refreshed = await getAccountById(account.id);
-          try {
-            const summary = await execute(refreshed?.token ?? outcome.token);
-            return { ok: true, summary };
-          } catch (retryError) {
-            if (extractGitHubApiStatus(retryError) === 401) {
-              await markAccountInvalidated(account.id, "revoked");
-            }
-            return {
-              ok: false,
-              error: serializeReviewerFetchError(retryError),
-            };
-          }
-        }
-      } finally {
-        inFlightControllers.delete(message.requestId);
-      }
+          }),
+        (summary) => ({ ok: true, summary }),
+      );
     },
     async handleMetadataBatchMessage(
       message: FetchPullReviewerMetadataBatchMessage,
     ): Promise<FetchPullReviewerMetadataBatchResponse> {
-      pruneCanceledRequestIds(Date.now());
-
-      const controller = new AbortController();
-      inFlightControllers.set(message.requestId, controller);
-
-      if (canceledRequestIds.delete(message.requestId)) {
-        controller.abort();
-      }
-
-      try {
-        const account =
-          message.accountId == null ? null : await getAccountById(message.accountId);
-
-        const execute = (token: string | null) =>
+      return runWithRefreshRetry(
+        message,
+        (token, signal) =>
           fetchPullReviewerMetadataBatch({
             owner: message.owner,
             repo: message.repo,
             githubToken: token,
-            signal: controller.signal,
+            signal,
             ...(message.targetPullNumbers == null
               ? {}
               : { targetPullNumbers: message.targetPullNumbers }),
-          });
-
-        try {
-          const metadata = await execute(account?.token ?? null);
-          return { ok: true, metadata };
-        } catch (error) {
-          if (extractGitHubApiStatus(error) !== 401 || account == null) {
-            return {
-              ok: false,
-              error: serializeReviewerFetchError(error),
-            };
-          }
-
-          if (account.refreshToken == null) {
-            await markAccountInvalidated(account.id, "revoked");
-            return {
-              ok: false,
-              error: serializeReviewerFetchError(error),
-            };
-          }
-
-          const outcome = await refreshCoordinator.refreshAccountToken(account.id);
-          if (outcome.ok !== true) {
-            return {
-              ok: false,
-              error: serializeReviewerFetchError(error),
-            };
-          }
-
-          const refreshed = await getAccountById(account.id);
-          try {
-            const metadata = await execute(refreshed?.token ?? outcome.token);
-            return { ok: true, metadata };
-          } catch (retryError) {
-            if (extractGitHubApiStatus(retryError) === 401) {
-              await markAccountInvalidated(account.id, "revoked");
-            }
-            return {
-              ok: false,
-              error: serializeReviewerFetchError(retryError),
-            };
-          }
-        }
-      } finally {
-        inFlightControllers.delete(message.requestId);
-      }
+          }),
+        (metadata) => ({ ok: true, metadata }),
+      );
     },
   };
 }

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -10,6 +10,7 @@ import {
 const {
   refreshAccountTokenMock,
   fetchPullReviewerSummaryMock,
+  fetchPullReviewerMetadataBatchMock,
   getAccountByIdMock,
   listAccountsMock,
   markAccountInvalidatedMock,
@@ -20,6 +21,7 @@ const {
 } = vi.hoisted(() => ({
   refreshAccountTokenMock: vi.fn(),
   fetchPullReviewerSummaryMock: vi.fn(),
+  fetchPullReviewerMetadataBatchMock: vi.fn(),
   getAccountByIdMock: vi.fn(),
   listAccountsMock: vi.fn<() => Promise<unknown[]>>(),
   markAccountInvalidatedMock: vi.fn(),
@@ -60,6 +62,7 @@ vi.mock("../src/github/api", async () => {
   return {
     ...actual,
     fetchPullReviewerSummary: fetchPullReviewerSummaryMock,
+    fetchPullReviewerMetadataBatch: fetchPullReviewerMetadataBatchMock,
   };
 });
 
@@ -102,6 +105,7 @@ beforeEach(() => {
   vi.resetModules();
   refreshAccountTokenMock.mockReset();
   fetchPullReviewerSummaryMock.mockReset();
+  fetchPullReviewerMetadataBatchMock.mockReset();
   getAccountByIdMock.mockReset();
   listAccountsMock.mockReset().mockResolvedValue([]);
   markAccountInvalidatedMock.mockReset();
@@ -311,6 +315,54 @@ describe("background runtime.onMessage handler", () => {
     expect(fetchPullReviewerSummaryMock).toHaveBeenCalledTimes(2);
     expect(fetchPullReviewerSummaryMock.mock.calls[1][0]).toMatchObject({
       githubToken: "ghu_new",
+    });
+    expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes on metadata batch 401 and retries with the updated token", async () => {
+    const listener = await bootBackground();
+    const metadata = [
+      {
+        number: "42",
+        authorLogin: "octo-author",
+        requestedUsers: [],
+        requestedTeams: ["maintainers"],
+      },
+    ];
+    getAccountByIdMock
+      .mockResolvedValueOnce({
+        id: "acc-1",
+        token: "ghu_old",
+        refreshToken: "ghr_old",
+      })
+      .mockResolvedValueOnce({
+        id: "acc-1",
+        token: "ghu_new",
+        refreshToken: "ghr_new",
+      });
+    fetchPullReviewerMetadataBatchMock
+      .mockRejectedValueOnce({ status: 401 })
+      .mockResolvedValueOnce(metadata);
+
+    const response = await callListener(
+      listener,
+      {
+        type: "fetchPullReviewerMetadataBatch",
+        requestId: "req-batch-1",
+        owner: "cinev",
+        repo: "shotloom",
+        accountId: "acc-1",
+        targetPullNumbers: ["42"],
+      },
+      { id: SELF_RUNTIME_ID },
+    );
+
+    expect(response).toEqual({ ok: true, metadata });
+    expect(refreshAccountTokenMock).toHaveBeenCalledWith("acc-1");
+    expect(fetchPullReviewerMetadataBatchMock).toHaveBeenCalledTimes(2);
+    expect(fetchPullReviewerMetadataBatchMock.mock.calls[1][0]).toMatchObject({
+      githubToken: "ghu_new",
+      targetPullNumbers: ["42"],
     });
     expect(markAccountInvalidatedMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- Share the reviewer fetch account lookup, cancellation, 401 refresh, retry, invalidation, and error serialization flow between summary and metadata batch handlers.
- Add metadata batch coverage for refresh-and-retry behavior.

## Why

The summary and metadata batch background paths had parallel auth retry logic. Keeping that logic duplicated makes future auth, cancellation, or invalidation fixes easier to apply to only one path by mistake.

## Changes

- Extract a typed `runWithRefreshRetry` helper inside the reviewer fetch service.
- Keep fetch-specific request construction in each handler while sharing the common background control flow.
- Mock and verify metadata batch refresh retry behavior in the background runtime tests.

## Impact

- User-facing impact: None intended; reviewer fetching behavior is preserved.
- API/schema impact: None.
- Performance impact: None expected.
- Operational or rollout impact: Lower maintenance risk for auth retry changes.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm test tests/background.test.ts`
- `pnpm typecheck`
- `pnpm lint`

## Breaking Changes

- None

## Related Issues

Resolves #103
