### PR TITLE
test(reviewers): expand packaged-extension coverage

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -21,7 +21,10 @@
 
 1. Parse the current repository route from `window.location.pathname`.
 2. Find PR rows with centralized GitHub selectors.
-3. Extract the pull request number from the row id or primary pull request link.
+3. Extract the pull request number from the row id or a centralized pull
+   request link selector. The selector prefers GitHub's `Link--primary` class
+   and falls back to `js-navigation-open` pull links for markup variants where
+   the title link keeps navigation behavior but loses the primary-link class.
 4. Resolve the covering account for `owner/repo` via `resolveAccountForRepo`.
 5. Send one `fetchPullReviewerMetadataBatch` message per page/account when the
    page-level metadata cache is cold or stale. The content script includes the

--- a/src/features/reviewers/dom.ts
+++ b/src/features/reviewers/dom.ts
@@ -181,7 +181,10 @@ export function extractPullNumber(row: Element): string | null {
     }
   }
 
-  const link = row.querySelector<HTMLAnchorElement>(githubSelectors.primaryLink);
+  const link = findFirst<HTMLAnchorElement>(
+    row,
+    githubSelectors.pullLinkSelectors,
+  );
   const href = link?.getAttribute("href");
   const match = href?.match(/\/pull\/(\d+)/);
 
