### PR TITLE
perf(api): codify reviewer request budgets

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -125,22 +125,37 @@
 ## Request volume decision
 
 - ADR: [0001 - Keep No-Token Support For Public Repositories](./adr/0001-keep-no-token-support-for-public-repositories.md)
-- The current implementation keeps the REST-only public path and starts with
-  `GET /repos/{owner}/{repo}/pulls?per_page=100&state=all` as a page-level
-  metadata hint before row summaries. For searched, filtered, and paginated
-  GitHub list pages, the content script sends visible pull numbers so the
-  background can follow REST pagination until those numbers are covered, bounded
-  to three REST pages total.
+- The current implementation keeps the REST-only public path and uses one
+  page-level metadata batch per fresh `owner/repo/account/visible pull numbers`
+  set before row summaries. That batch starts with
+  `GET /repos/{owner}/{repo}/pulls?per_page=100&state=all`.
+- For searched, filtered, and paginated GitHub list pages, the content script
+  sends visible pull numbers so the background can follow REST pagination until
+  those numbers are covered. The hard budget is three pull-list pages total
+  (`PULL_METADATA_BATCH_PAGE_BUDGET`), or up to 300 pull records at GitHub's
+  documented `per_page=100` maximum.
+- Rows covered by page metadata skip the per-row pull endpoint and fetch only
+  reviews, so the cold-row budget is the shared pull-list metadata batch plus
+  one `GET /repos/{owner}/{repo}/pulls/{n}/reviews?per_page=100` request per
+  uncached visible row, with additional review pages followed only when GitHub
+  returns review pagination links.
+- If a successful metadata batch does not cover an older visible pull within
+  the three-page budget, that row falls back to the original per-row
+  `pull + reviews` REST path. This fallback is intentional: it preserves
+  reviewer visibility for older filtered/search results without making the
+  shared no-token metadata discovery unbounded.
 - The content script de-duplicates in-flight row fetches, caches each pull
   request summary for the active page session with freshness metadata, and
   caches the page-level metadata result per `owner/repo/account` and visible
-  pull-number set with a shorter freshness window.
+  pull-number set with a shorter freshness window. When page metadata already
+  covers a row, row-level duplicate pull endpoint fetches are avoided.
 - Issue-event requests are targeted to ambiguous requested+completed reviewer
-  overlaps only, and follow at most two GitHub API issue-event pages. Rows
-  whose requested users do not overlap a latest non-`COMMENTED` review keep the
-  lower-volume pull metadata plus reviews path. If a confirming
-  `review_requested` event is unavailable within the two-page bound, the row
-  uses the completed review state rather than an uncertain refresh badge.
+  overlaps only, and follow at most two GitHub API issue-event pages
+  (`REVIEW_REQUEST_EVENT_PAGE_BUDGET`). Rows whose requested users do not
+  overlap a latest non-`COMMENTED` review keep the lower-volume pull metadata
+  plus reviews path. If a confirming `review_requested` event is unavailable
+  within the two-page bound, the row uses the completed review state rather
+  than an uncertain refresh badge.
 - A GraphQL-first rewrite is not the next step because it would push the product away from the current no-token public-repository path and add a second transport model to maintain.
 - If request volume remains the next bottleneck, the preferred follow-up is to
   tune the three-page REST pagination bound with fixture-backed evidence before

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -38,8 +38,8 @@ const pullReviewerMetadataSchema = pullSchema.extend({
 });
 
 const pullReviewerMetadataListSchema = z.array(pullReviewerMetadataSchema);
