### PR TITLE
feat(options): show structured repository diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The options page lets you tune the display without changing the core reviewer-fo
 - Show reviewer avatars only, or expand users into `@login` pills.
 - Show or hide review-state badges.
 - Choose whether reviewer chip links search open PRs only or include closed PRs too.
-- Check account and repository access diagnostics for private repositories.
+- Check account, repository access, installation coverage, and rate-limit diagnostics for private repositories.
 
 ![Display settings and repository diagnostics in the options page](./docs/chrome-web-store-assets/03-options-repository-check.png)
 

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -18,6 +18,10 @@
   one of five guidance states — token expired, App not installed, auth rate
   limit, unauthenticated rate limit, or sign-in required — chosen by severity
   priority across all row failures on the page.
+- The options page repository diagnostics show structured evidence for reviewer
+  access checks: matched account, auth mode, GitHub App installation coverage,
+  endpoint result, and any rate-limit headers GitHub returned for the diagnostic
+  request. Rate-limit snapshots are diagnostic output only and are not persisted.
 
 ## Runtime flow
 

--- a/docs/manual-chrome-testing.md
+++ b/docs/manual-chrome-testing.md
@@ -109,8 +109,8 @@ This extension is intentionally narrow. Manual verification should stay focused 
    **Check matched account** for one selected repository. Confirm diagnostics
    reports the matched account result. For unusually large selected
    installations where GitHub pagination exceeds the local ceiling, diagnostics
-   should say the local installation repository snapshot is incomplete before
-   reporting the account access result.
+   should show `Installation coverage` as
+   `Maybe covered - local snapshot truncated` alongside the endpoint result.
 
 ### App-uncovered banner
 

--- a/entrypoints/options/components/DiagnosticsPanel.tsx
+++ b/entrypoints/options/components/DiagnosticsPanel.tsx
@@ -1,20 +1,20 @@
 import { useRef, useState, type CSSProperties } from "react";
 
 import { validateRepositoryAccessWithAccount } from "../../../src/auth/account-token-refresh";