@@ -217,7 +220,10 @@ export function ensureReviewerMount(row: Element): HTMLElement | null {
 }
 
 function createFallbackMetaContainer(row: Element): HTMLElement | null {
-  const link = row.querySelector<HTMLAnchorElement>(githubSelectors.primaryLink);
+  const link = findFirst<HTMLAnchorElement>(
+    row,
+    githubSelectors.pullLinkSelectors,
+  );
   if (link == null) return null;
 
   const container = document.createElement("span");

--- a/src/features/reviewers/index.ts
+++ b/src/features/reviewers/index.ts
@@ -737,20 +737,21 @@ export function bootReviewerListPage(
 }
 
 function createRowFingerprint(row: Element, pullNumber: string): string {
-  const link = row.querySelector<HTMLAnchorElement>(
-    githubSelectors.primaryLink,
+  const link = findFirst<HTMLAnchorElement>(
+    row,
+    githubSelectors.pullLinkSelectors,
   );
   const href = link?.getAttribute("href") ?? "";
   const metaContainer = findFirst(row, githubSelectors.metaContainers);
   return [pullNumber, href, readRowMetadataText(metaContainer)].join("|");
 }
 
-function findFirst(
+function findFirst<T extends Element = Element>(
   root: ParentNode,
   selectors: readonly string[],
-): Element | null {
+): T | null {
   for (const selector of selectors) {
-    const match = root.querySelector(selector);
+    const match = root.querySelector<T>(selector);
     if (match != null) return match;
   }
   return null;

--- a/src/github/selectors.ts
+++ b/src/github/selectors.ts
@@ -1,6 +1,7 @@
 export const githubSelectors = {
   row: ".js-issue-row",
-  primaryLink: 'a.Link--primary[href*="/pull/"]',
+  primaryLink:
+    'a.Link--primary[href*="/pull/"], a.js-navigation-open[href*="/pull/"]',
   metaContainers: [
     ".d-flex.mt-1.text-small.color-fg-muted",
     '[class*="ListItem-module__ListItemMetadataRow"]',

--- a/src/github/selectors.ts
+++ b/src/github/selectors.ts
@@ -1,7 +1,10 @@
 export const githubSelectors = {
   row: ".js-issue-row",
-  primaryLink:
-    'a.Link--primary[href*="/pull/"], a.js-navigation-open[href*="/pull/"]',
+  primaryLink: 'a.Link--primary[href*="/pull/"]',
+  pullLinkSelectors: [
+    'a.Link--primary[href*="/pull/"]',
+    'a.js-navigation-open[href*="/pull/"]',
+  ],
   metaContainers: [
     ".d-flex.mt-1.text-small.color-fg-muted",
     '[class*="ListItem-module__ListItemMetadataRow"]',

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -38,12 +38,25 @@ const renderCases: FixtureCase[] = [
     fixture: "github-pulls-link-only.html",
     pullNumber: "77",
   },
+  {
+    name: "title-only metadata fallback",
+    fixture: "github-pulls-title-only-metadata.html",
+    pullNumber: "203",
+  },
+  {
+    name: "non-primary pull link fallback",
+    fixture: "github-pulls-non-primary-link.html",
+    pullNumber: "314",
+  },
 ];
 
 for (const fixtureCase of renderCases) {
   test(`renders reviewer chips for ${fixtureCase.name}`, async () => {
     await withExtensionContext(async (context) => {
-      const fixtureHtml = await readFile(path.join(fixturesDir, fixtureCase.fixture), "utf8");
+      const fixtureHtml = await readFile(
+        path.join(fixturesDir, fixtureCase.fixture),
+        "utf8",
+      );
 
       await routeFixturePage(context, fixtureHtml);
       await routePullListApi(context, [
@@ -68,12 +81,16 @@ for (const fixtureCase of renderCases) {
       ]);
 
       const page = await context.newPage();
-      await page.goto("https://github.com/hon454/github-pulls-show-reviewers/pulls");
+      await page.goto(
+        "https://github.com/hon454/github-pulls-show-reviewers/pulls",
+      );
 
       const root = page.locator(".ghpsr-root");
       await expect(root).toContainText("Reviewers:");
       await expect(root).toContainText("Team: platform");
-      await expect(root.locator('a.ghpsr-avatar[title*="@alice"]')).toHaveCount(1);
+      await expect(root.locator('a.ghpsr-avatar[title*="@alice"]')).toHaveCount(
+        1,
+      );
       await expect(
         root.locator('a.ghpsr-avatar[title*="@bob"][title*="approved"]'),
       ).toHaveCount(1);
@@ -83,7 +100,10 @@ for (const fixtureCase of renderCases) {
 
 test("omits the inline reviewer row when both requested and reviewed are empty", async () => {
   await withExtensionContext(async (context) => {
-    const fixtureHtml = await readFile(path.join(fixturesDir, singleRowFixture), "utf8");
+    const fixtureHtml = await readFile(
+      path.join(fixturesDir, singleRowFixture),
+      "utf8",
+    );
 
     await routeFixturePage(context, fixtureHtml);
     await routePullListApi(context, [
@@ -102,9 +122,122 @@ test("omits the inline reviewer row when both requested and reviewed are empty",
     await routeReviewsApi(context, "42", []);
 
     const page = await context.newPage();
-    await page.goto("https://github.com/hon454/github-pulls-show-reviewers/pulls");
+    await page.goto(
+      "https://github.com/hon454/github-pulls-show-reviewers/pulls",
+    );
 
     await expect(page.locator(".ghpsr-root")).toBeEmpty();
+  });
+});
+
+test("renders reviewer chips after a same-repository GitHub rerender", async () => {
+  await withExtensionContext(async (context) => {
+    const initialFixtureHtml = await readFile(
+      path.join(fixturesDir, singleRowFixture),
+      "utf8",
+    );
+    const rerenderFixtureHtml = await readFile(
+      path.join(fixturesDir, "github-pulls-missing-inline-meta.html"),
+      "utf8",
+    );
+
+    await routeFixturePage(context, initialFixtureHtml);
+    await routePullListApi(context, [
+      {
+        number: 42,
+        user: { login: "hon454" },
+        requested_reviewers: [{ login: "alice" }],
+        requested_teams: [],
+      },
+      {
+        number: 128,
+        user: { login: "hon454" },
+        requested_reviewers: [{ login: "charlie" }],
+        requested_teams: [{ slug: "design-systems" }],
+      },
+    ]);
+    await routePullApi(context, "42", {
+      user: { login: "hon454" },
+      requested_reviewers: [{ login: "alice" }],
+      requested_teams: [],
+    });
+    await routePullApi(context, "128", {
+      user: { login: "hon454" },
+      requested_reviewers: [{ login: "charlie" }],
+      requested_teams: [{ slug: "design-systems" }],
+    });
+    await routeReviewsApi(context, "42", []);
+    await routeReviewsApi(context, "128", [
+      {
+        state: "APPROVED",
+        submitted_at: "2026-04-20T12:00:00Z",
+        user: { login: "dana" },
+      },
+    ]);
+
+    const page = await context.newPage();
+    await page.goto(
+      "https://github.com/hon454/github-pulls-show-reviewers/pulls",
+    );
+    await expect(page.locator('a.ghpsr-avatar[title*="@alice"]')).toHaveCount(
+      1,
+    );
+
+    await page.evaluate((html) => {
+      const nextDocument = new DOMParser().parseFromString(html, "text/html");
+      const nextContainer = nextDocument.querySelector(
+        ".js-navigation-container",
+      );
+      const currentContainer = document.querySelector(
+        ".js-navigation-container",
+      );
+      if (nextContainer == null || currentContainer == null) {
+        throw new Error("fixture navigation container missing");
+      }
+      window.history.pushState(
+        {},
+        "",
+        "/hon454/github-pulls-show-reviewers/pulls?page=2",
+      );
+      currentContainer.replaceWith(nextContainer);
+      document.dispatchEvent(new Event("turbo:render", { bubbles: true }));
+    }, rerenderFixtureHtml);
+
+    const root = page.locator(".ghpsr-root");
+    await expect(root).toContainText("Reviewers:");
+    await expect(root).toContainText("Team: design-systems");
+    await expect(root.locator('a.ghpsr-avatar[title*="@charlie"]')).toHaveCount(
+      1,
+    );
+    await expect(
+      root.locator('a.ghpsr-avatar[title*="@dana"][title*="approved"]'),
+    ).toHaveCount(1);
+  });
+});
+
+test("clears metadata-missing reviewer slots silently when reviewer fetch fails", async () => {
+  await withExtensionContext(async (context) => {
+    const fixtureHtml = await readFile(
+      path.join(fixturesDir, "github-pulls-title-only-metadata.html"),
+      "utf8",
+    );
+
+    await routeFixturePage(context, fixtureHtml);
+    await routePullListApi(context, []);
+    await routePullApiError(context, "203", 403);
+    await routeReviewsApiError(context, "203", 403);
+
+    const page = await context.newPage();
+    await page.goto(
+      "https://github.com/hon454/github-pulls-show-reviewers/pulls",
+    );
+
+    await expect(page.locator(".ghpsr-status--error")).toHaveCount(0);
+    const root = page.locator(".ghpsr-root");
+    const rootCount = await root.count();
+    if (rootCount > 0) {
+      await expect(root).toBeEmpty();
+    }
   });
 });
 
@@ -155,7 +288,9 @@ test("renders unauth-rate-limit banner with Sign in CTA when an unauthenticated 
     );
 
     const page = await context.newPage();
-    await page.goto("https://github.com/hon454/github-pulls-show-reviewers/pulls");
+    await page.goto(
+      "https://github.com/hon454/github-pulls-show-reviewers/pulls",
+    );
 
     const banner = page.locator("[data-ghpsr-banner]");
     await expect(banner).toContainText(
@@ -188,18 +323,23 @@ test("renders app-uncovered banner with Configure access CTA when a signed-in ro
     await routePullListApi(context, []);
     // Defensive stub: in case the background ever calls the installations API,
     // return an empty list rather than letting the real network handle it.
-    await context.route("https://api.github.com/user/installations**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ total_count: 0, installations: [] }),
-      });
-    });
+    await context.route(
+      "https://api.github.com/user/installations**",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ total_count: 0, installations: [] }),
+        });
+      },
+    );
     await routePullApiError(context, "42", 404);
     await routeReviewsApiError(context, "42", 404);
 
     const page = await context.newPage();
-    await page.goto("https://github.com/hon454/github-pulls-show-reviewers/pulls");
+    await page.goto(
+      "https://github.com/hon454/github-pulls-show-reviewers/pulls",
+    );
 
     const banner = page.locator("[data-ghpsr-banner]");
     await expect(banner).toContainText(
@@ -216,7 +356,10 @@ test("renders app-uncovered banner with Configure access CTA when a signed-in ro
 
 test("refreshes an expired selected-installation account before rendering private reviewer metadata", async () => {
   await withExtensionContext(async (context) => {
-    const fixtureHtml = await readFile(path.join(fixturesDir, singleRowFixture), "utf8");
+    const fixtureHtml = await readFile(
+      path.join(fixturesDir, singleRowFixture),
+      "utf8",
+    );
     const now = Date.now();
     const refreshRequests: string[] = [];
     const metadataAuthHeaders: string[] = [];
@@ -300,7 +443,9 @@ test("refreshes an expired selected-installation account before rendering privat
     );
 
     const page = await context.newPage();
-    await page.goto("https://github.com/hon454/github-pulls-show-reviewers/pulls");
+    await page.goto(
+      "https://github.com/hon454/github-pulls-show-reviewers/pulls",
+    );
 
     const root = page.locator(".ghpsr-root");
     await expect(root).toContainText("Reviewers:");
@@ -339,7 +484,10 @@ test("refreshes an expired selected-installation account before rendering privat
 
 test("clears the reviewer slot silently when review history is denied", async () => {
   await withExtensionContext(async (context) => {
-    const fixtureHtml = await readFile(path.join(fixturesDir, singleRowFixture), "utf8");
+    const fixtureHtml = await readFile(
+      path.join(fixturesDir, singleRowFixture),
+      "utf8",
+    );
 
     await routeFixturePage(context, fixtureHtml);
     await routePullListApi(context, []);
@@ -366,7 +514,9 @@ test("clears the reviewer slot silently when review history is denied", async ()
     );
 
     const page = await context.newPage();
-    await page.goto("https://github.com/hon454/github-pulls-show-reviewers/pulls");
+    await page.goto(
+      "https://github.com/hon454/github-pulls-show-reviewers/pulls",
+    );
 
     // Row-level error rendering is removed; failures silently clear the reviewer slot.
     await expect(page.locator(".ghpsr-status--error")).toHaveCount(0);
@@ -380,9 +530,13 @@ test("clears the reviewer slot silently when review history is denied", async ()
 });
 
 async function withExtensionContext(
-  run: (context: Awaited<ReturnType<typeof chromium.launchPersistentContext>>) => Promise<void>,
+  run: (
+    context: Awaited<ReturnType<typeof chromium.launchPersistentContext>>,
+  ) => Promise<void>,
 ): Promise<void> {
-  const userDataDir = await mkdtemp(path.join(os.tmpdir(), "ghpsr-playwright-"));
+  const userDataDir = await mkdtemp(
+    path.join(os.tmpdir(), "ghpsr-playwright-"),
+  );
   const context = await chromium.launchPersistentContext(userDataDir, {
     channel: "chromium",
     args: [
@@ -393,7 +547,8 @@ async function withExtensionContext(
 
   try {
     const serviceWorker =
-      context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+      context.serviceWorkers()[0] ??
+      (await context.waitForEvent("serviceworker"));
     expect(serviceWorker.url()).toContain("chrome-extension://");
     await settleExtensionInstallUi(context);
     await run(context);
@@ -434,13 +589,16 @@ async function routeFixturePage(
   context: Awaited<ReturnType<typeof chromium.launchPersistentContext>>,
   fixtureHtml: string,
 ): Promise<void> {
-  await context.route("https://github.com/hon454/github-pulls-show-reviewers/pulls", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "text/html",
-      body: fixtureHtml,
-    });
-  });
+  await context.route(
+    "https://github.com/hon454/github-pulls-show-reviewers/pulls",
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: fixtureHtml,
+      });
+    },
+  );
 }
 
 async function routePullApi(
@@ -542,7 +700,8 @@ async function seedSignedInAccount(
   },
 ): Promise<void> {
   const serviceWorker =
-    context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+    context.serviceWorkers()[0] ??
+    (await context.waitForEvent("serviceworker"));
   const extensionId = new URL(serviceWorker.url()).host;
   const optionsPage = await context.newPage();
   try {

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -224,20 +224,42 @@ test("clears metadata-missing reviewer slots silently when reviewer fetch fails"
 
     await routeFixturePage(context, fixtureHtml);
     await routePullListApi(context, []);
-    await routePullApiError(context, "203", 403);
-    await routeReviewsApiError(context, "203", 403);
+    let pullRequestCount = 0;
+    let reviewsRequestCount = 0;
+    await context.route(
+      "https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/203",
+      async (route) => {
+        pullRequestCount += 1;
+        await route.fulfill({
+          status: 403,
+          contentType: "application/json",
+          body: JSON.stringify({ message: "status 403" }),
+        });
+      },
+    );
+    await context.route(
+      "https://api.github.com/repos/hon454/github-pulls-show-reviewers/pulls/203/reviews**",
+      async (route) => {
+        reviewsRequestCount += 1;
+        await route.fulfill({
+          status: 403,
+          contentType: "application/json",
+          body: JSON.stringify({ message: "status 403" }),
+        });
+      },
+    );
 
     const page = await context.newPage();
     await page.goto(
       "https://github.com/hon454/github-pulls-show-reviewers/pulls",
     );
 
+    await expect.poll(() => pullRequestCount).toBe(1);
+    await expect.poll(() => reviewsRequestCount).toBe(1);
     await expect(page.locator(".ghpsr-status--error")).toHaveCount(0);
     const root = page.locator(".ghpsr-root");
-    const rootCount = await root.count();
-    if (rootCount > 0) {
-      await expect(root).toBeEmpty();
-    }
+    await expect(root).toHaveCount(1);
+    await expect(root).toBeEmpty();
   });
 });
 

--- a/tests/fixtures/github-pulls-non-primary-link.html
+++ b/tests/fixtures/github-pulls-non-primary-link.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>GitHub Pulls Fixture Non Primary Link</title>
+  </head>
+  <body>
+    <div class="js-navigation-container js-active-navigation-container">
+      <div class="js-issue-row">
+        <div class="Box-row">
+          <a
+            class="js-navigation-open markdown-title"
+            href="/hon454/github-pulls-show-reviewers/pull/314"
+          >
+            Pull link lacks the Link--primary class
+          </a>
+        </div>
+        <div class="d-flex mt-1 text-small color-fg-muted">
+          <span class="d-none d-md-inline-flex">
+            <span class="issue-meta-section ml-2">#314 opened by hon454</span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/reviewer-dom.test.ts
+++ b/tests/reviewer-dom.test.ts
@@ -270,6 +270,35 @@ describe("renderReviewers", () => {
     expect(extractPullNumber(row!)).toBe("203");
   });
 
+  it("prefers the title link over earlier non-primary navigation links", () => {
+    document.body.innerHTML = `
+      <div class="js-issue-row">
+        <a class="js-navigation-open" href="/hon454/github-pulls-show-reviewers/pull/202">
+          Earlier navigation link
+        </a>
+        <a class="Link--primary" href="/hon454/github-pulls-show-reviewers/pull/203">
+          Title link
+        </a>
+      </div>
+    `;
+    const row = document.querySelector(".js-issue-row")!;
+    const earlierLink = row.querySelector<HTMLAnchorElement>(
+      ".js-navigation-open",
+    )!;
+    const titleLink = row.querySelector<HTMLAnchorElement>(".Link--primary")!;
+
+    const mountNode = ensureReviewerMount(row);
+
+    expect(extractPullNumber(row)).toBe("203");
+    expect(mountNode).not.toBeNull();
+    expect(
+      titleLink.nextElementSibling?.getAttribute("data-ghpsr-fallback-meta"),
+    ).toBe("true");
+    expect(
+      earlierLink.nextElementSibling?.getAttribute("data-ghpsr-fallback-meta"),
+    ).not.toBe("true");
+  });
+
   it("declares :focus-visible styles for reviewer avatars, pills, and team chips", () => {
     ensureReviewerStyles();
     const styleEl = document.querySelector("[data-ghpsr-style]");


### PR DESCRIPTION
## Summary

- Expands packaged MV3 extension coverage for GitHub pull-list DOM variants that can affect reviewer chip rendering.
- Adds regression coverage for same-repository rerender/navigation and silent row-slot clearing when metadata mounts are missing.

## Why

GitHub PR list markup changes are the highest-risk path for this extension because selector drift can silently remove reviewer visibility from the core workflow. This PR adds fixture-backed packaged-extension checks around those selector and rerender paths.

## Changes

- Adds packaged-extension render cases for title-only metadata and non-primary pull-link markup.
- Covers a GitHub-style same-repository rerender that replaces the PR list DOM and verifies reviewer chips render on the new row.
- Verifies metadata-missing fetch failures clear reviewer slots without row-level error text.
- Extends the centralized pull-link selector with a `js-navigation-open` fallback and documents that selector fallback strategy.

## Impact

- User-facing impact: Better resilience for reviewer chip rendering across GitHub PR list markup variants.
- API/schema impact: None.
- Performance impact: None expected; selector fallback remains local DOM querying.
- Operational or rollout impact: None.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:coverage` (362 tests passed)
- `pnpm test:e2e` (13 packaged-extension tests passed)
- Manual Chrome testing not run; covered by packaged MV3 Playwright E2E fixtures.

## Breaking Changes

- None

## Related Issues

Resolves #112

<!-- Co-location checklist: src/github/selectors.ts changed, so fixture-backed regression coverage was added under tests/. docs/implementation-notes.md was updated for the selector fallback strategy. -->
