### PR TITLE
perf(github): cap ambiguous review request event lookup

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -136,11 +136,11 @@
   caches the page-level metadata result per `owner/repo/account` and visible
   pull-number set with a shorter freshness window.
 - Issue-event requests are targeted to ambiguous requested+completed reviewer
-  overlaps only, and follow at most two issue-event pages. Rows whose requested
-  users do not overlap a latest non-`COMMENTED` review keep the lower-volume
-  pull metadata plus reviews path. If a confirming `review_requested` event is
-  unavailable within the two-page bound, the row uses the completed review
-  state rather than an uncertain refresh badge.
+  overlaps only, and follow at most two GitHub API issue-event pages. Rows
+  whose requested users do not overlap a latest non-`COMMENTED` review keep the
+  lower-volume pull metadata plus reviews path. If a confirming
+  `review_requested` event is unavailable within the two-page bound, the row
+  uses the completed review state rather than an uncertain refresh badge.
 - A GraphQL-first rewrite is not the next step because it would push the product away from the current no-token public-repository path and add a second transport model to maintain.
 - If request volume remains the next bottleneck, the preferred follow-up is to
   tune the three-page REST pagination bound with fixture-backed evidence before

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -61,13 +61,14 @@
    asking the user to sign in again.
 7. For ambiguous user reviewers that appear in both `requested_reviewers` and
    the latest non-`COMMENTED` review set (`APPROVED`, `CHANGES_REQUESTED`, or
-   `DISMISSED`), read the pull request's issue events and compare ordering.
-   When the latest `review_requested` event for that user is newer than the
-   latest completed review, keep the user requested so the row shows the
-   refresh badge. Otherwise, drop the stale requested marker so the row shows
-   the completed review state. If this targeted issue-event lookup fails, fall
-   back to the completed review state instead of labeling the reviewer as
-   re-requested.
+   `DISMISSED`), read up to two pages of the pull request's issue events and
+   compare ordering. When the latest `review_requested` event for that user
+   within that bounded lookup is newer than the latest completed review, keep
+   the user requested so the row shows the refresh badge. Otherwise, drop the
+   stale requested marker so the row shows the completed review state. If this
+   targeted issue-event lookup fails, or the confirming event is beyond the
+   two-page bound, fall back to the completed review state instead of labeling
+   the reviewer as re-requested.
 8. Render a single `Reviewers` section inline in the PR row metadata area. Each reviewer is an avatar chip. Requested reviewers keep the blue requested ring. Completed reviewers show a ring and badge derived from one `(isRequested, state)` mapping. Review selection prefers the latest non-`COMMENTED` review for a reviewer, falling back to the latest `COMMENTED` review only when no non-comment review exists. A still-requested reviewer with prior `APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED` evidence shows the refresh badge only when the event ordering confirms a later re-request. Requested teams keep the text chip shape. User chip links follow the same primary axis as the ring color: blue-ring (still-requested) chips link to `review-requested:<login>`; colored-ring (completed) chips link to `reviewed-by:<login>`. Reviewer chip links use `is:pr is:open` searches by default.
 9. On API errors, emit a signal to the banner aggregator; do not render
    row-level error text.
@@ -135,8 +136,11 @@
   caches the page-level metadata result per `owner/repo/account` and visible
   pull-number set with a shorter freshness window.
 - Issue-event requests are targeted to ambiguous requested+completed reviewer