-import { validateGitHubRepositoryAccess } from "../../../src/github/api";
 import {
-  resolveAccountCoverageForRepo,
-  type Account,
-} from "../../../src/storage/accounts";
-
-type Status =
-  | { tone: "neutral" | "success" | "error"; message: string }
-  | null;
+  buildMatchedAccountDiagnostic,
+  buildNoTokenDiagnostic,
+  buildUncoveredAccountDiagnostic,
+  type RepositoryDiagnosticTone,
+  type RepositoryDiagnosticViewModel,
+} from "../../../src/features/repository-diagnostics";
+import { validateGitHubRepositoryAccess } from "../../../src/github/api";
+import { resolveAccountCoverageForRepo } from "../../../src/storage/accounts";
 
 export function DiagnosticsPanel() {
   const [repository, setRepository] = useState("");
-  const [status, setStatus] = useState<Status>(null);
-  const [matchedAccount, setMatchedAccount] = useState<Account | null>(null);
+  const [diagnostic, setDiagnostic] =
+    useState<RepositoryDiagnosticViewModel | null>(null);
   const [busy, setBusy] = useState(false);
   const busyRef = useRef(false);
 
@@ -25,13 +25,18 @@ export function DiagnosticsPanel() {
 
     busyRef.current = true;
     setBusy(true);
-    setStatus({ tone: "neutral", message: "Running diagnostics..." });
+    setDiagnostic({
+      tone: "neutral",
+      message: "Running diagnostics...",
+      fields: [],
+    });
     try {
       await execute();
     } catch (error) {
-      setStatus({
+      setDiagnostic({
         tone: "error",
         message: `Could not run diagnostics. ${errorMessage(error)}`,
+        fields: [],
       });
     } finally {
       busyRef.current = false;
@@ -43,52 +48,52 @@ export function DiagnosticsPanel() {
     const trimmed = repository.trim();
     const match = trimmed.match(/^([^/\s]+)\/([^/\s]+)$/);
     if (!match) {
-      setStatus({
+      setDiagnostic({
         tone: "error",
         message: "Enter a repository as owner/name before running diagnostics.",
+        fields: [],
       });
       return;
     }
     await runDiagnostic(async () => {
       const resolution = await resolveAccountCoverageForRepo(match[1], match[2]);
-      const account =
-        resolution.status === "uncovered" ? null : resolution.account;
-      setMatchedAccount(account);
-      if (account == null) {
-        setStatus({
-          tone: "error",
-          message: `No connected account covers ${trimmed}. Install the GitHub App on the owner.`,
-        });
+      if (resolution.status === "uncovered") {
+        setDiagnostic(
+          buildUncoveredAccountDiagnostic(
+            trimmed,
+            `No connected account covers ${trimmed}. Install the GitHub App on the owner.`,
+          ),
+        );
         return;
       }
       const result = await validateRepositoryAccessWithAccount({
-        account,
+        account: resolution.account,
         repository: trimmed,
       });
-      const truncatedPrefix =
-        resolution.status === "maybe-covered-truncated"
-          ? "The local installation repository snapshot is incomplete, so this account may still cover the repository. "
-          : "";
-      setStatus({
-        tone: result.ok ? "success" : "error",
-        message: `${truncatedPrefix}${result.message}`,
-      });
+      setDiagnostic(
+        buildMatchedAccountDiagnostic({
+          repository: trimmed,
+          coverageStatus: resolution.status,
+          account: resolution.account,
+          result,
+        }),
+      );
     });
   }
 
   async function runNoToken() {
     const trimmed = repository.trim();
     if (!trimmed) {
-      setStatus({
+      setDiagnostic({
         tone: "error",
         message: "Enter a repository before running the no-token check.",
+        fields: [],
       });
       return;
     }
-    setMatchedAccount(null);
     await runDiagnostic(async () => {
       const result = await validateGitHubRepositoryAccess(null, trimmed);
-      setStatus({ tone: result.ok ? "success" : "error", message: result.message });
+      setDiagnostic(buildNoTokenDiagnostic({ repository: trimmed, result }));
     });
   }
 
@@ -127,18 +132,34 @@ export function DiagnosticsPanel() {
           Check no-token path
         </button>
       </div>
-      {matchedAccount ? (
-        <p style={styles.hint}>Matched account: @{matchedAccount.login}.</p>
-      ) : null}
-      {status ? (
-        <p
-          style={{ ...styles.hint, color: toneColor(status.tone) }}
-          role="status"
-          aria-live="polite"
-          data-testid="diagnostics-status"
-        >
-          {status.message}
-        </p>
+      {diagnostic ? (
+        <>
+          <p
+            style={{ ...styles.hint, color: toneColor(diagnostic.tone) }}
+            role="status"
+            aria-live="polite"
+            data-testid="diagnostics-status"
+          >
+            {diagnostic.message}
+          </p>
+          {diagnostic.fields.length > 0 ? (
+            <dl style={styles.diagnosticFields} data-testid="diagnostics-fields">
+              {diagnostic.fields.map((field) => (
+                <div key={field.label} style={styles.diagnosticField}>
+                  <dt style={styles.diagnosticLabel}>{field.label}</dt>
+                  <dd
+                    style={{
+                      ...styles.diagnosticValue,
+                      color: toneColor(field.tone),
+                    }}
+                  >
+                    {field.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          ) : null}
+        </>
       ) : null}
     </section>
   );
@@ -150,8 +171,9 @@ function errorMessage(error: unknown): string {
     : "Please try again.";
 }
 
-function toneColor(tone: "neutral" | "success" | "error"): string {
+function toneColor(tone: RepositoryDiagnosticTone): string {
   if (tone === "success") return "#1a7f37";
+  if (tone === "warning") return "#9a6700";
   if (tone === "error") return "#cf222e";
   return "#52463b";
 }
@@ -182,6 +204,25 @@ const styles: Record<string, CSSProperties> = {
   },
   actions: { display: "flex", gap: 12, marginTop: 12, flexWrap: "wrap" },
   hint: { fontSize: 13, color: "#52463b", marginTop: 12 },
+  diagnosticFields: {
+    display: "grid",
+    gridTemplateColumns: "max-content minmax(0, 1fr)",
+    gap: "8px 12px",
+    margin: "12px 0 0",
+    fontSize: 13,
+  },
+  diagnosticField: {
+    display: "contents",
+  },
+  diagnosticLabel: {
+    color: "#6e5f4f",
+    fontWeight: 700,
+  },
+  diagnosticValue: {
+    margin: 0,
+    minWidth: 0,
+    overflowWrap: "anywhere",
+  },
   primaryButton: {
     border: 0,
     borderRadius: 999,

--- a/src/features/repository-diagnostics/index.ts
+++ b/src/features/repository-diagnostics/index.ts
@@ -1,0 +1,10 @@
+export {
+  buildMatchedAccountDiagnostic,
+  buildNoTokenDiagnostic,
+  buildUncoveredAccountDiagnostic,
+} from "./view-model";
+export type {
+  RepositoryDiagnosticField,
+  RepositoryDiagnosticTone,
+  RepositoryDiagnosticViewModel,
+} from "./view-model";

--- a/src/features/repository-diagnostics/view-model.ts
+++ b/src/features/repository-diagnostics/view-model.ts
@@ -1,5 +1,4 @@
 import type {
-  GitHubRateLimitSnapshot,
   RepositoryValidationOutcome,
   RepositoryValidationResult,
 } from "../../github/api";
@@ -40,7 +39,7 @@ export function buildMatchedAccountDiagnostic(input: {
     field("Auth mode", "Matched account token", "success"),
     coverageField(input.coverageStatus),
     endpointResultField(input.result),
-    ...rateLimitFields(input.result.rateLimit),
+    ...rateLimitFields(input.result),
   ];
 
   return {
@@ -63,7 +62,7 @@ export function buildNoTokenDiagnostic(input: {
       field("Auth mode", "No token"),
       field("Installation coverage", "Not checked"),
       endpointResultField(input.result),
-      ...rateLimitFields(input.result.rateLimit),
+      ...rateLimitFields(input.result),
     ],
   };
 }
@@ -78,7 +77,7 @@ export function buildUncoveredAccountDiagnostic(
     fields: [
       field("Repository", repository),
       field("Matched account", "None", "error"),
-      field("Auth mode", "Matched account token", "error"),
+      field("Auth mode", "Not checked"),
       field("Installation coverage", "Uncovered", "error"),
       field("Endpoint result", "Not checked"),
     ],
@@ -154,9 +153,8 @@ function endpointOutcomeTone(
   return "error";
 }
 
-function rateLimitFields(
-  rateLimit: GitHubRateLimitSnapshot | undefined,
-): RepositoryDiagnosticField[] {
+function rateLimitFields(result: RepositoryValidationResult): RepositoryDiagnosticField[] {
+  const { rateLimit } = result;
   if (!rateLimit) {
     return [];
   }
@@ -179,7 +177,20 @@ function rateLimitFields(
     return [];
   }
 
-  return [field("Rate limit", segments.join(", "), "error")];
+  return [field("Rate limit", segments.join(", "), rateLimitTone(result))];
+}
+
+function rateLimitTone(
+  result: RepositoryValidationResult,
+): RepositoryDiagnosticTone {
+  if (
+    result.outcome === "unauthenticated-rate-limit" ||
+    result.rateLimit?.remaining === 0
+  ) {
+    return "error";
+  }
+
+  return "neutral";
 }
 
 function formatResetAt(resetAt: number): string {

--- a/src/features/repository-diagnostics/view-model.ts
+++ b/src/features/repository-diagnostics/view-model.ts
@@ -124,6 +124,8 @@ function endpointOutcomeLabel(outcome: RepositoryValidationOutcome): string {
       return "Invalid repository";
     case "no-pulls":
       return "No pull requests found";
+    case "authenticated-rate-limit":
+      return "Signed-in rate limit";
     case "unauthenticated-rate-limit":
       return "Unauthenticated rate limit";
     case "unauthenticated-private-like":
@@ -184,6 +186,7 @@ function rateLimitTone(
   result: RepositoryValidationResult,
 ): RepositoryDiagnosticTone {
   if (
+    result.outcome === "authenticated-rate-limit" ||
     result.outcome === "unauthenticated-rate-limit" ||
     result.rateLimit?.remaining === 0
   ) {

--- a/src/features/repository-diagnostics/view-model.ts
+++ b/src/features/repository-diagnostics/view-model.ts
@@ -1,0 +1,191 @@
+import type {
+  GitHubRateLimitSnapshot,
+  RepositoryValidationOutcome,
+  RepositoryValidationResult,
+} from "../../github/api";
+import type { AccountCoverageResolution, Account } from "../../storage/accounts";
+
+export type RepositoryDiagnosticTone =
+  | "neutral"
+  | "success"
+  | "warning"
+  | "error";
+
+export type RepositoryDiagnosticField = {
+  label: string;
+  value: string;
+  tone: RepositoryDiagnosticTone;
+};
+
+export type RepositoryDiagnosticViewModel = {
+  tone: Extract<RepositoryDiagnosticTone, "neutral" | "success" | "error">;
+  message: string;
+  fields: RepositoryDiagnosticField[];
+};
+
+type MatchedAccountCoverageStatus = Exclude<
+  AccountCoverageResolution["status"],
+  "uncovered"
+>;
+
+export function buildMatchedAccountDiagnostic(input: {
+  repository: string;
+  coverageStatus: MatchedAccountCoverageStatus;
+  account: Account;
+  result: RepositoryValidationResult;
+}): RepositoryDiagnosticViewModel {
+  const fields: RepositoryDiagnosticField[] = [
+    field("Repository", input.result.fullName ?? input.repository),
+    field("Matched account", `@${input.account.login}`, "success"),
+    field("Auth mode", "Matched account token", "success"),
+    coverageField(input.coverageStatus),
+    endpointResultField(input.result),
+    ...rateLimitFields(input.result.rateLimit),
+  ];
+
+  return {
+    tone: input.result.ok ? "success" : "error",
+    message: input.result.message,
+    fields,
+  };
+}
+
+export function buildNoTokenDiagnostic(input: {
+  repository: string;
+  result: RepositoryValidationResult;
+}): RepositoryDiagnosticViewModel {
+  return {
+    tone: input.result.ok ? "success" : "error",
+    message: input.result.message,
+    fields: [
+      field("Repository", input.result.fullName ?? input.repository),
+      field("Matched account", "Not checked"),
+      field("Auth mode", "No token"),
+      field("Installation coverage", "Not checked"),
+      endpointResultField(input.result),
+      ...rateLimitFields(input.result.rateLimit),
+    ],
+  };
+}
+
+export function buildUncoveredAccountDiagnostic(
+  repository: string,
+  message: string,
+): RepositoryDiagnosticViewModel {
+  return {
+    tone: "error",
+    message,
+    fields: [
+      field("Repository", repository),
+      field("Matched account", "None", "error"),
+      field("Auth mode", "Matched account token", "error"),
+      field("Installation coverage", "Uncovered", "error"),
+      field("Endpoint result", "Not checked"),
+    ],
+  };
+}
+
+function field(
+  label: string,
+  value: string,
+  tone: RepositoryDiagnosticTone = "neutral",
+): RepositoryDiagnosticField {
+  return { label, value, tone };
+}
+
+function coverageField(
+  status: MatchedAccountCoverageStatus,
+): RepositoryDiagnosticField {
+  if (status === "covered") {
+    return field("Installation coverage", "Covered", "success");
+  }
+
+  return field(
+    "Installation coverage",
+    "Maybe covered; installation repository snapshot is incomplete",
+    "warning",
+  );
+}
+
+function endpointResultField(
+  result: RepositoryValidationResult,
+): RepositoryDiagnosticField {
+  const httpStatus = result.httpStatus ? ` (HTTP ${result.httpStatus})` : "";
+
+  return field(
+    "Endpoint result",
+    `${endpointOutcomeLabel(result.outcome)}${httpStatus}`,
+    endpointOutcomeTone(result.outcome),
+  );
+}
+
+function endpointOutcomeLabel(outcome: RepositoryValidationOutcome): string {
+  switch (outcome) {
+    case "accessible":
+      return "Accessible";
+    case "invalid-repository":
+      return "Invalid repository";
+    case "no-pulls":
+      return "No pull requests found";
+    case "unauthenticated-rate-limit":
+      return "Unauthenticated rate limit";
+    case "unauthenticated-private-like":
+      return "Sign-in required for reviewer access";
+    case "token-invalid":
+      return "Token expired";
+    case "token-permission":
+      return "GitHub App installation missing";
+    case "token-not-found":
+      return "Repository not covered by GitHub App";
+    case "unknown-error":
+      return "Unknown error";
+  }
+}
+
+function endpointOutcomeTone(
+  outcome: RepositoryValidationOutcome,
+): RepositoryDiagnosticTone {
+  if (outcome === "accessible") {
+    return "success";
+  }
+
+  if (outcome === "no-pulls" || outcome === "invalid-repository") {
+    return "warning";
+  }
+
+  return "error";
+}
+
+function rateLimitFields(
+  rateLimit: GitHubRateLimitSnapshot | undefined,
+): RepositoryDiagnosticField[] {
+  if (!rateLimit) {
+    return [];
+  }
+
+  const segments: string[] = [];
+
+  if (rateLimit.remaining !== null && rateLimit.limit !== null) {
+    segments.push(`${rateLimit.remaining} of ${rateLimit.limit} remaining`);
+  }
+
+  if (rateLimit.resource) {
+    segments.push(`resource ${rateLimit.resource}`);
+  }
+
+  if (rateLimit.resetAt !== null) {
+    segments.push(`resets at ${formatResetAt(rateLimit.resetAt)}`);
+  }
+
+  if (segments.length === 0) {
+    return [];
+  }
+
+  return [field("Rate limit", segments.join(", "), "error")];
+}
+
+function formatResetAt(resetAt: number): string {
+  return new Date(resetAt * 1000)
+    .toISOString()
+    .replace(/T(\d{2}:\d{2}):\d{2}\.\d{3}Z$/, " $1 UTC");
+}

--- a/src/features/repository-diagnostics/view-model.ts
+++ b/src/features/repository-diagnostics/view-model.ts
@@ -102,7 +102,7 @@ function coverageField(
 
   return field(
     "Installation coverage",
-    "Maybe covered; installation repository snapshot is incomplete",
+    "Maybe covered - local snapshot truncated",
     "warning",
   );
 }
@@ -110,11 +110,9 @@ function coverageField(
 function endpointResultField(
   result: RepositoryValidationResult,
 ): RepositoryDiagnosticField {
-  const httpStatus = result.httpStatus ? ` (HTTP ${result.httpStatus})` : "";
-
   return field(
     "Endpoint result",
-    `${endpointOutcomeLabel(result.outcome)}${httpStatus}`,
+    endpointOutcomeLabel(result.outcome),
     endpointOutcomeTone(result.outcome),
   );
 }

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -117,6 +117,7 @@ export type RepositoryValidationOutcome =
   | "accessible"
   | "invalid-repository"
   | "no-pulls"
+  | "authenticated-rate-limit"
   | "unauthenticated-rate-limit"
   | "unauthenticated-private-like"
   | "token-invalid"
@@ -1309,6 +1310,10 @@ function classifyRepositoryValidationOutcome(
   const primaryError = getPrimaryGitHubApiError(error);
 
   if (auth.githubToken) {
+    if (primaryError && isRateLimitError(primaryError)) {
+      return "authenticated-rate-limit";
+    }
+
     if (primaryError?.status === 401) {
       return "token-invalid";
     }

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -124,33 +124,43 @@ export type RepositoryValidationOutcome =
   | "token-not-found"
   | "unknown-error";
 
+type RepositoryValidationFailureEvidence = {
+  endpoint?: GitHubEndpointDescriptor;
+  httpStatus?: number;
+  rateLimit?: GitHubRateLimitSnapshot;
+};
+
 export type RepositoryValidationResult =
-  | {
+  | ({
       ok: true;
       authMode: RepositoryValidationAuthMode;
       outcome: "accessible";
       message: string;
       fullName: string;
       pullNumber: string;
-    }
-  | {
+    } & RepositoryValidationFailureEvidence)
+  | ({
       ok: false;
       authMode: RepositoryValidationAuthMode;
       outcome: Exclude<RepositoryValidationOutcome, "accessible">;
       message: string;
       fullName?: string;
       pullNumber?: string;
-    };
+    } & RepositoryValidationFailureEvidence);
 
-type GitHubEndpointName = "pull" | "reviews" | "issue-events" | "pulls-list";
+export type GitHubEndpointName =
+  | "pull"
+  | "reviews"
+  | "issue-events"
+  | "pulls-list";
 
-type GitHubEndpointDescriptor = {
+export type GitHubEndpointDescriptor = {
   name: GitHubEndpointName;
   method: "GET";
   path: string;
 };
 
-type GitHubRateLimitSnapshot = {
+export type GitHubRateLimitSnapshot = {
   limit: number | null;
   remaining: number | null;
   resource: string | null;
@@ -707,6 +717,7 @@ export async function validateGitHubRepositoryAccess(
       outcome: classifyRepositoryValidationOutcome(error, auth),
       fullName,
       message: describeRepositoryValidationError(error, fullName, auth),
+      ...getRepositoryValidationFailureEvidence(error),
     };
   }
 
@@ -758,6 +769,7 @@ export async function validateGitHubRepositoryAccess(
         auth,
         pullNumber,
       ),
+      ...getRepositoryValidationFailureEvidence(error),
     };
   }
 
@@ -1325,6 +1337,37 @@ function classifyRepositoryValidationOutcome(
   }
 
   return "unknown-error";
+}
+
+function getRepositoryValidationFailureEvidence(
+  error: unknown,
+): RepositoryValidationFailureEvidence {
+  const primaryError = getPrimaryGitHubApiError(error);
+  if (primaryError == null) {
+    return {};
+  }
+
+  return {
+    ...(primaryError.endpoint == null
+      ? {}
+      : { endpoint: primaryError.endpoint }),
+    httpStatus: primaryError.status,
+    ...(hasRateLimitEvidence(primaryError.rateLimit)
+      ? { rateLimit: primaryError.rateLimit }
+      : {}),
+  };
+}
+
+function hasRateLimitEvidence(
+  rateLimit: GitHubRateLimitSnapshot | undefined,
+): rateLimit is GitHubRateLimitSnapshot {
+  return (
+    rateLimit != null &&
+    (rateLimit.limit != null ||
+      rateLimit.remaining != null ||
+      rateLimit.resource != null ||
+      rateLimit.resetAt != null)
+  );
 }
 
 function getPrimaryGitHubApiError(error: unknown): GitHubApiError | null {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1656,6 +1656,85 @@ describe("validateGitHubRepositoryAccess", () => {
     expect(result.message).toContain("unexpected response shape");
     expect(result.message).not.toMatch(/ZodError/);
   });
+
+  it("includes endpoint and status evidence for repository access failures", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "Not Found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await validateGitHubRepositoryAccess(
+      { token: "ghu_example" },
+      "hon454/private-reviewers",
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.outcome).toBe("token-not-found");
+    expect(result.endpoint).toEqual({
+      name: "pulls-list",
+      method: "GET",
+      path: "/repos/hon454/private-reviewers/pulls?per_page=1&state=all",
+    });
+    expect(result.httpStatus).toBe(404);
+    expect(result.rateLimit).toBeUndefined();
+  });
+
+  it("includes unauthenticated rate-limit snapshot evidence when headers are present", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+        status: 403,
+        headers: {
+          "Content-Type": "application/json",
+          "x-ratelimit-limit": "60",
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-resource": "core",
+          "x-ratelimit-reset": "1710000000",
+        },
+      }),
+    );
+
+    const result = await validateGitHubRepositoryAccess(
+      null,
+      "hon454/github-pulls-show-reviewers",
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.authMode).toBe("no-token");
+    expect(result.outcome).toBe("unauthenticated-rate-limit");
+    expect(result.endpoint?.name).toBe("pulls-list");
+    expect(result.httpStatus).toBe(403);
+    expect(result.rateLimit).toEqual({
+      limit: 60,
+      remaining: 0,
+      resource: "core",
+      resetAt: 1710000000,
+    });
+  });
+
+  it("keeps malformed repository responses typed without invented HTTP evidence", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify([{ not_a_number: "oops" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await validateGitHubRepositoryAccess(
+      { token: "ghu_example" },
+      "hon454/github-pulls-show-reviewers",
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.outcome).toBe("unknown-error");
+    expect(result.endpoint).toBeUndefined();
+    expect(result.httpStatus).toBeUndefined();
+    expect(result.rateLimit).toBeUndefined();
+  });
 });
 
 describe("validateAccountToken", () => {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1715,6 +1715,39 @@ describe("validateGitHubRepositoryAccess", () => {
     });
   });
 
+  it("classifies signed-in rate-limit diagnostics separately from unknown errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+        status: 403,
+        headers: {
+          "Content-Type": "application/json",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-resource": "core",
+          "x-ratelimit-reset": "1710000000",
+        },
+      }),
+    );
+
+    const result = await validateGitHubRepositoryAccess(
+      { token: "ghu_example" },
+      "hon454/github-pulls-show-reviewers",
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.authMode).toBe("token");
+    expect(result.outcome).toBe("authenticated-rate-limit");
+    expect(result.endpoint?.name).toBe("pulls-list");
+    expect(result.httpStatus).toBe(403);
+    expect(result.rateLimit).toEqual({
+      limit: 5000,
+      remaining: 0,
+      resource: "core",
+      resetAt: 1710000000,
+    });
+  });
+
   it("keeps malformed repository responses typed without invented HTTP evidence", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response(JSON.stringify([{ not_a_number: "oops" }]), {

--- a/tests/options-page.test.ts
+++ b/tests/options-page.test.ts
@@ -4,6 +4,7 @@ import { act, createElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type * as GitHubApiModule from "../src/github/api";
+import type { RepositoryValidationResult } from "../src/github/api";
 import type { Account } from "../src/storage/accounts";
 import type * as AccountsModule from "../src/storage/accounts";
 
@@ -91,10 +92,9 @@ vi.mock("../src/github/auth", () => ({
   DeviceFlowError: class extends Error {},
 }));
 
-const validateGitHubRepositoryAccessMock = vi.fn(async () => ({
-  ok: true,
-  message: "Repository is accessible.",
-}));
+const validateGitHubRepositoryAccessMock = vi.fn(async () =>
+  validationResult({ message: "Repository is accessible." }),
+);
 
 vi.mock("../src/github/api", async (importActual) => ({
   ...(await importActual<GitHubApiModuleType>()),
@@ -134,6 +134,38 @@ async function renderOptionsPageInStrictMode() {
   });
 }
 
+function account(partial: Partial<Account> = {}): Account {
+  return {
+    id: "acc",
+    login: "hon454",
+    avatarUrl: null,
+    token: "ghu_abc",
+    createdAt: 1,
+    installations: [],
+    installationsRefreshedAt: 1,
+    invalidated: false,
+    invalidatedReason: null,
+    refreshToken: null,
+    expiresAt: null,
+    refreshTokenExpiresAt: null,
+    ...partial,
+  };
+}
+
+function validationResult(
+  partial: Partial<RepositoryValidationResult> = {},
+): RepositoryValidationResult {
+  return {
+    ok: true,
+    authMode: "token",
+    outcome: "accessible",
+    message: "Repository diagnostics checked pull #12 in cinev/shotloom.",
+    fullName: "cinev/shotloom",
+    pullNumber: "12",
+    ...partial,
+  } as RepositoryValidationResult;
+}
+
 beforeEach(() => {
   // `vi.mock` factory results are cached across `vi.resetModules()` in
   // this file (module cache is reset but factory outputs are reused), so
@@ -164,10 +196,9 @@ beforeEach(() => {
   });
   resolveAccountForRepoMock.mockResolvedValue(null);
   resolveAccountCoverageForRepoMock.mockResolvedValue({ status: "uncovered" });
-  validateGitHubRepositoryAccessMock.mockResolvedValue({
-    ok: true,
-    message: "Repository is accessible.",
-  });
+  validateGitHubRepositoryAccessMock.mockResolvedValue(
+    validationResult({ message: "Repository is accessible." }),
+  );
   vi.stubGlobal("browser", {
     runtime: {
       sendMessage: vi.fn(),
@@ -221,12 +252,7 @@ describe("OptionsPage", () => {
   });
 
   it("surfaces incomplete selected-installation snapshots in matched diagnostics", async () => {
-    const account: Account = {
-      id: "acc",
-      login: "hon454",
-      avatarUrl: null,
-      token: "ghu_abc",
-      createdAt: 1,
+    const matchedAccount = account({
       installations: [
         {
           id: 42,
@@ -238,16 +264,10 @@ describe("OptionsPage", () => {
           },
         },
       ],
-      installationsRefreshedAt: 1,
-      invalidated: false,
-      invalidatedReason: null,
-      refreshToken: null,
-      expiresAt: null,
-      refreshTokenExpiresAt: null,
-    };
+    });
     resolveAccountCoverageForRepoMock.mockResolvedValueOnce({
       status: "maybe-covered-truncated",
-      account,
+      account: matchedAccount,
     });
     await renderOptionsPage();
 
@@ -274,12 +294,129 @@ describe("OptionsPage", () => {
       "shotloom",
     );
     expect(validateGitHubRepositoryAccessMock).toHaveBeenCalledWith(
-      account,
+      matchedAccount,
       "cinev/shotloom",
     );
     expect(
+      document.querySelector('[data-testid="diagnostics-fields"]')?.textContent,
+    ).toContain("Installation coverageMaybe covered - local snapshot truncated");
+  });
+
+  it("renders structured diagnostics for a matched account success", async () => {
+    const matchedAccount = account();
+    resolveAccountCoverageForRepoMock.mockResolvedValueOnce({
+      status: "covered",
+      account: matchedAccount,
+    });
+    validateGitHubRepositoryAccessMock.mockResolvedValueOnce(
+      validationResult(),
+    );
+    await renderOptionsPage();
+
+    await act(async () => {
+      fireEvent.change(
+        document.querySelector<HTMLInputElement>(
+          '[data-testid="diagnostics-repo"]',
+        )!,
+        { target: { value: "cinev/shotloom" } },
+      );
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      document
+        .querySelector<HTMLButtonElement>('[data-testid="diagnostics-matched"]')!
+        .click();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(
       document.querySelector('[data-testid="diagnostics-status"]')?.textContent,
-    ).toContain("installation repository snapshot is incomplete");
+    ).toContain("checked pull #12");
+    const fields = document.querySelector('[data-testid="diagnostics-fields"]');
+    expect(fields?.textContent).toContain("Matched account@hon454");
+    expect(fields?.textContent).toContain("Auth modeMatched account token");
+    expect(fields?.textContent).toContain("Installation coverageCovered");
+    expect(fields?.textContent).toContain("Endpoint resultAccessible");
+  });
+
+  it("renders uncovered installation diagnostics without repository validation", async () => {
+    resolveAccountCoverageForRepoMock.mockResolvedValueOnce({
+      status: "uncovered",
+    });
+    await renderOptionsPage();
+
+    await act(async () => {
+      fireEvent.change(
+        document.querySelector<HTMLInputElement>(
+          '[data-testid="diagnostics-repo"]',
+        )!,
+        { target: { value: "cinev/shotloom" } },
+      );
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      document
+        .querySelector<HTMLButtonElement>('[data-testid="diagnostics-matched"]')!
+        .click();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(validateGitHubRepositoryAccessMock).not.toHaveBeenCalled();
+    const fields = document.querySelector('[data-testid="diagnostics-fields"]');
+    expect(fields?.textContent).toContain("Matched accountNone");
+    expect(fields?.textContent).toContain("Installation coverageUncovered");
+    expect(fields?.textContent).toContain("Endpoint resultNot checked");
+  });
+
+  it("renders no-token rate-limit diagnostics", async () => {
+    validateGitHubRepositoryAccessMock.mockResolvedValueOnce(
+      validationResult({
+        ok: false,
+        authMode: "no-token",
+        outcome: "unauthenticated-rate-limit",
+        message: "Repository diagnostics hit the unauthenticated rate limit.",
+        fullName: "cinev/shotloom",
+        rateLimit: {
+          limit: 60,
+          remaining: 0,
+          resource: "core",
+          resetAt: 1710000000,
+        },
+      }),
+    );
+    await renderOptionsPage();
+
+    await act(async () => {
+      fireEvent.change(
+        document.querySelector<HTMLInputElement>(
+          '[data-testid="diagnostics-repo"]',
+        )!,
+        { target: { value: "cinev/shotloom" } },
+      );
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      document
+        .querySelector<HTMLButtonElement>('[data-testid="diagnostics-no-token"]')!
+        .click();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const fields = document.querySelector('[data-testid="diagnostics-fields"]');
+    expect(fields?.textContent).toContain("Matched accountNot checked");
+    expect(fields?.textContent).toContain("Auth modeNo token");
+    expect(fields?.textContent).toContain(
+      "Endpoint resultUnauthenticated rate limit",
+    );
+    expect(fields?.textContent).toContain(
+      "Rate limit0 of 60 remaining, resource core, resets at 2024-03-09 16:00 UTC",
+    );
   });
 
   it("renders account cards when accounts are present", async () => {

--- a/tests/options-page.test.ts
+++ b/tests/options-page.test.ts
@@ -368,6 +368,7 @@ describe("OptionsPage", () => {
     expect(validateGitHubRepositoryAccessMock).not.toHaveBeenCalled();
     const fields = document.querySelector('[data-testid="diagnostics-fields"]');
     expect(fields?.textContent).toContain("Matched accountNone");
+    expect(fields?.textContent).toContain("Auth modeNot checked");
     expect(fields?.textContent).toContain("Installation coverageUncovered");
     expect(fields?.textContent).toContain("Endpoint resultNot checked");
   });

--- a/tests/repository-diagnostics.test.ts
+++ b/tests/repository-diagnostics.test.ts
@@ -109,7 +109,7 @@ describe("repository diagnostics view model", () => {
       account: account(),
       result: validationResult({
         ok: false,
-        outcome: "unauthenticated-rate-limit",
+        outcome: "authenticated-rate-limit",
         authMode: "token",
         message: "Repository diagnostics failed for octo/repo.",
         fullName: "octo/repo",
@@ -137,7 +137,7 @@ describe("repository diagnostics view model", () => {
         },
         {
           label: "Endpoint result",
-          value: "Unauthenticated rate limit",
+          value: "Signed-in rate limit",
           tone: "error",
         },
         {

--- a/tests/repository-diagnostics.test.ts
+++ b/tests/repository-diagnostics.test.ts
@@ -68,7 +68,7 @@ describe("repository diagnostics view model", () => {
         { label: "Installation coverage", value: "Covered", tone: "success" },
         {
           label: "Endpoint result",
-          value: "Accessible (HTTP 200)",
+          value: "Accessible",
           tone: "success",
         },
       ],
@@ -131,12 +131,12 @@ describe("repository diagnostics view model", () => {
         { label: "Auth mode", value: "Matched account token", tone: "success" },
         {
           label: "Installation coverage",
-          value: "Maybe covered; installation repository snapshot is incomplete",
+          value: "Maybe covered - local snapshot truncated",
           tone: "warning",
         },
         {
           label: "Endpoint result",
-          value: "Unauthenticated rate limit (HTTP 403)",
+          value: "Unauthenticated rate limit",
           tone: "error",
         },
         {

--- a/tests/repository-diagnostics.test.ts
+++ b/tests/repository-diagnostics.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildMatchedAccountDiagnostic,
+  buildNoTokenDiagnostic,
   buildUncoveredAccountDiagnostic,
 } from "../src/features/repository-diagnostics";
 import type {
@@ -133,6 +134,49 @@ describe("repository diagnostics view model", () => {
           label: "Installation coverage",
           value: "Maybe covered - local snapshot truncated",
           tone: "warning",
+        },
+        {
+          label: "Endpoint result",
+          value: "Unauthenticated rate limit",
+          tone: "error",
+        },
+        {
+          label: "Rate limit",
+          value: "0 of 60 remaining, resource core, resets at 2024-03-09 16:00 UTC",
+          tone: "error",
+        },
+      ],
+    });
+  });
+
+  it("builds no-token diagnostics with unchecked account and coverage fields", () => {
+    const diagnostic = buildNoTokenDiagnostic({
+      repository: "octo/repo",
+      result: validationResult({
+        ok: false,
+        authMode: "no-token",
+        outcome: "unauthenticated-rate-limit",
+        message: "Repository diagnostics failed for octo/repo.",
+        rateLimit: {
+          limit: 60,
+          remaining: 0,
+          resource: "core",
+          resetAt: 1710000000,
+        },
+      }),
+    });
+
+    expect(diagnostic).toEqual({
+      tone: "error",
+      message: "Repository diagnostics failed for octo/repo.",
+      fields: [
+        { label: "Repository", value: "octo/repo", tone: "neutral" },
+        { label: "Matched account", value: "Not checked", tone: "neutral" },
+        { label: "Auth mode", value: "No token", tone: "neutral" },
+        {
+          label: "Installation coverage",
+          value: "Not checked",
+          tone: "neutral",
         },
         {
           label: "Endpoint result",

--- a/tests/repository-diagnostics.test.ts
+++ b/tests/repository-diagnostics.test.ts
@@ -88,7 +88,7 @@ describe("repository diagnostics view model", () => {
       fields: [
         { label: "Repository", value: "octo/private-repo", tone: "neutral" },
         { label: "Matched account", value: "None", tone: "error" },
-        { label: "Auth mode", value: "Matched account token", tone: "error" },
+        { label: "Auth mode", value: "Not checked", tone: "neutral" },
         { label: "Installation coverage", value: "Uncovered", tone: "error" },
         { label: "Endpoint result", value: "Not checked", tone: "neutral" },
       ],
@@ -223,6 +223,31 @@ describe("repository diagnostics view model", () => {
       label: "Endpoint result",
       value: "GitHub App installation missing",
       tone: "error",
+    });
+  });
+
+  it("keeps non-exhausted rate-limit evidence neutral on unrelated failures", () => {
+    const diagnostic = buildMatchedAccountDiagnostic({
+      repository: "octo/repo",
+      coverageStatus: "covered",
+      account: account(),
+      result: validationResult({
+        ok: false,
+        outcome: "token-not-found",
+        message: "Repository was not found.",
+        rateLimit: {
+          limit: 5000,
+          remaining: 4999,
+          resource: "core",
+          resetAt: null,
+        },
+      }),
+    });
+
+    expect(diagnostic.fields).toContainEqual({
+      label: "Rate limit",
+      value: "4999 of 5000 remaining, resource core",
+      tone: "neutral",
     });
   });
 });

--- a/tests/repository-diagnostics.test.ts
+++ b/tests/repository-diagnostics.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMatchedAccountDiagnostic,
+  buildUncoveredAccountDiagnostic,
+} from "../src/features/repository-diagnostics";
+import type {
+  GitHubRateLimitSnapshot,
+  RepositoryValidationResult,
+} from "../src/github/api";
+import type { Account } from "../src/storage/accounts";
+
+function account(partial: Partial<Account> = {}): Account {
+  return {
+    id: "acct_1",
+    login: "octocat",
+    avatarUrl: "https://avatars.githubusercontent.com/u/583231?v=4",
+    token: "ghu_example",
+    createdAt: 1710000000,
+    installations: [],
+    installationsRefreshedAt: 1710000000,
+    invalidated: false,
+    invalidatedReason: null,
+    refreshToken: null,
+    expiresAt: null,
+    refreshTokenExpiresAt: null,
+    ...partial,
+  };
+}
+
+function validationResult(
+  partial: Partial<RepositoryValidationResult> = {},
+): RepositoryValidationResult {
+  return {
+    ok: true,
+    authMode: "token",
+    outcome: "accessible",
+    message: "Repository diagnostics checked pull #42 in octo/repo.",
+    fullName: "octo/repo",
+    pullNumber: "42",
+    ...partial,
+  } as RepositoryValidationResult;
+}
+
+describe("repository diagnostics view model", () => {
+  it("builds success fields for a matched account diagnostic", () => {
+    const diagnostic = buildMatchedAccountDiagnostic({
+      repository: "octo/repo",
+      coverageStatus: "covered",
+      account: account({ login: "octocat" }),
+      result: validationResult({
+        endpoint: {
+          name: "reviews",
+          method: "GET",
+          path: "/repos/octo/repo/pulls/42/reviews",
+        },
+        httpStatus: 200,
+      }),
+    });
+
+    expect(diagnostic).toEqual({
+      tone: "success",
+      message: "Repository diagnostics checked pull #42 in octo/repo.",
+      fields: [
+        { label: "Repository", value: "octo/repo", tone: "neutral" },
+        { label: "Matched account", value: "@octocat", tone: "success" },
+        { label: "Auth mode", value: "Matched account token", tone: "success" },
+        { label: "Installation coverage", value: "Covered", tone: "success" },
+        {
+          label: "Endpoint result",
+          value: "Accessible (HTTP 200)",
+          tone: "success",
+        },
+      ],
+    });
+  });
+
+  it("builds an uncovered diagnostic without repository validation", () => {
+    expect(
+      buildUncoveredAccountDiagnostic(
+        "octo/private-repo",
+        "No signed-in account covers this repository.",
+      ),
+    ).toEqual({
+      tone: "error",
+      message: "No signed-in account covers this repository.",
+      fields: [
+        { label: "Repository", value: "octo/private-repo", tone: "neutral" },
+        { label: "Matched account", value: "None", tone: "error" },
+        { label: "Auth mode", value: "Matched account token", tone: "error" },
+        { label: "Installation coverage", value: "Uncovered", tone: "error" },
+        { label: "Endpoint result", value: "Not checked", tone: "neutral" },
+      ],
+    });
+  });
+
+  it("includes truncated coverage and rate-limit evidence with formatted reset time", () => {
+    const rateLimit: GitHubRateLimitSnapshot = {
+      limit: 60,
+      remaining: 0,
+      resource: "core",
+      resetAt: 1710000000,
+    };
+
+    const diagnostic = buildMatchedAccountDiagnostic({
+      repository: "octo/repo",
+      coverageStatus: "maybe-covered-truncated",
+      account: account(),
+      result: validationResult({
+        ok: false,
+        outcome: "unauthenticated-rate-limit",
+        authMode: "token",
+        message: "Repository diagnostics failed for octo/repo.",
+        fullName: "octo/repo",
+        endpoint: {
+          name: "pulls-list",
+          method: "GET",
+          path: "/repos/octo/repo/pulls",
+        },
+        httpStatus: 403,
+        rateLimit,
+      }),
+    });
+
+    expect(diagnostic).toEqual({
+      tone: "error",
+      message: "Repository diagnostics failed for octo/repo.",
+      fields: [
+        { label: "Repository", value: "octo/repo", tone: "neutral" },
+        { label: "Matched account", value: "@octocat", tone: "success" },
+        { label: "Auth mode", value: "Matched account token", tone: "success" },
+        {
+          label: "Installation coverage",
+          value: "Maybe covered; installation repository snapshot is incomplete",
+          tone: "warning",
+        },
+        {
+          label: "Endpoint result",
+          value: "Unauthenticated rate limit (HTTP 403)",
+          tone: "error",
+        },
+        {
+          label: "Rate limit",
+          value: "0 of 60 remaining, resource core, resets at 2024-03-09 16:00 UTC",
+          tone: "error",
+        },
+      ],
+    });
+  });
+
+  it("maps token-invalid and token-permission outcomes to user-facing endpoint labels", () => {
+    const tokenInvalid = buildMatchedAccountDiagnostic({
+      repository: "octo/repo",
+      coverageStatus: "covered",
+      account: account(),
+      result: validationResult({
+        ok: false,
+        outcome: "token-invalid",
+        message: "Token failed.",
+      }),
+    });
+    const tokenPermission = buildMatchedAccountDiagnostic({
+      repository: "octo/repo",
+      coverageStatus: "covered",
+      account: account(),
+      result: validationResult({
+        ok: false,
+        outcome: "token-permission",
+        message: "Permission failed.",
+      }),
+    });
+
+    expect(tokenInvalid.fields).toContainEqual({
+      label: "Endpoint result",
+      value: "Token expired",
+      tone: "error",
+    });
+    expect(tokenPermission.fields).toContainEqual({
+      label: "Endpoint result",
+      value: "GitHub App installation missing",
+      tone: "error",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add structured repository diagnostics to the options page for matched account, auth mode, installation coverage, endpoint result, and rate-limit evidence.
- Expose transient GitHub endpoint/status/rate-limit evidence from repository validation failures, including distinct signed-in and no-token rate-limit outcomes.
- Document the updated diagnostics behavior and manual QA expectation.

## Why

Users need clearer private-repository access diagnostics when reviewer loading fails. A single status message did not show whether the issue was account matching, GitHub App installation coverage, token mode, endpoint outcome, or rate-limit state.

## Changes

- Added API-level repository validation evidence for GitHub endpoint, HTTP status, and non-empty rate-limit headers.
- Added explicit repository validation outcomes for signed-in and unauthenticated rate-limit diagnostics so structured endpoint results do not fall back to unknown errors.
- Added a pure repository diagnostics view-model for matched-account, no-token, and uncovered-account diagnostic rows.
- Updated the options page diagnostics panel to render structured fields instead of a single status line plus separate matched-account hint.
- Added API, view-model, and options-page tests for access failure evidence, uncovered installations, expired/permission outcomes, and rate-limit output.
- Updated README and implementation/manual testing docs for the structured diagnostics behavior.

## Impact

- User-facing impact: options diagnostics now show concrete access evidence for private repository troubleshooting.
- API/schema impact: `RepositoryValidationResult` includes optional transient evidence fields and a signed-in rate-limit outcome; no persisted schema change.
- Performance impact: no new diagnostic requests beyond the existing checks; rate-limit snapshots are display-only.
- Operational or rollout impact: None.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

### Test details

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:coverage` (30 files, 388 tests passed)
- `pnpm vitest run tests/api.test.ts tests/repository-diagnostics.test.ts` (2 files, 58 tests passed)
- `pnpm typecheck` after the signed-in rate-limit follow-up fix

## Breaking Changes

- None

## Related Issues

Resolves #114
