### PR TITLE
fix(access-banner): open options page from sign-in banner

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -8,13 +8,9 @@ import {
   isFetchPullReviewerMetadataBatchMessage,
   isFetchPullReviewerSummaryMessage,
 } from "../src/runtime/reviewer-fetch";
-import {
-  isRefreshAccountInstallationsMessage,
-} from "../src/runtime/installation-refresh";
-import {
-  listAccounts,
-  markAccountInvalidated,
-} from "../src/storage/accounts";
+import { isRefreshAccountInstallationsMessage } from "../src/runtime/installation-refresh";
+import { isOpenOptionsPageMessage } from "../src/runtime/options-page";
+import { listAccounts, markAccountInvalidated } from "../src/storage/accounts";
 
 export default defineBackground(() => {
   const coordinator = createRefreshCoordinator({
@@ -93,9 +89,7 @@ export default defineBackground(() => {
         typeof (message as { accountId?: unknown }).accountId === "string"
       ) {
         coordinator
-          .refreshAccountToken(
-            (message as { accountId: string }).accountId,
-          )
+          .refreshAccountToken((message as { accountId: string }).accountId)
           .then(
             (outcome) => sendResponse(outcome),
             (error) => {
@@ -106,6 +100,19 @@ export default defineBackground(() => {
               sendResponse(undefined);
             },
           );
+        return true;
+      }
+      if (isOpenOptionsPageMessage(message)) {
+        browser.runtime.openOptionsPage().then(
+          () => sendResponse({ ok: true }),
+          (error) => {
+            console.error(
+              "[GitHub Pulls Show Reviewers] Failed to open options page.",
+              error,
+            );
+            sendResponse({ ok: false });
+          },
+        );
         return true;
       }
       if (isFetchPullReviewerSummaryMessage(message)) {

--- a/src/features/access-banner/dom.ts
+++ b/src/features/access-banner/dom.ts
@@ -27,7 +27,7 @@ export type BannerMount = {
 };
 
 type CtaSpec =
-  | { kind: "link"; label: string; href: string }
+  | { kind: "link"; label: string; href: string; action?: "open-options" }
   | { kind: "none" };
 
 function ctaFor(
@@ -41,7 +41,12 @@ function ctaFor(
     case "auth-expired":
     case "unauth-rate-limit":
     case "signin-required":
-      return { kind: "link", label: "Sign in", href: optionsPageUrl };
+      return {
+        kind: "link",
+        label: "Sign in",
+        href: optionsPageUrl,
+        action: "open-options",
+      };
     case "auth-rate-limit":
       return { kind: "none" };
   }
@@ -51,6 +56,7 @@ export function mountBanner(input: {
   insertAfter: HTMLElement;
   installUrl: string;
   optionsPageUrl: string;
+  onOpenOptionsPage?: () => void;
   onDismiss: () => void;
 }): BannerMount {
   let element: HTMLElement | null = null;
@@ -96,6 +102,12 @@ export function mountBanner(input: {
       link.rel = "noreferrer";
       link.textContent = cta.label;
       link.className = "ghpsr-banner-cta";
+      if (cta.action === "open-options" && input.onOpenOptionsPage) {
+        link.addEventListener("click", (event) => {
+          event.preventDefault();
+          input.onOpenOptionsPage?.();
+        });
+      }
       element.append(link);
     }
 

--- a/src/features/access-banner/index.ts
+++ b/src/features/access-banner/index.ts
@@ -1,7 +1,11 @@
 import type { ContentScriptContext } from "wxt/utils/content-script-context";
 
-import { buildInstallAppUrl, readGitHubAppConfig } from "../../config/github-app";
+import {
+  buildInstallAppUrl,
+  readGitHubAppConfig,
+} from "../../config/github-app";
 import { parsePullListRoute } from "../../github/routes";
+import type { OpenOptionsPageMessage } from "../../runtime/options-page";
 
 import { createBannerAggregator, type BannerAggregator } from "./aggregator";
 import { mountBanner, type BannerMount } from "./dom";
@@ -32,6 +36,16 @@ export function bootAccessBanner(
   const appConfig = appConfigResult.config;
   const installUrl = buildInstallAppUrl(appConfig.slug);
 
+  function openOptionsPage(): void {
+    const message: OpenOptionsPageMessage = { type: "openOptionsPage" };
+    browser.runtime.sendMessage(message).catch((error) => {
+      console.warn(
+        "[ghpsr] Failed to open options page from access banner.",
+        error,
+      );
+    });
+  }
+
   let mount: BannerMount | null = null;
 
   function ensureMountTarget(): HTMLElement | null {
@@ -53,6 +67,7 @@ export function bootAccessBanner(
         insertAfter: target,
         installUrl,
         optionsPageUrl,
+        onOpenOptionsPage: openOptionsPage,
         onDismiss: () => aggregator.dismiss(),
       });
     }

--- a/src/runtime/options-page.ts
+++ b/src/runtime/options-page.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const openOptionsPageMessageSchema = z.object({
   type: z.literal("openOptionsPage"),
-});
+}).strict();
 
 export type OpenOptionsPageMessage = z.infer<
   typeof openOptionsPageMessageSchema

--- a/src/runtime/options-page.ts
+++ b/src/runtime/options-page.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const openOptionsPageMessageSchema = z.object({
+  type: z.literal("openOptionsPage"),
+});
+
+export type OpenOptionsPageMessage = z.infer<
+  typeof openOptionsPageMessageSchema
+>;
+
+export function isOpenOptionsPageMessage(
+  value: unknown,
+): value is OpenOptionsPageMessage {
+  return openOptionsPageMessageSchema.safeParse(value).success;
+}

--- a/tests/access-banner.test.ts
+++ b/tests/access-banner.test.ts
@@ -367,15 +367,11 @@ describe("formatBannerMessage", () => {
   it("returns signin-required copy that mentions private repos", () => {
     expect(
       formatBannerMessage({ current: "signin-required", repo: TEST_REPO }),
-    ).toBe(
-      "Sign in with GitHub to see reviewers on private repositories.",
-    );
+    ).toBe("Sign in with GitHub to see reviewers on private repositories.");
   });
 
   it("returns an empty string when current is null", () => {
-    expect(
-      formatBannerMessage({ current: null, repo: TEST_REPO }),
-    ).toBe("");
+    expect(formatBannerMessage({ current: null, repo: TEST_REPO })).toBe("");
   });
 });
 
@@ -385,10 +381,12 @@ describe("banner DOM", () => {
   function setup() {
     document.body.innerHTML = `<main><div class="gh-header"></div></main>`;
     const target = document.querySelector<HTMLElement>(".gh-header")!;
+    const onOpenOptionsPage = vi.fn();
     return mountBanner({
       insertAfter: target,
       installUrl: "https://github.com/apps/test-app/installations/new",
       optionsPageUrl: "chrome-extension://ext-id/options.html",
+      onOpenOptionsPage,
       onDismiss: () => {},
     });
   }
@@ -401,7 +399,11 @@ describe("banner DOM", () => {
 
   it("renders Configure access link for app-uncovered", () => {
     const banner = setup();
-    banner.update({ current: "app-uncovered", dismissed: false, repo: TEST_REPO });
+    banner.update({
+      current: "app-uncovered",
+      dismissed: false,
+      repo: TEST_REPO,
+    });
     const el = document.querySelector("[data-ghpsr-banner]")!;
     expect(el.textContent).toContain("cinev/shotloom");
     expect(el.textContent).toContain("@cinev's GitHub App installation");
@@ -454,6 +456,33 @@ describe("banner DOM", () => {
     );
   });
 
+  it("opens options through the extension runtime when Sign in is clicked", () => {
+    document.body.innerHTML = `<main><div class="gh-header"></div></main>`;
+    const target = document.querySelector<HTMLElement>(".gh-header")!;
+    const onOpenOptionsPage = vi.fn();
+    const banner = mountBanner({
+      insertAfter: target,
+      installUrl: "https://github.com/apps/test-app/installations/new",
+      optionsPageUrl: "chrome-extension://ext-id/options.html",
+      onOpenOptionsPage,
+      onDismiss: () => {},
+    });
+    banner.update({
+      current: "auth-expired",
+      dismissed: false,
+      repo: TEST_REPO,
+    });
+
+    const link = document.querySelector<HTMLAnchorElement>(
+      "[data-ghpsr-banner] a",
+    )!;
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    link.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onOpenOptionsPage).toHaveBeenCalledTimes(1);
+  });
+
   it("renders no CTA link for auth-rate-limit (passive wait)", () => {
     const banner = setup();
     banner.update({
@@ -498,7 +527,7 @@ describe("banner DOM", () => {
 });
 
 describe("bootAccessBanner", () => {
-  function stubBootGlobals() {
+  function stubBootGlobals(sendMessage = vi.fn(async () => ({ ok: true }))) {
     vi.stubGlobal("__GITHUB_APP_CLIENT_ID__", "Iv1.testclient");
     vi.stubGlobal("__GITHUB_APP_SLUG__", "test-reviewer-app");
     vi.stubGlobal("__GITHUB_APP_NAME__", "Test Reviewer App");
@@ -506,13 +535,21 @@ describe("bootAccessBanner", () => {
     vi.stubGlobal("browser", {
       runtime: {
         getURL: (path: string) => `chrome-extension://ext-id${path}`,
+        sendMessage,
       },
     });
+    return { sendMessage };
   }
 
-  async function bootOnPullList() {
-    stubBootGlobals();
-    window.history.replaceState({}, "", "/hon454/github-pulls-show-reviewers/pulls");
+  async function bootOnPullList(input?: {
+    sendMessage?: ReturnType<typeof vi.fn>;
+  }) {
+    stubBootGlobals(input?.sendMessage);
+    window.history.replaceState(
+      {},
+      "",
+      "/hon454/github-pulls-show-reviewers/pulls",
+    );
 
     const invalidationCallbacks: Array<() => void> = [];
     const ctx = {
@@ -536,9 +573,14 @@ describe("bootAccessBanner", () => {
     vi.stubGlobal("browser", {
       runtime: {
         getURL: (path: string) => `chrome-extension://ext-id${path}`,
+        sendMessage: vi.fn(async () => ({ ok: true })),
       },
     });
-    window.history.replaceState({}, "", "/hon454/github-pulls-show-reviewers/pulls");
+    window.history.replaceState(
+      {},
+      "",
+      "/hon454/github-pulls-show-reviewers/pulls",
+    );
 
     const { bootAccessBanner } = await import("../src/features/access-banner");
     const handle = bootAccessBanner({
@@ -608,6 +650,21 @@ describe("bootAccessBanner", () => {
     expect(link?.getAttribute("href")).toBe(
       "https://github.com/apps/test-reviewer-app/installations/new",
     );
+  });
+
+  it("routes Sign in clicks through the background options-page opener", async () => {
+    document.body.innerHTML = `<main id="main"></main>`;
+    const sendMessage = vi.fn(async () => ({ ok: true }));
+
+    const { handle } = await bootOnPullList({ sendMessage });
+    handle.reportFailure("auth-expired");
+    document
+      .querySelector<HTMLAnchorElement>("[data-ghpsr-banner] a")!
+      .dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+
+    expect(sendMessage).toHaveBeenCalledWith({ type: "openOptionsPage" });
   });
 
   it("teardown unsubscribes and removes mounted UI", async () => {

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -199,6 +199,33 @@ describe("background runtime.onMessage handler", () => {
     expect(response).toEqual({ ok: true });
   });
 
+  it("reports a failed options page open back to the caller", async () => {
+    openOptionsPageMock.mockRejectedValueOnce(new Error("blocked"));
+    const listener = await bootBackground();
+
+    const response = await callListener(
+      listener,
+      { type: "openOptionsPage" },
+      { id: SELF_RUNTIME_ID },
+    );
+
+    expect(openOptionsPageMock).toHaveBeenCalledTimes(1);
+    expect(response).toEqual({ ok: false });
+  });
+
+  it("rejects options page messages from a different extension id", async () => {
+    const listener = await bootBackground();
+
+    const response = await callListener(
+      listener,
+      { type: "openOptionsPage" },
+      { id: "some-other-extension-id" },
+    );
+
+    expect(response).toBeUndefined();
+    expect(openOptionsPageMock).not.toHaveBeenCalled();
+  });
+
   it("rejects valid refresh messages from a different extension id", async () => {
     const listener = await bootBackground();
 

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -56,9 +56,8 @@ vi.mock("../src/storage/accounts", () => ({
 }));
 
 vi.mock("../src/github/api", async () => {
-  const actual = await vi.importActual<typeof GithubApiModule>(
-    "../src/github/api",
-  );
+  const actual =
+    await vi.importActual<typeof GithubApiModule>("../src/github/api");
   return {
     ...actual,
     fetchPullReviewerSummary: fetchPullReviewerSummaryMock,
@@ -100,6 +99,7 @@ function callListener(
 
 let capturedAlarmListener: ((alarm: { name: string }) => void) | null;
 const alarmsCreateMock = vi.fn(async () => undefined);
+const openOptionsPageMock = vi.fn(async () => undefined);
 
 beforeEach(() => {
   vi.resetModules();
@@ -115,6 +115,7 @@ beforeEach(() => {
   createInstallationRefreshServiceMock.mockClear();
   getGitHubAppConfigMock.mockClear();
   alarmsCreateMock.mockClear();
+  openOptionsPageMock.mockClear();
   capturedMessageListener = null;
   capturedAlarmListener = null;
 
@@ -128,7 +129,7 @@ beforeEach(() => {
           capturedMessageListener = listener;
         }),
       },
-      openOptionsPage: vi.fn(),
+      openOptionsPage: openOptionsPageMock,
     },
     action: {
       onClicked: { addListener: vi.fn() },
@@ -185,6 +186,19 @@ describe("background runtime.onMessage handler", () => {
     expect(sync).toBe(true);
   });
 
+  it("opens the options page for extension-originated banner CTA messages", async () => {
+    const listener = await bootBackground();
+
+    const response = await callListener(
+      listener,
+      { type: "openOptionsPage" },
+      { id: SELF_RUNTIME_ID },
+    );
+
+    expect(openOptionsPageMock).toHaveBeenCalledTimes(1);
+    expect(response).toEqual({ ok: true });
+  });
+
   it("rejects valid refresh messages from a different extension id", async () => {
     const listener = await bootBackground();
 
@@ -211,11 +225,9 @@ describe("background runtime.onMessage handler", () => {
       { type: "somethingElse", accountId: "acc-1" },
       { id: SELF_RUNTIME_ID },
     );
-    const notAnObject = await callListener(
-      listener,
-      "refreshAccessToken",
-      { id: SELF_RUNTIME_ID },
-    );
+    const notAnObject = await callListener(listener, "refreshAccessToken", {
+      id: SELF_RUNTIME_ID,
+    });
     const emptyReviewerFetch = await callListener(
       listener,
       {
@@ -374,7 +386,10 @@ describe("background runtime.onMessage handler", () => {
       token: "ghu_old",
       refreshToken: "ghr_old",
     });
-    refreshAccountTokenMock.mockResolvedValueOnce({ ok: false, terminal: false });
+    refreshAccountTokenMock.mockResolvedValueOnce({
+      ok: false,
+      terminal: false,
+    });
     fetchPullReviewerSummaryMock.mockRejectedValueOnce({ status: 401 });
 
     const response = await callListener(

--- a/tests/runtime-messages.test.ts
+++ b/tests/runtime-messages.test.ts
@@ -12,6 +12,10 @@ import {
   isRefreshAccountInstallationsMessage,
   refreshAccountInstallationsMessageSchema,
 } from "../src/runtime/installation-refresh";
+import {
+  isOpenOptionsPageMessage,
+  openOptionsPageMessageSchema,
+} from "../src/runtime/options-page";
 
 describe("reviewer fetch runtime message schemas", () => {
   it("accepts valid fetch-summary messages through the schema-backed guard", () => {
@@ -107,5 +111,24 @@ describe("installation refresh runtime message schema", () => {
       refreshAccountInstallationsMessageSchema.safeParse(message).success,
     ).toBe(false);
     expect(isRefreshAccountInstallationsMessage(message)).toBe(false);
+  });
+});
+
+describe("options page runtime message schema", () => {
+  it("accepts the payload-free open-options message", () => {
+    const message = { type: "openOptionsPage" };
+
+    expect(openOptionsPageMessageSchema.safeParse(message).success).toBe(true);
+    expect(isOpenOptionsPageMessage(message)).toBe(true);
+  });
+
+  it("rejects extra fields on the payload-free open-options message", () => {
+    const message = {
+      type: "openOptionsPage",
+      url: "chrome-extension://other/options.html",
+    };
+
+    expect(openOptionsPageMessageSchema.safeParse(message).success).toBe(false);
+    expect(isOpenOptionsPageMessage(message)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Route the access banner Sign in CTA through the extension background page instead of direct `chrome-extension://` navigation.
- Add a strict typed runtime message for opening the options page from content scripts.
- Cover the banner click path, background message dispatch, sender rejection, failure response, and runtime message schema with regression tests.

## Why

Chrome can block direct top-level navigation from a GitHub page to `chrome-extension://.../options.html`, which leaves users on `ERR_BLOCKED_BY_CLIENT` when they try to re-authenticate after reviewer loading hits an expired saved GitHub App session. The extension already has a safe background-side options opener, so the banner should use that path.

## Changes

- Access banner Sign in links now prevent the default navigation and request `browser.runtime.openOptionsPage()` through the background script.
- Background runtime message handling accepts an extension-originated `openOptionsPage` envelope and reports both success and failure to the caller.
- The options-page runtime message schema is payload-free and strict, rejecting extra fields instead of silently stripping them.
- Tests assert that Sign in clicks are intercepted, foreign-extension opener messages are rejected, opener failures resolve to `{ ok: false }`, and malformed opener envelopes are rejected.

## Impact

- User-facing impact: Users can reach the options page from auth-expired, sign-in-required, and unauthenticated rate-limit banners without hitting Chrome's blocked-page error.
- API/schema impact: The extension-internal `openOptionsPage` runtime message is strict and has no payload.
- Performance impact: None.
- Operational or rollout impact: Existing installs need the updated extension bundle loaded before the fixed CTA behavior is available.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

### Test details

- `pnpm typecheck`
- `pnpm test -- tests/access-banner.test.ts tests/background.test.ts --runInBand`
- `pnpm test -- tests/background.test.ts tests/runtime-messages.test.ts --runInBand`
- `pnpm lint`
- `pnpm build`

## Breaking Changes

- None

## Related Issues

No issue: investigated from local Chrome sign-in banner failure.

<!-- Co-location checklist: no docs update required; this fixes CTA routing for an existing auth recovery path without changing auth scope, storage schema, permissions, selectors, user-facing copy, or Chrome Web Store copy. -->