-  overlaps only. Rows whose requested users do not overlap a latest
-  non-`COMMENTED` review keep the lower-volume pull metadata plus reviews path.
+  overlaps only, and follow at most two issue-event pages. Rows whose requested
+  users do not overlap a latest non-`COMMENTED` review keep the lower-volume
+  pull metadata plus reviews path. If a confirming `review_requested` event is
+  unavailable within the two-page bound, the row uses the completed review
+  state rather than an uncertain refresh badge.
 - A GraphQL-first rewrite is not the next step because it would push the product away from the current no-token public-repository path and add a second transport model to maintain.
 - If request volume remains the next bottleneck, the preferred follow-up is to
   tune the three-page REST pagination bound with fixture-backed evidence before

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -888,8 +888,12 @@ async function collectReviewRequestEventsAcrossPages(params: {
     collected.push(...parsed.data);
     pageCount += 1;
 
+    if (pageCount >= MAX_REVIEW_REQUEST_EVENT_PAGES) {
+      return collected;
+    }
+
     const nextUrl = parseNextPageUrl(response.headers.get("Link"));
-    if (nextUrl == null || pageCount >= MAX_REVIEW_REQUEST_EVENT_PAGES) {
+    if (nextUrl == null || !isGitHubApiUrl(nextUrl)) {
       return collected;
     }
 
@@ -1011,6 +1015,15 @@ function isExpectedGitHubApiUrl(url: string, expectedPathname: string): boolean 
       parsed.hostname === "api.github.com" &&
       parsed.pathname === expectedPathname
     );
+  } catch {
+    return false;
+  }
+}
+
+function isGitHubApiUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && parsed.hostname === "api.github.com";
   } catch {
     return false;
   }

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -39,6 +39,7 @@ const pullReviewerMetadataSchema = pullSchema.extend({
 
 const pullReviewerMetadataListSchema = z.array(pullReviewerMetadataSchema);
 const MAX_PULL_METADATA_BATCH_PAGES = 3;
+const MAX_REVIEW_REQUEST_EVENT_PAGES = 2;
 
 const pullListSchema = z.array(
   z.object({
@@ -878,15 +879,17 @@ async function collectReviewRequestEventsAcrossPages(params: {
   const collected: z.infer<typeof reviewRequestEventsSchema> = [];
 
   let response = params.firstResponse;
+  let pageCount = 0;
   while (true) {
     const parsed = reviewRequestEventsSchema.safeParse(await response.json());
     if (!parsed.success) {
       throw new GitHubApiSchemaError(params.endpoint, parsed.error.issues);
     }
     collected.push(...parsed.data);
+    pageCount += 1;
 
     const nextUrl = parseNextPageUrl(response.headers.get("Link"));
-    if (nextUrl == null) {
+    if (nextUrl == null || pageCount >= MAX_REVIEW_REQUEST_EVENT_PAGES) {
       return collected;
     }
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -687,7 +687,7 @@ describe("fetchPullReviewerSummary", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("follows paginated issue events when resolving an ambiguous requested reviewer", async () => {
+  it("keeps a requested reviewer when the confirming issue event is within the lookup bound", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
@@ -720,7 +720,13 @@ describe("fetchPullReviewerSummary", () => {
               requested_reviewer: { login: "alice", avatar_url: null },
             },
           ]),
-          { status: 200, headers: { "Content-Type": "application/json" } },
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              Link: '<https://api.github.com/repos/hon454/github-pulls-show-reviewers/issues/42/events?per_page=100&page=3>; rel="next"',
+            },
+          },
         ),
       );
 
@@ -744,6 +750,72 @@ describe("fetchPullReviewerSummary", () => {
     expect(fetchMock.mock.calls[2]?.[0]).toBe(
       "https://api.github.com/repos/hon454/github-pulls-show-reviewers/issues/42/events?per_page=100&page=2",
     );
+  });
+
+  it("falls back to completed review state when the confirming issue event is beyond the lookup bound", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "APPROVED",
+              submitted_at: "2026-05-07T02:03:16Z",
+              user: { login: "alice", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            Link: '<https://api.github.com/repos/hon454/github-pulls-show-reviewers/issues/42/events?per_page=100&page=2>; rel="next"',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            Link: '<https://api.github.com/repos/hon454/github-pulls-show-reviewers/issues/42/events?per_page=100&page=3>; rel="next"',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              event: "review_requested",
+              created_at: "2026-05-07T03:00:00Z",
+              requested_reviewer: { login: "alice", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: null,
+      pullMetadata: {
+        number: "42",
+        authorLogin: "author",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+      },
+    });
+
+    expect(summary.requestedUsers).toEqual([]);
+    expect(summary.completedReviews).toEqual([
+      { login: "alice", avatarUrl: null, state: "APPROVED" },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("falls back to completed review state when an ambiguous issue-events lookup fails", async () => {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -818,6 +818,54 @@ describe("fetchPullReviewerSummary", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
+  it("does not follow non-GitHub issue-events pagination links with auth headers", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              state: "APPROVED",
+              submitted_at: "2026-05-07T02:03:16Z",
+              user: { login: "alice", avatar_url: null },
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            Link: '<https://example.com/repos/hon454/github-pulls-show-reviewers/issues/42/events?per_page=100&page=2>; rel="next"',
+          },
+        }),
+      );
+
+    const summary = await fetchPullReviewerSummary({
+      owner: "hon454",
+      repo: "github-pulls-show-reviewers",
+      pullNumber: "42",
+      githubToken: "gho_token",
+      pullMetadata: {
+        number: "42",
+        authorLogin: "author",
+        requestedUsers: [{ login: "alice", avatarUrl: null }],
+        requestedTeams: [],
+      },
+    });
+
+    expect(summary.requestedUsers).toEqual([]);
+    expect(summary.completedReviews).toEqual([
+      { login: "alice", avatarUrl: null, state: "APPROVED" },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.map((call) => call[0])).not.toContain(
+      "https://example.com/repos/hon454/github-pulls-show-reviewers/issues/42/events?per_page=100&page=2",
+    );
+  });
+
   it("falls back to completed review state when an ambiguous issue-events lookup fails", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(


### PR DESCRIPTION
## Summary

- Caps ambiguous reviewer issue-event lookup to a bounded two-page scan.
- Preserves completed review state when re-request ordering evidence is unavailable under that bound.
- Guards issue-event pagination links before reusing auth headers, with regression coverage and updated implementation notes.

## Why

Long-lived pull requests can have large issue-event histories. Ambiguous reviewers that are both requested and have a completed non-comment review still need ordering evidence, but the lookup should not follow pagination indefinitely just to decide whether to show a refresh badge.

## Changes

- Adds a named two-page cap for ambiguous `review_requested` issue-event collection.
- Keeps requested reviewer state when confirming re-request evidence appears within the bound.
- Falls back to completed review state when confirming evidence is beyond the bound, unavailable, malformed, failed, or aborted according to existing abort/schema behavior.
- Stops following non-GitHub issue-event pagination links before reusing authenticated request headers.
- Updates implementation notes to record the bounded GitHub API lookup and conservative fallback.

## Impact

- User-facing impact: Ambiguous reviewers with only out-of-bound re-request evidence show completed review state instead of an uncertain refresh badge.
- API/schema impact: None.
- Performance impact: Ambiguous issue-event lookup is bounded to at most two issue-event pages.
- Operational or rollout impact: Issue-event pagination only follows GitHub API links before reusing auth headers.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- tests/api.test.ts` (28 files, 365 tests)
- CI: `lint-and-test` and `e2e` passed

## Breaking Changes

- None

## Related Issues

Resolves #111