-const MAX_PULL_METADATA_BATCH_PAGES = 3;
-const MAX_REVIEW_REQUEST_EVENT_PAGES = 2;
+export const PULL_METADATA_BATCH_PAGE_BUDGET = 3;
+export const REVIEW_REQUEST_EVENT_PAGE_BUDGET = 2;
 
 const pullListSchema = z.array(
   z.object({
@@ -888,7 +888,7 @@ async function collectReviewRequestEventsAcrossPages(params: {
     collected.push(...parsed.data);
     pageCount += 1;
 
-    if (pageCount >= MAX_REVIEW_REQUEST_EVENT_PAGES) {
+    if (pageCount >= REVIEW_REQUEST_EVENT_PAGE_BUDGET) {
       return collected;
     }
 
@@ -938,7 +938,7 @@ async function collectPullMetadataAcrossPages(params: {
     if (
       targets.size === 0 ||
       hasAllTargetPulls(collected, targets) ||
-      pageCount >= MAX_PULL_METADATA_BATCH_PAGES
+      pageCount >= PULL_METADATA_BATCH_PAGE_BUDGET
     ) {
       return collected;
     }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   GitHubApiError,
   GitHubApiSchemaError,
+  PULL_METADATA_BATCH_PAGE_BUDGET,
+  REVIEW_REQUEST_EVENT_PAGE_BUDGET,
   fetchPullReviewerSummary,
   fetchPullReviewerMetadataBatch,
   describeGitHubApiError,
@@ -1347,6 +1349,11 @@ describe("fetchPullReviewerSummary", () => {
 });
 
 describe("fetchPullReviewerMetadataBatch", () => {
+  it("publishes the fixed REST request budgets used by reviewer loading", () => {
+    expect(PULL_METADATA_BATCH_PAGE_BUDGET).toBe(3);
+    expect(REVIEW_REQUEST_EVENT_PAGE_BUDGET).toBe(2);
+  });
+
   it("reads requested reviewer metadata for a page of pull requests without a token", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
@@ -1464,7 +1471,7 @@ describe("fetchPullReviewerMetadataBatch", () => {
     });
   });
 
-  it("stops pull-list pagination after a bounded number of pages", async () => {
+  it("stops older visible pull-list discovery after the metadata request budget", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
@@ -1532,7 +1539,7 @@ describe("fetchPullReviewerMetadataBatch", () => {
       targetPullNumbers: ["150"],
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(PULL_METADATA_BATCH_PAGE_BUDGET);
     expect(metadata.map((pull) => pull.number)).toEqual(["300", "250", "200"]);
   });
 

--- a/tests/reviewers.test.ts
+++ b/tests/reviewers.test.ts
@@ -641,6 +641,11 @@ describe("bootReviewerListPage", () => {
         <div class="d-flex mt-1 text-small color-fg-muted"></div>
       </div>
     `;
+    window.history.replaceState(
+      {},
+      "",
+      "/cinev/shotloom/pulls?q=is%3Apr+review-requested%3Aalice",
+    );
     resolveAccountForRepoMock.mockResolvedValue(null);
     const summary: PullReviewerSummary = {
       status: "ok",
@@ -683,6 +688,87 @@ describe("bootReviewerListPage", () => {
     ).toMatchObject({
       targetPullNumbers: ["150", "149"],
     });
+  });
+
+  it("uses metadata-covered older visible rows without row pull fallback", async () => {
+    document.body.innerHTML = `
+      <div class="js-issue-row" id="issue_150">
+        <a class="Link--primary" href="/cinev/shotloom/pull/150">PR #150</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+      <div class="js-issue-row" id="issue_149">
+        <a class="Link--primary" href="/cinev/shotloom/pull/149">PR #149</a>
+        <div class="d-flex mt-1 text-small color-fg-muted"></div>
+      </div>
+    `;
+    resolveAccountForRepoMock.mockResolvedValue(null);
+    const summary: PullReviewerSummary = {
+      status: "ok",
+      requestedUsers: [],
+      requestedTeams: [],
+      completedReviews: [],
+    };
+    runtimeSendMessageMock.mockImplementation((message: { type?: string }) => {
+      if (message.type === "fetchPullReviewerMetadataBatch") {
+        return Promise.resolve({
+          ok: true,
+          metadata: [
+            {
+              number: "150",
+              authorLogin: "cinev",
+              requestedUsers: [{ login: "alice", avatarUrl: null }],
+              requestedTeams: [],
+            },
+            {
+              number: "149",
+              authorLogin: "cinev",
+              requestedUsers: [],
+              requestedTeams: ["platform"],
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ ok: true, summary });
+    });
+
+    const { bootReviewerListPage } = await import("../src/features/reviewers");
+    bootReviewerListPage(makeCtx());
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(getRuntimeMessages("fetchPullReviewerMetadataBatch")).toHaveLength(1);
+    expect(
+      getRuntimeMessages("fetchPullReviewerMetadataBatch")[0],
+    ).toMatchObject({
+      targetPullNumbers: ["150", "149"],
+    });
+    expect(
+      getRuntimeMessages("fetchPullReviewerSummary").map((message) => ({
+        pullNumber: message.pullNumber,
+        pullMetadata: message.pullMetadata,
+      })),
+    ).toEqual([
+      {
+        pullNumber: "150",
+        pullMetadata: {
+          number: "150",
+          authorLogin: "cinev",
+          requestedUsers: [{ login: "alice", avatarUrl: null }],
+          requestedTeams: [],
+        },
+      },
+      {
+        pullNumber: "149",
+        pullMetadata: {
+          number: "149",
+          authorLogin: "cinev",
+          requestedUsers: [],
+          requestedTeams: ["platform"],
+        },
+      },
+    ]);
   });
 
   it("short-circuits same-page row fallback after a final page metadata rate-limit failure", async () => {


### PR DESCRIPTION
## Summary

- Defines named REST request budget constants for reviewer metadata and review-request event pagination.
- Adds regression coverage for filtered/older pull-list request budgets and metadata-covered rows.
- Documents the intended fallback behavior for uncovered older visible pull requests.

## Why

Filtered, searched, or older GitHub pull-list pages can show pull numbers outside the first REST metadata page. This PR makes the existing bounded REST behavior explicit so public no-token support remains predictable while covered rows avoid duplicate per-row pull metadata requests.

## Changes

- Exposes the fixed pull metadata and review-request event page budgets from the GitHub API module.
- Verifies metadata pagination request counts for covered and uncovered older visible pulls.
- Verifies content-script summary requests reuse page metadata for filtered older rows.
- Expands the implementation notes with the current request budget and row fallback contract.

## Impact

- User-facing impact: None; reviewer rendering behavior is unchanged.
- API/schema impact: None.
- Performance impact: Clarifies and tests the existing bounded REST request behavior.
- Operational or rollout impact: None.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

### Test details

- `pnpm exec vitest run tests/api.test.ts tests/reviewers.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:coverage`
- `pnpm test:e2e`

## Breaking Changes

- None

## Related Issues

Resolves #110

Co-location checklist: implementation behavior documentation was updated in `docs/implementation-notes.md`; no selector, permission, storage, auth, release, or Chrome Web Store copy changes.
